### PR TITLE
Incompatible AGP version bug

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Plugins
-agp = "8.7.0"
+agp = "8.6.1"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
 imagepicker = "2.1"


### PR DESCRIPTION
## Incompatible AGP version bug
This PR fixes #32 by changing the AGP version.

### Key Features
Changed AGP version from 8.7.0 to 8.6.1 to fix error "The project is using an incompatible version (AGP 8.7.0) of the Android Gradle plugin. Latest supported version is AGP 8.6.0" when building.

### Next Steps
Merge to main and merge into every other branch.