### PR TITLE
APK Build on CI

### DIFF
--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -2,9 +2,9 @@ name: AndroidBuild
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -20,6 +20,10 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
+      - name: Grant execute permission for gradlew
+        run: |
+          chmod +x ./gradlew
+
       - name: Build with Gradle
         run: ./gradlew build
 

--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -37,4 +37,4 @@ jobs:
         run: echo "${{ secrets.KEYSTORE }}" | base64 --decode > /tmp/keystore.jks
 
       - name: Build Release
-        run: ./gradlew assembleDebug -Pandroid.injected.signing.store.file=/tmp/keystore.jks -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew assembleDebug

--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest //or ubunto-latest or windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -19,9 +19,6 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '17'
-
-      - name: Grant execute permissions for gradlew //this step is only for macOS
-        run: chmod +x ./gradlew
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -1,0 +1,39 @@
+name: AndroidBuild
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: macOS-latest //or ubunto-latest or windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3.13.0
+        with:
+          distribution: 'adopt'
+          java-version: '17'
+
+      - name: Grant execute permissions for gradlew //this step is only for macOS
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: dsTemplate.apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE }}" | base64 --decode > /tmp/keystore.jks
+
+      - name: Build Release
+        run: ./gradlew assembleRelease -Pandroid.injected.signing.store.file=/tmp/keystore.jks -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}

--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -37,4 +37,4 @@ jobs:
         run: echo "${{ secrets.KEYSTORE }}" | base64 --decode > /tmp/keystore.jks
 
       - name: Build Release
-        run: ./gradlew assembleRelease -Pandroid.injected.signing.store.file=/tmp/keystore.jks -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew assembleDebug -Pandroid.injected.signing.store.file=/tmp/keystore.jks -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}


### PR DESCRIPTION
# APK Build on CI
## Description
This PR introduces a new Github Actions Workflow to build an APK on each push on to `origin/main`. It closes issue #54.
## Changes
None
## Files 
#### Added
- `.github/workflows/AndroidBuild.yml`
#### Modified
#### Removed
## Dependencies Added
Not applicable
## Testing
Not applicable