### PR TITLE
fix/authentication/signup : Fix authentication for CI-built APK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 


### PR DESCRIPTION
# Fix authentication for CI-built APK
## Description
This PR introduces a fix for the authentication not working when building from the CI. It closes issue #60 
## Changes
Added a [permission for network state access](https://developer.android.com/reference/android/Manifest.permission#ACCESS_NETWORK_STATE) in `AndroidManifest.xml`
## Files 
#### Added
None
#### Modified
* `app/src/main/AndroidManifest.xml`: added network state access permission
#### Removed
None
## Dependencies Added
None
## Testing
N/A  
See APK built by the CI