### PR TITLE
Fix/alert/UI tests: Fix and complete UI tests for AlertScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,8 +221,8 @@ dependencies {
 
   /// Mockito for android testing
   androidTestImplementation(libs.androidx.junit)
-  androidTestImplementation(libs.mockito.android)
   androidTestImplementation(libs.mockito.kotlin)
+  androidTestImplementation(libs.dexmaker.mockito.inline)
 
   // Mockito for unit testing
   testImplementation(libs.mockito.kotlin)

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -50,9 +50,9 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
     composeTestRule
-      .onNodeWithTag("alertSubmit")
-      .assertIsDisplayed()
-      .assertTextEquals("Ask for Help")
+        .onNodeWithTag("alertSubmit")
+        .assertIsDisplayed()
+        .assertTextEquals("Ask for Help")
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -1,26 +1,39 @@
 package com.android.periodpals.ui.alert
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 
+@RunWith(AndroidJUnit4::class)
 class AlertScreenTest {
 
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
 
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+  }
+
   @Test
-  fun displayAllComponents() {
-    composeTestRule.setContent {
-      MaterialTheme { AlertScreen(NavigationActions(rememberNavController())) }
-    }
+  fun allComponentsAreDisplayed() {
+    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertInstruction").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed()
@@ -28,28 +41,25 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertMessage").assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag("alertSubmit")
-        .assertIsDisplayed()
-        .assertTextEquals("Ask for Help")
+      .onNodeWithTag("alertSubmit")
+      .assertIsDisplayed()
+      .assertTextEquals("Ask for Help")
   }
 
   @Test
-  fun interactWithComponents() {
-    composeTestRule.setContent {
-      MaterialTheme { AlertScreen(NavigationActions(rememberNavController())) }
-    }
+  fun createValidAlert() {
+    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertProduct").performClick()
-    composeTestRule.onNodeWithTag("Pads").performClick()
-    //        composeTestRule.onNodeWithTag("alertProduct").assertTextEquals("Pads")
+    composeTestRule.onNodeWithText("Pads").performClick()
+
     composeTestRule.onNodeWithTag("alertUrgency").performClick()
-    composeTestRule.onNodeWithTag("!! Medium").performClick()
-    //        composeTestRule.onNodeWithTag("alertUrgency").assertTextEquals("!! Medium")
+    composeTestRule.onNodeWithText("!! Medium").performClick()
 
     composeTestRule.onNodeWithTag("alertLocation").performTextInput("Rolex")
     composeTestRule.onNodeWithTag("alertMessage").performTextInput("I need help finding a tampon")
 
-    // Cannot test navigation actions
-    //    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+    verify(navigationActions).navigateTo(Screen.ALERT_LIST)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -11,12 +11,15 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.navigation.TopLevelDestination
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -61,5 +64,60 @@ class AlertScreenTest {
 
     composeTestRule.onNodeWithTag("alertSubmit").performClick()
     verify(navigationActions).navigateTo(Screen.ALERT_LIST)
+  }
+
+  @Test
+  fun createInvalidAlertNoProduct() {
+    composeTestRule.setContent { AlertScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("alertUrgency").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithText("!! Medium").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("alertLocation").performTextInput("Rolex")
+    composeTestRule.onNodeWithTag("alertMessage").performTextInput("I need help finding a tampon")
+
+    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
+  }
+
+  @Test
+  fun createInvalidAlertNoUrgencyLevel() {
+    composeTestRule.setContent { AlertScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("alertProduct").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithText("Pads").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("alertLocation").performTextInput("Rolex")
+    composeTestRule.onNodeWithTag("alertMessage").performTextInput("I need help finding a tampon")
+
+    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
+  }
+
+  @Test
+  fun createInvalidAlertNoLocation() {
+    composeTestRule.setContent { AlertScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("alertProduct").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithText("Pads").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("alertUrgency").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithText("!! Medium").performClick()
+    composeTestRule.waitForIdle()
+
+    composeTestRule.onNodeWithTag("alertMessage").performTextInput("I need help finding a tampon")
+
+    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -44,9 +44,9 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertMessage").assertIsDisplayed()
     composeTestRule
-      .onNodeWithTag("alertSubmit")
-      .assertIsDisplayed()
-      .assertTextEquals("Ask for Help")
+        .onNodeWithTag("alertSubmit")
+        .assertIsDisplayed()
+        .assertTextEquals("Ask for Help")
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -1,6 +1,7 @@
 package com.android.periodpals.ui.alert
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -45,10 +46,13 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertMessage").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
     composeTestRule
-        .onNodeWithTag("alertSubmit")
-        .assertIsDisplayed()
-        .assertTextEquals("Ask for Help")
+      .onNodeWithTag("alertSubmit")
+      .assertIsDisplayed()
+      .assertTextEquals("Ask for Help")
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -31,12 +31,14 @@ class AlertScreenTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+
     `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+
+    composeTestRule.setContent { AlertScreen(navigationActions) }
   }
 
   @Test
   fun allComponentsAreDisplayed() {
-    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertInstruction").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed()
@@ -51,7 +53,6 @@ class AlertScreenTest {
 
   @Test
   fun createValidAlert() {
-    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertProduct").performClick()
     composeTestRule.onNodeWithText("Pads").performClick()
@@ -68,7 +69,6 @@ class AlertScreenTest {
 
   @Test
   fun createInvalidAlertNoProduct() {
-    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertUrgency").performClick()
     composeTestRule.waitForIdle()
@@ -85,7 +85,6 @@ class AlertScreenTest {
 
   @Test
   fun createInvalidAlertNoUrgencyLevel() {
-    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertProduct").performClick()
     composeTestRule.waitForIdle()
@@ -102,7 +101,6 @@ class AlertScreenTest {
 
   @Test
   fun createInvalidAlertNoLocation() {
-    composeTestRule.setContent { AlertScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertProduct").performClick()
     composeTestRule.waitForIdle()

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -147,6 +147,7 @@ fun ExposedDropdownMenuSample(
         value = text,
         onValueChange = {},
         singleLine = true,
+        readOnly = true,
         label = { Text(label) },
         trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
         colors = ExposedDropdownMenuDefaults.textFieldColors(),

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.alert
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -35,10 +37,12 @@ import com.android.periodpals.ui.navigation.TopAppBar
 
 @Composable
 fun AlertScreen(navigationActions: NavigationActions) {
+  val context = LocalContext.current
   var location by remember { mutableStateOf("") }
   var message by remember { mutableStateOf("") }
+  val (productIsSelected, setProductIsSelected) = remember { mutableStateOf(false) }
+  val (urgencyIsSelected, setUrgencyIsSelected) = remember { mutableStateOf(false) }
 
-  //    TODO("TOP APP BAR and BOTTOM NAVIGATION")
   Scaffold(
     modifier = Modifier.testTag("alertScreen"),
     bottomBar = {
@@ -68,6 +72,7 @@ fun AlertScreen(navigationActions: NavigationActions) {
           listOf("Tampons", "Pads", "No Preference"),
           "Product Needed",
           "alertProduct",
+          setProductIsSelected,
         )
 
         // Urgency
@@ -75,6 +80,7 @@ fun AlertScreen(navigationActions: NavigationActions) {
           listOf("!!! High", "!! Medium", "! Low"),
           "Urgency level",
           "alertUrgency",
+          setUrgencyIsSelected,
         )
 
         // Location
@@ -97,7 +103,17 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
         // Submit Button
         Button(
-          onClick = { navigationActions.navigateTo(Screen.ALERT_LIST) },
+          onClick = {
+            if (location.isEmpty()) {
+              Toast.makeText(context, "Please enter a location", Toast.LENGTH_SHORT).show()
+            } else if (!productIsSelected) {
+              Toast.makeText(context, "Please select a product", Toast.LENGTH_SHORT).show()
+            } else if (!urgencyIsSelected) {
+              Toast.makeText(context, "Please select an urgency level", Toast.LENGTH_SHORT).show()
+            } else {
+              navigationActions.navigateTo(Screen.ALERT_LIST)
+            }
+          },
           modifier = Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
         ) {
           Text("Ask for Help", style = MaterialTheme.typography.headlineMedium)
@@ -109,7 +125,12 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String) {
+fun ExposedDropdownMenuSample(
+  list: List<String>,
+  label: String,
+  testTag: String,
+  setIsSelected: (Boolean) -> Unit,
+) {
   var options = list
   var expanded by remember { mutableStateOf(false) }
   var text by remember { mutableStateOf("Please choose one option") }
@@ -136,6 +157,7 @@ fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String
           onClick = {
             text = option
             expanded = false
+            setIsSelected(true)
           },
           contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
         )

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -44,122 +44,124 @@ fun AlertScreen(navigationActions: NavigationActions) {
   val (urgencyIsSelected, setUrgencyIsSelected) = remember { mutableStateOf(false) }
 
   Scaffold(
-    modifier = Modifier.testTag("alertScreen"),
-    bottomBar = {
-      BottomNavigationMenu(
-        onTabSelect = { route -> navigationActions.navigateTo(route) },
-        tabList = LIST_TOP_LEVEL_DESTINATION,
-        selectedItem = navigationActions.currentRoute(),
-      )
-    },
-    topBar = { TopAppBar(title = "Create Alert") },
-    content = { paddingValues ->
-      Column(
-        modifier = Modifier.fillMaxSize().padding(30.dp).padding(paddingValues),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly,
-      ) {
-        // Text Instruction
-        Text(
-          "Push a notification to users near you! If they are available and have the products you need, they'll be able to help you!",
-          modifier = Modifier.testTag("alertInstruction"),
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.titleSmall,
+      modifier = Modifier.testTag("alertScreen"),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
         )
-
-        // Product
-        ExposedDropdownMenuSample(
-          listOf("Tampons", "Pads", "No Preference"),
-          "Product Needed",
-          "alertProduct",
-          setProductIsSelected,
-        )
-
-        // Urgency
-        ExposedDropdownMenuSample(
-          listOf("!!! High", "!! Medium", "! Low"),
-          "Urgency level",
-          "alertUrgency",
-          setUrgencyIsSelected,
-        )
-
-        // Location
-        OutlinedTextField(
-          value = location,
-          onValueChange = { location = it },
-          label = { Text("Location") },
-          placeholder = { Text("Enter your location") },
-          modifier = Modifier.fillMaxWidth().testTag("alertLocation"),
-        )
-
-        // Message
-        OutlinedTextField(
-          value = message,
-          onValueChange = { message = it },
-          label = { Text("Message") },
-          placeholder = { Text("Write a message for the other users") },
-          modifier = Modifier.fillMaxWidth().height(150.dp).testTag("alertMessage"),
-        )
-
-        // Submit Button
-        Button(
-          onClick = {
-            if (location.isEmpty()) {
-              Toast.makeText(context, "Please enter a location", Toast.LENGTH_SHORT).show()
-            } else if (!productIsSelected) {
-              Toast.makeText(context, "Please select a product", Toast.LENGTH_SHORT).show()
-            } else if (!urgencyIsSelected) {
-              Toast.makeText(context, "Please select an urgency level", Toast.LENGTH_SHORT).show()
-            } else {
-              navigationActions.navigateTo(Screen.ALERT_LIST)
-            }
-          },
-          modifier = Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
+      },
+      topBar = { TopAppBar(title = "Create Alert") },
+      content = { paddingValues ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(30.dp).padding(paddingValues),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceEvenly,
         ) {
-          Text("Ask for Help", style = MaterialTheme.typography.headlineMedium)
+          // Text Instruction
+          Text(
+              "Push a notification to users near you! If they are available and have the products you need, they'll be able to help you!",
+              modifier = Modifier.testTag("alertInstruction"),
+              textAlign = TextAlign.Center,
+              style = MaterialTheme.typography.titleSmall,
+          )
+
+          // Product
+          ExposedDropdownMenuSample(
+              listOf("Tampons", "Pads", "No Preference"),
+              "Product Needed",
+              "alertProduct",
+              setProductIsSelected,
+          )
+
+          // Urgency
+          ExposedDropdownMenuSample(
+              listOf("!!! High", "!! Medium", "! Low"),
+              "Urgency level",
+              "alertUrgency",
+              setUrgencyIsSelected,
+          )
+
+          // Location
+          OutlinedTextField(
+              value = location,
+              onValueChange = { location = it },
+              label = { Text("Location") },
+              placeholder = { Text("Enter your location") },
+              modifier = Modifier.fillMaxWidth().testTag("alertLocation"),
+          )
+
+          // Message
+          OutlinedTextField(
+              value = message,
+              onValueChange = { message = it },
+              label = { Text("Message") },
+              placeholder = { Text("Write a message for the other users") },
+              modifier = Modifier.fillMaxWidth().height(150.dp).testTag("alertMessage"),
+          )
+
+          // Submit Button
+          Button(
+              onClick = {
+                if (location.isEmpty()) {
+                  Toast.makeText(context, "Please enter a location", Toast.LENGTH_SHORT).show()
+                } else if (!productIsSelected) {
+                  Toast.makeText(context, "Please select a product", Toast.LENGTH_SHORT).show()
+                } else if (!urgencyIsSelected) {
+                  Toast.makeText(context, "Please select an urgency level", Toast.LENGTH_SHORT)
+                      .show()
+                } else {
+                  navigationActions.navigateTo(Screen.ALERT_LIST)
+                }
+              },
+              modifier =
+                  Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
+          ) {
+            Text("Ask for Help", style = MaterialTheme.typography.headlineMedium)
+          }
         }
-      }
-    },
+      },
   )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExposedDropdownMenuSample(
-  list: List<String>,
-  label: String,
-  testTag: String,
-  setIsSelected: (Boolean) -> Unit,
+    list: List<String>,
+    label: String,
+    testTag: String,
+    setIsSelected: (Boolean) -> Unit,
 ) {
   var options = list
   var expanded by remember { mutableStateOf(false) }
   var text by remember { mutableStateOf("Please choose one option") }
 
   ExposedDropdownMenuBox(
-    modifier = Modifier.testTag(testTag),
-    expanded = expanded,
-    onExpandedChange = { expanded = it },
+      modifier = Modifier.testTag(testTag),
+      expanded = expanded,
+      onExpandedChange = { expanded = it },
   ) {
     TextField(
-      modifier = Modifier.menuAnchor(),
-      value = text,
-      onValueChange = {},
-      singleLine = true,
-      label = { Text(label) },
-      trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-      colors = ExposedDropdownMenuDefaults.textFieldColors(),
+        modifier = Modifier.menuAnchor(),
+        value = text,
+        onValueChange = {},
+        singleLine = true,
+        label = { Text(label) },
+        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+        colors = ExposedDropdownMenuDefaults.textFieldColors(),
     )
     ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       options.forEach { option ->
         DropdownMenuItem(
-          modifier = Modifier,
-          text = { Text(option) },
-          onClick = {
-            text = option
-            expanded = false
-            setIsSelected(true)
-          },
-          contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+            modifier = Modifier,
+            text = { Text(option) },
+            onClick = {
+              text = option
+              expanded = false
+              setIsSelected(true)
+            },
+            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
         )
       }
     }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -40,64 +40,71 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
   //    TODO("TOP APP BAR and BOTTOM NAVIGATION")
   Scaffold(
-      modifier = Modifier.testTag("alertScreen"),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
-      },
-      topBar = {
-        TopAppBar(
-            title = "Create Alert",
+    modifier = Modifier.testTag("alertScreen"),
+    bottomBar = {
+      BottomNavigationMenu(
+        onTabSelect = { route -> navigationActions.navigateTo(route) },
+        tabList = LIST_TOP_LEVEL_DESTINATION,
+        selectedItem = navigationActions.currentRoute(),
+      )
+    },
+    topBar = { TopAppBar(title = "Create Alert") },
+    content = { paddingValues ->
+      Column(
+        modifier = Modifier.fillMaxSize().padding(30.dp).padding(paddingValues),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.SpaceEvenly,
+      ) {
+        // Text Instruction
+        Text(
+          "Push a notification to users near you! If they are available and have the products you need, they'll be able to help you!",
+          modifier = Modifier.testTag("alertInstruction"),
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.titleSmall,
         )
-      },
-      content = { paddingValues ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(30.dp).padding(paddingValues),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceEvenly) {
-              // Text Instruction
-              Text(
-                  "Push a notification to users near you! If they are available and have the products you need, they'll be able to help you!",
-                  modifier = Modifier.testTag("alertInstruction"),
-                  textAlign = TextAlign.Center,
-                  style = MaterialTheme.typography.titleSmall)
 
-              // Product
-              ExposedDropdownMenuSample(
-                  listOf("Tampons", "Pads", "No Preference"), "Product Needed", "alertProduct")
+        // Product
+        ExposedDropdownMenuSample(
+          listOf("Tampons", "Pads", "No Preference"),
+          "Product Needed",
+          "alertProduct",
+        )
 
-              // Urgency
-              ExposedDropdownMenuSample(
-                  listOf("!!! High", "!! Medium", "! Low"), "Urgency level", "alertUrgency")
+        // Urgency
+        ExposedDropdownMenuSample(
+          listOf("!!! High", "!! Medium", "! Low"),
+          "Urgency level",
+          "alertUrgency",
+        )
 
-              // Location
-              OutlinedTextField(
-                  value = location,
-                  onValueChange = { location = it },
-                  label = { Text("Location") },
-                  placeholder = { Text("Enter your location") },
-                  modifier = Modifier.fillMaxWidth().testTag("alertLocation"))
+        // Location
+        OutlinedTextField(
+          value = location,
+          onValueChange = { location = it },
+          label = { Text("Location") },
+          placeholder = { Text("Enter your location") },
+          modifier = Modifier.fillMaxWidth().testTag("alertLocation"),
+        )
 
-              // Message
-              OutlinedTextField(
-                  value = message,
-                  onValueChange = { message = it },
-                  label = { Text("Message") },
-                  placeholder = { Text("Write a message for the other users") },
-                  modifier = Modifier.fillMaxWidth().height(150.dp).testTag("alertMessage"))
+        // Message
+        OutlinedTextField(
+          value = message,
+          onValueChange = { message = it },
+          label = { Text("Message") },
+          placeholder = { Text("Write a message for the other users") },
+          modifier = Modifier.fillMaxWidth().height(150.dp).testTag("alertMessage"),
+        )
 
-              // Submit Button
-              Button(
-                  onClick = { navigationActions.navigateTo(Screen.ALERT_LIST) },
-                  modifier =
-                      Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
-              ) {
-                Text("Ask for Help", style = MaterialTheme.typography.headlineMedium)
-              }
-            }
-      })
+        // Submit Button
+        Button(
+          onClick = { navigationActions.navigateTo(Screen.ALERT_LIST) },
+          modifier = Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
+        ) {
+          Text("Ask for Help", style = MaterialTheme.typography.headlineMedium)
+        }
+      }
+    },
+  )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -108,33 +115,29 @@ fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String
   var text by remember { mutableStateOf("Please choose one option") }
 
   ExposedDropdownMenuBox(
-      modifier = Modifier.testTag(testTag),
-      expanded = expanded,
-      onExpandedChange = { expanded = it },
+    modifier = Modifier.testTag(testTag),
+    expanded = expanded,
+    onExpandedChange = { expanded = it },
   ) {
     TextField(
-        modifier = Modifier.menuAnchor(),
-        value = text,
-        onValueChange = {},
-        readOnly = true,
-        singleLine = true,
-        label = { Text(label) },
-        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-        colors = ExposedDropdownMenuDefaults.textFieldColors(),
+      modifier = Modifier.menuAnchor(),
+      value = text,
+      onValueChange = {},
+      singleLine = true,
+      label = { Text(label) },
+      trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+      colors = ExposedDropdownMenuDefaults.textFieldColors(),
     )
-    ExposedDropdownMenu(
-        expanded = expanded,
-        onDismissRequest = { expanded = false },
-    ) {
+    ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       options.forEach { option ->
         DropdownMenuItem(
-            modifier = Modifier.testTag(option),
-            text = { Text(option) },
-            onClick = {
-              text = option
-              expanded = false
-            },
-            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+          modifier = Modifier,
+          text = { Text(option) },
+          onClick = {
+            text = option
+            expanded = false
+          },
+          contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
         )
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp = "8.6.1"
 androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
+dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
 json = "20240303"
 kotlin = "2.0.0"
@@ -101,6 +102,7 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref =
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
+dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
# Fix and complete UI tests for AlertScreen
## Description
This PR introduces new tests for the Alert screen and fixes the old ones. It also fixes the problems pointed out by said new tests. It closes issue #64 and fixes part of #63 .
## Changes
Added dependencies to make mockito work in androidTests, and properly mocked `NavigationActions`. Added verification of correct navigation in the old tests and created new tests to check that nothing happens when trying to submit an invalid Alert.  
Invalid alerts are ones which don't have a period product, urgency level and location selected.
## Files 
#### Added
None
#### Modified
- `app/build.gradle.kts` and `gradle/libs.versions.toml`: add the missing dependency
- `app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt`: modified and added tests
- `app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt`: fixed problems pointed out by new tests
#### Removed
None
## Dependencies Added
- [`com.linkedin.dexmaker:dexmaker-mockito-inline`](https://stackoverflow.com/a/67337292) to make mockito work with androidTests. Had to remove `libs.mockito.android` for androidTests as a consequence
## Testing
All UI tests for `AlertScreen` pass. They should be complete enough.