### PR TITLE
fix/alert/alert-list-ui-tests : Fix and complete UI tests for AlertListScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,8 +221,8 @@ dependencies {
 
   /// Mockito for android testing
   androidTestImplementation(libs.androidx.junit)
-  androidTestImplementation(libs.mockito.android)
   androidTestImplementation(libs.mockito.kotlin)
+  androidTestImplementation(libs.dexmaker.mockito.inline)
 
   // Mockito for unit testing
   testImplementation(libs.mockito.kotlin)

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
@@ -7,23 +7,33 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.ui.alert.AlertListScreen
 import com.android.periodpals.ui.alert.NoAlertDialog
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 @RunWith(AndroidJUnit4::class)
 class AlertListScreenTest {
 
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
 
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+  }
+
   @Test
-  fun titleAndNavigationElementsCorrectlyDisplayed() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
+  fun sharedComponentsCorrectlyDisplayed() {
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("alertListScreen").assertExists()
     composeTestRule.onNodeWithTag("tabRowAlert").assertIsDisplayed()
@@ -32,8 +42,23 @@ class AlertListScreenTest {
   }
 
   @Test
-  fun palsAlertsContentIsCorrect() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
+  fun myAlertsTabIsSelectedByDefault() {
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
+    composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
+  }
+
+  @Test
+  fun myAlertsTabContentIsCorrect() {
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
+
+    composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
+  }
+
+  @Test
+  fun palsAlertsTabContentIsCorrect() {
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
 
     composeTestRule.onNodeWithTag("palsAlertsTab").performClick()
 
@@ -42,96 +67,50 @@ class AlertListScreenTest {
   }
 
   @Test
-  fun myAlertsContentIsCorrect() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
-
-    composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
-  }
-
-  @Test
   fun clickingOnAlertItemDoesNothing() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
 
-    // Check that the default tab is My Alerts tab
-    composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
-    composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
-
-    // Check that the alert item is displayed
     composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
-
-    // Click on the card and verify that nothing changes
     composeTestRule.onNodeWithTag("alertItem").performClick()
-
-    // Check that the default tab is My Alerts tab
+    // check that it did nothing
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
-
-    // Check that the alert item is displayed
     composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
   }
 
   @Test
   fun clickingOnNoAlertDialogDoesNothing() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
 
-    // Check that the default tab is My Alerts tab
-    composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
-    composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
-
-    // Switch to Pals Alerts screen
     composeTestRule.onNodeWithTag("palsAlertsTab").performClick()
-
-    // Check that the Pals Alerts tab is selected and my Alerts is not selected
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsNotSelected()
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsSelected()
 
-    // Check that the dialog is displayed
     composeTestRule.onNodeWithTag("noAlertsCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("noAlertsCardText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("noAlertsCard").performClick()
 
-    // Click on the card
-    composeTestRule.onNodeWithTag("noAlertsCard").assertIsDisplayed()
-
-    // Check that nothing changed
-    // Check that the Pals Alerts tab is selected and my Alerts is not selected
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsNotSelected()
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsSelected()
-
-    // Check that the dialog is displayed
     composeTestRule.onNodeWithTag("noAlertsCard").assertIsDisplayed()
     composeTestRule.onNodeWithTag("noAlertsCardText").assertIsDisplayed()
   }
 
   @Test
   fun switchingTabWorks() {
-    composeTestRule.setContent { AlertListScreen(NavigationActions(rememberNavController())) }
+    composeTestRule.setContent { AlertListScreen(navigationActions) }
 
-    // Explicitly select My Alerts tab
-    composeTestRule.onNodeWithTag("myAlertsTab").performClick()
-
-    // Check that the default tab is My Alerts tab
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
 
-    // Check that My Alert content is correctly displayed
-    composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
-
-    // Switch to Pals Alerts tab
     composeTestRule.onNodeWithTag("palsAlertsTab").performClick()
+
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsSelected()
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsNotSelected()
 
-    // Verify Pals Alerts content is displayed
-    composeTestRule.onNodeWithTag("noAlertsCard").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("noAlertsCardText").assertIsDisplayed()
-
-    // Switch back to My Alerts tab
     composeTestRule.onNodeWithTag("myAlertsTab").performClick()
+
     composeTestRule.onNodeWithTag("myAlertsTab").assertIsSelected()
     composeTestRule.onNodeWithTag("palsAlertsTab").assertIsNotSelected()
-
-    // Verify My Alerts content is displayed
-    composeTestRule.onNodeWithTag("alertItem").assertIsDisplayed()
   }
 
   @Test
@@ -142,7 +121,7 @@ class AlertListScreenTest {
     composeTestRule.onNodeWithTag("noAlertsIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("noAlertsCardText").assertExists()
     composeTestRule
-        .onNodeWithTag("noAlertsCardText")
-        .assertTextEquals("No alerts here for the moment...")
+      .onNodeWithTag("noAlertsCardText")
+      .assertTextEquals("No alerts here for the moment...")
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
@@ -121,7 +121,7 @@ class AlertListScreenTest {
     composeTestRule.onNodeWithTag("noAlertsIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("noAlertsCardText").assertExists()
     composeTestRule
-      .onNodeWithTag("noAlertsCardText")
-      .assertTextEquals("No alerts here for the moment...")
+        .onNodeWithTag("noAlertsCardText")
+        .assertTextEquals("No alerts here for the moment...")
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt
@@ -28,7 +28,7 @@ class AlertListScreenTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
-    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
   }
 
   @Test
@@ -121,7 +121,7 @@ class AlertListScreenTest {
     composeTestRule.onNodeWithTag("noAlertsIcon").assertIsDisplayed()
     composeTestRule.onNodeWithTag("noAlertsCardText").assertExists()
     composeTestRule
-        .onNodeWithTag("noAlertsCardText")
-        .assertTextEquals("No alerts here for the moment...")
+      .onNodeWithTag("noAlertsCardText")
+      .assertTextEquals("No alerts here for the moment...")
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp = "8.6.1"
 androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
+dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
 json = "20240303"
 kotlin = "2.0.0"
@@ -101,6 +102,7 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref =
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
+dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
# Fix and complete UI tests for AlertListScreen
## Description
This PR introduces corrects some duplicated testing for the AlertList screen. It closes issue #69 and fixes part of #63.
## Changes
Added dependencies to make mockito work in androidTests, and properly mocked `NavigationActions`. Refactored some of the tests to not duplicate testing purposelessly.
## Files 
#### Added
None
#### Modified
- `app/build.gradle.kts` and `gradle/libs.versions.toml`: add the missing dependency
- `app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListScreenTest.kt`: modified some tests
#### Removed
None
## Dependencies Added
- [`com.linkedin.dexmaker:dexmaker-mockito-inline`](https://stackoverflow.com/a/67337292) to make mockito work with androidTests. Had to remove `libs.mockito.android` for androidTests as a consequence
## Testing
All UI tests for `AlertListScreen` pass. They should be complete enough.