### PR TITLE
fix/authentication/signin-ui-tests : Fix and complete UI tests for SignInScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,8 +221,8 @@ dependencies {
 
   /// Mockito for android testing
   androidTestImplementation(libs.androidx.junit)
-  androidTestImplementation(libs.mockito.android)
   androidTestImplementation(libs.mockito.kotlin)
+  androidTestImplementation(libs.dexmaker.mockito.inline)
 
   // Mockito for unit testing
   testImplementation(libs.mockito.kotlin)

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -1,144 +1,127 @@
 package com.android.periodpals.ui.authentication
-//
-// import androidx.compose.ui.test.assertIsDisplayed
-// import androidx.compose.ui.test.assertTextEquals
-// import androidx.compose.ui.test.junit4.createComposeRule
-// import androidx.compose.ui.test.onNodeWithTag
-// import androidx.compose.ui.test.performClick
-// import androidx.compose.ui.test.performTextInput
-// import androidx.navigation.compose.rememberNavController
-// import com.android.periodpals.model.auth.AuthViewModel
-// import com.android.periodpals.ui.navigation.NavigationActions
-// import org.junit.Before
-// import org.junit.Rule
-// import org.junit.Test
-// import org.mockito.Mockito.mock
-//
-// class SignInScreenTest {
-//
-//  @get:Rule val composeTestRule = createComposeRule()
-//  lateinit var authViewModel: AuthViewModel
-//
-//  // lateinit var supabaseClient: SupabaseClient
-//
-//  @Before
-//  fun setUp() {
-//    authViewModel = mock(AuthViewModel::class.java)
-//    // supabaseClient = mock(SupabaseClient::class.java)
-//  }
-//
-//  @Test
-//  fun signInScreen_displaysCorrectUI() {
-//    // Set the content to the SignInScreen
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Check if the welcome text is displayed
-//    composeTestRule.onNodeWithTag("signInScreen").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInBackground").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInTitle").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInInstruction").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInEmail").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInPassword").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInPasswordVisibility").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInButton").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInOrText").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInGoogleButton").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signInNotRegistered").assertIsDisplayed()
-//  }
-//
-//  @Test
-//  fun signInScreen_emailValidation_emptyEmail_showsError() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Click on the sign in button with empty fields
-//    composeTestRule.onNodeWithTag("signInButton").performClick()
-//
-//    // Verify that the error message for email is displayed
-//    composeTestRule.onNodeWithTag("signInEmailError").assertTextEquals("Email cannot be empty")
-//  }
-//
-//  @Test
-//  fun signInScreen_emailValidation_invalidEmail_showsError() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Enter an invalid email
-//    composeTestRule.onNodeWithTag("signInEmail").performTextInput("invalidEmail")
-//
-//    // Click on the sign in button
-//    composeTestRule.onNodeWithTag("signInButton").performClick()
-//
-//    // Verify that the error message for email is displayed
-//    composeTestRule.onNodeWithTag("signInEmailError").assertTextEquals("Email must contain @")
-//  }
-//
-//  @Test
-//  fun signInScreen_passwordValidation_emptyPassword_showsError() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Enter a valid email
-//    composeTestRule.onNodeWithTag("signInEmail").performTextInput("test@example.com")
-//
-//    // Click on the sign in button with empty password
-//    composeTestRule.onNodeWithTag("signInButton").performClick()
-//
-//    // Verify that the error message for password is displayed
-//    composeTestRule
-//      .onNodeWithTag("signInPasswordError")
-//      .assertTextEquals("Password cannot be empty")
-//  }
-//
-//  @Test
-//  fun signInScreen_signIn_successfulLogin() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Enter valid email and password
-//    composeTestRule.onNodeWithTag("signInEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signInPassword").performTextInput("ValidPassword123")
-//
-//    // Click on the sign in button
-//    composeTestRule.onNodeWithTag("signInButton").performClick()
-//
-//    // Check for a successful login Toast (mocking would be required here)
-//    // Currently, you can't test Toast directly; you can use dependency injection or other methods
-//  }
-//
-//  @Test
-//  fun signInScreen_signIn_failsInvalidLogin() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Enter valid email and an invalid password
-//    composeTestRule.onNodeWithTag("signInEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signInPassword").performTextInput("InvalidPassword")
-//
-//    // Click on the sign in button
-//    composeTestRule.onNodeWithTag("signInButton").performClick()
-//
-//    // Check for a failed login Toast (mocking would be required here)
-//    // You can set up your test to verify that the error message or Toast appears.
-//  }
-//
-//  @Test
-//  fun signInScreen_navigatesToSignUp() {
-//    composeTestRule.setContent {
-//      SignInScreen(authViewModel, NavigationActions(rememberNavController()))
-//    }
-//
-//    // Click on the "Not registered yet? Sign up here!" text
-//    composeTestRule.onNodeWithTag("signInNotRegistered").performClick()
-//
-//    // Check for a navigation action (mocking would be required here)
-//    // You would verify that the navigation to the sign-up screen is triggered.
-//  }
-// }
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.android.periodpals.model.auth.AuthViewModel
+import com.android.periodpals.model.user.UserAuthState
+import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class SignInScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var authViewModel: AuthViewModel
+
+  companion object {
+    private const val email = "test@example.com"
+    private const val password = "password"
+  }
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    authViewModel = mock(AuthViewModel::class.java)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
+    `when`(authViewModel.userAuthState)
+      .thenReturn(mutableStateOf(UserAuthState.Success("User is logged in")))
+    composeTestRule.setContent { SignInScreen(authViewModel, navigationActions) }
+  }
+
+  @Test
+  fun allComponentsAreDisplayed() {
+
+    composeTestRule.onNodeWithTag("signInScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInBackground").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInInstruction").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInEmail").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInPassword").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInPasswordVisibility").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInOrText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInGoogleButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInNotRegistered").assertIsDisplayed()
+  }
+
+  @Test
+  fun emptyEmailShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    composeTestRule.onNodeWithTag("signInEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInEmailError").assertTextEquals("Email cannot be empty")
+  }
+
+  @Test
+  fun emptyEmailDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    composeTestRule.onNodeWithTag("signInEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signInEmailError").assertTextEquals("Email cannot be empty")
+    verify(authViewModel, never()).logInWithEmail(any(), any(), any())
+  }
+
+  @Test
+  fun emptyPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    composeTestRule.onNodeWithTag("signInPasswordError").assertIsDisplayed()
+    composeTestRule
+      .onNodeWithTag("signInPasswordError")
+      .assertTextEquals("Password cannot be empty")
+  }
+
+  @Test
+  fun emptyPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    composeTestRule.onNodeWithTag("signInPasswordError").assertIsDisplayed()
+    composeTestRule
+      .onNodeWithTag("signInPasswordError")
+      .assertTextEquals("Password cannot be empty")
+  }
+
+  @Test
+  fun validSignInAttemptNavigatesToProfileScreen() {
+
+    composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    verify(navigationActions).navigateTo(Screen.PROFILE)
+  }
+
+  @Test
+  fun validSignInAttemptCallsVMLogInWithEmail() {
+
+    composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signInButton").performClick()
+    verify(authViewModel).logInWithEmail(any(), eq(email), eq(password))
+  }
+
+  @Test
+  fun signUpHereNavigatesToSignUpScreen() {
+    composeTestRule.onNodeWithTag("signInNotRegistered").performClick()
+    verify(navigationActions).navigateTo(Screen.SIGN_UP)
+  }
+}

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.model.auth.AuthViewModel
 import com.android.periodpals.model.user.UserAuthState
 import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
@@ -38,7 +37,7 @@ class SignInScreenTest {
     navigationActions = mock(NavigationActions::class.java)
     authViewModel = mock(AuthViewModel::class.java)
 
-    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.SIGN_IN)
     `when`(authViewModel.userAuthState)
         .thenReturn(mutableStateOf(UserAuthState.Success("User is logged in")))
     composeTestRule.setContent { SignInScreen(authViewModel, navigationActions) }
@@ -74,8 +73,6 @@ class SignInScreenTest {
 
     composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signInButton").performClick()
-    composeTestRule.onNodeWithTag("signInEmailError").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("signInEmailError").assertTextEquals("Email cannot be empty")
     verify(authViewModel, never()).logInWithEmail(any(), any(), any())
   }
 
@@ -95,10 +92,7 @@ class SignInScreenTest {
 
     composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
     composeTestRule.onNodeWithTag("signInButton").performClick()
-    composeTestRule.onNodeWithTag("signInPasswordError").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("signInPasswordError")
-        .assertTextEquals("Password cannot be empty")
+    verify(authViewModel, never()).logInWithEmail(any(), any(), any())
   }
 
   @Test
@@ -112,7 +106,6 @@ class SignInScreenTest {
 
   @Test
   fun validSignInAttemptCallsVMLogInWithEmail() {
-
     composeTestRule.onNodeWithTag("signInEmail").performTextInput(email)
     composeTestRule.onNodeWithTag("signInPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signInButton").performClick()

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -40,7 +40,7 @@ class SignInScreenTest {
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
     `when`(authViewModel.userAuthState)
-      .thenReturn(mutableStateOf(UserAuthState.Success("User is logged in")))
+        .thenReturn(mutableStateOf(UserAuthState.Success("User is logged in")))
     composeTestRule.setContent { SignInScreen(authViewModel, navigationActions) }
   }
 
@@ -86,8 +86,8 @@ class SignInScreenTest {
     composeTestRule.onNodeWithTag("signInButton").performClick()
     composeTestRule.onNodeWithTag("signInPasswordError").assertIsDisplayed()
     composeTestRule
-      .onNodeWithTag("signInPasswordError")
-      .assertTextEquals("Password cannot be empty")
+        .onNodeWithTag("signInPasswordError")
+        .assertTextEquals("Password cannot be empty")
   }
 
   @Test
@@ -97,8 +97,8 @@ class SignInScreenTest {
     composeTestRule.onNodeWithTag("signInButton").performClick()
     composeTestRule.onNodeWithTag("signInPasswordError").assertIsDisplayed()
     composeTestRule
-      .onNodeWithTag("signInPasswordError")
-      .assertTextEquals("Password cannot be empty")
+        .onNodeWithTag("signInPasswordError")
+        .assertTextEquals("Password cannot be empty")
   }
 
   @Test

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -165,12 +165,16 @@ fun SignInScreen(authViewModel: AuthViewModel, navigationActions: NavigationActi
                   )
                 }
               }
-          Text(
-              text = "Not registered yet? Sign up here!",
-              modifier =
-                  Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                      .testTag("signInNotRegistered"),
-          )
+          Row(modifier = Modifier) {
+            Text("Not registered yet? ")
+            Text(
+                text = "Sign up here!",
+                modifier =
+                    Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                        .testTag("signInNotRegistered"),
+                color = Color.Blue,
+            )
+          }
         }
       },
   )

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -35,10 +35,7 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
 import com.android.periodpals.model.auth.AuthViewModel
@@ -86,7 +83,10 @@ fun SignInScreen(authViewModel: AuthViewModel, navigationActions: NavigationActi
         ) {
           // Welcome text
           AuthWelcomeText(
-              text = "Welcome to PeriodPals", color = Color.Black, testTag = "signInTitle")
+              text = "Welcome to PeriodPals",
+              color = Color.Black,
+              testTag = "signInTitle",
+          )
 
           // Rectangle with login fields and button
           Box(
@@ -97,108 +97,83 @@ fun SignInScreen(authViewModel: AuthViewModel, navigationActions: NavigationActi
                       .padding(24.dp)) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)) {
-                      // Sign in instruction
-                      AuthInstruction(
-                          text = "Sign in to your account", testTag = "signInInstruction")
+                    verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+                ) {
+                  // Sign in instruction
+                  AuthInstruction(text = "Sign in to your account", testTag = "signInInstruction")
 
-                      // Email input and error message
-                      AuthEmailInput(
-                          email = email, onEmailChange = { email = it }, testTag = "signInEmail")
-                      if (emailErrorMessage.isNotEmpty()) {
-                        ErrorText(emailErrorMessage, "signInEmailError")
-                      }
+                  // Email input and error message
+                  AuthEmailInput(
+                      email = email, onEmailChange = { email = it }, testTag = "signInEmail")
+                  if (emailErrorMessage.isNotEmpty()) {
+                    ErrorText(emailErrorMessage, "signInEmailError")
+                  }
 
-                      // Password input and error message
-                      AuthPasswordInput(
-                          password = password,
-                          onPasswordChange = { password = it },
-                          passwordVisible = passwordVisible,
-                          onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                          testTag = "signInPassword",
-                          visibilityTestTag = "signInPasswordVisibility")
-                      if (passwordErrorMessage.isNotEmpty()) {
-                        ErrorText(passwordErrorMessage, "signInPasswordError")
-                      }
+                  // Password input and error message
+                  AuthPasswordInput(
+                      password = password,
+                      onPasswordChange = { password = it },
+                      passwordVisible = passwordVisible,
+                      onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+                      testTag = "signInPassword",
+                      visibilityTestTag = "signInPasswordVisibility",
+                  )
+                  if (passwordErrorMessage.isNotEmpty()) {
+                    ErrorText(passwordErrorMessage, "signInPasswordError")
+                  }
 
-                      // Sign in button
-                      AuthButton(
-                          text = "Sign in",
-                          onClick = {
-                            emailErrorMessage = validateEmail(email)
-                            passwordErrorMessage = validatePassword(password)
+                  // Sign in button
+                  AuthButton(
+                      text = "Sign in",
+                      onClick = {
+                        emailErrorMessage = validateEmail(email)
+                        passwordErrorMessage = validatePassword(password)
 
-                            if (emailErrorMessage.isEmpty() && passwordErrorMessage.isEmpty()) {
-                              authViewModel.logInWithEmail(context, email, password)
-                              authViewModel.isUserLoggedIn(context)
-                              val loginSuccess = userState is UserAuthState.Success
-                              if (loginSuccess) {
-                                // with supabase
-                                Toast.makeText(context, "Login Successful", Toast.LENGTH_SHORT)
-                                    .show()
-                                navigationActions.navigateTo(Screen.PROFILE)
-                              } else {
-                                Toast.makeText(context, "Login Failed", Toast.LENGTH_SHORT).show()
-                              }
-                            } else {
-                              Toast.makeText(
-                                      context, "Invalid email or password.", Toast.LENGTH_SHORT)
-                                  .show()
-                            }
-                            emailErrorMessage = validateEmail(email)
-                            passwordErrorMessage = validatePassword(password)
+                        if (emailErrorMessage.isEmpty() && passwordErrorMessage.isEmpty()) {
+                          authViewModel.logInWithEmail(context, email, password)
+                          authViewModel.isUserLoggedIn(context)
+                          val loginSuccess = userState is UserAuthState.Success
+                          if (loginSuccess) {
+                            // with supabase
+                            Toast.makeText(context, "Login Successful", Toast.LENGTH_SHORT).show()
+                            navigationActions.navigateTo(Screen.PROFILE)
+                          } else {
+                            Toast.makeText(context, "Login Failed", Toast.LENGTH_SHORT).show()
+                          }
+                        } else {
+                          Toast.makeText(context, "Invalid email or password.", Toast.LENGTH_SHORT)
+                              .show()
+                        }
+                      },
+                      testTag = "signInButton",
+                  )
 
-                            if (emailErrorMessage.isEmpty() && passwordErrorMessage.isEmpty()) {
-                              authViewModel.logInWithEmail(context, email, password)
-                              authViewModel.isUserLoggedIn(context)
-                              val loginSuccess = userState is UserAuthState.Success
-                              if (loginSuccess) {
-                                Toast.makeText(context, "Login Successful", Toast.LENGTH_SHORT)
-                                    .show()
-                              } else {
-                                Toast.makeText(context, "Login Failed", Toast.LENGTH_SHORT).show()
-                              }
-                            } else {
-                              Toast.makeText(
-                                      context, "Invalid email or password.", Toast.LENGTH_SHORT)
-                                  .show()
-                            }
-                          },
-                          testTag = "signInButton")
+                  // Or continue with text
+                  AuthSecondInstruction(text = "Or continue with", testTag = "signInOrText")
 
-                      // Or continue with text
-                      AuthSecondInstruction(text = "Or continue with", testTag = "signInOrText")
-
-                      // Google sign in button
-                      GoogleButton(
-                          onClick = {
-                            Toast.makeText(
-                                    context,
-                                    "Use other login method for now, thanks!",
-                                    Toast.LENGTH_SHORT)
-                                .show()
-                          },
-                          testTag = "signInGoogleButton")
-                    }
+                  // Google sign in button
+                  GoogleButton(
+                      onClick = {
+                        Toast.makeText(
+                                context,
+                                "Use other login method for now, thanks!",
+                                Toast.LENGTH_SHORT,
+                            )
+                            .show()
+                      },
+                      testTag = "signInGoogleButton",
+                  )
+                }
               }
-          // Not registered yet? Sign up here!
-          val annotatedText = buildAnnotatedString {
-            append("Not registered yet? ")
-            pushStringAnnotation(tag = "SignUp", annotation = "SignUp")
-            withStyle(style = SpanStyle(color = Color.Blue)) { append("Sign up here!") }
-            pop()
-          }
-          ClickableText(
-              modifier = Modifier.testTag("signInNotRegistered"),
-              text = annotatedText,
-              onClick = { offset ->
-                annotatedText
-                    .getStringAnnotations(tag = "SignUp", start = offset, end = offset)
-                    .firstOrNull()
-                    ?.let { navigationActions.navigateTo(Screen.SIGN_UP) }
-              })
+          Text(
+              text = "Not registered yet? Sign up here!",
+              modifier =
+                  Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                      .testTag("signInNotRegistered"),
+          )
         }
-      })
+      },
+  )
 }
 
 /** Validates the email and returns an error message if the email is invalid. */
@@ -232,20 +207,24 @@ fun GoogleButton(onClick: () -> Unit, modifier: Modifier = Modifier, testTag: St
       onClick = onClick,
       colors = ButtonDefaults.buttonColors(containerColor = Color.White),
       shape = RoundedCornerShape(50),
-      border = BorderStroke(1.dp, Color.LightGray)) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center) {
-              Image(
-                  painter = painterResource(id = R.drawable.google_logo),
-                  contentDescription = "Google Logo",
-                  modifier = Modifier.size(24.dp))
-              Spacer(modifier = Modifier.size(8.dp))
-              Text(
-                  text = "Sign in with Google",
-                  color = Color.Black,
-                  fontWeight = FontWeight.Medium,
-                  style = MaterialTheme.typography.bodyMedium)
-            }
-      }
+      border = BorderStroke(1.dp, Color.LightGray),
+  ) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+      Image(
+          painter = painterResource(id = R.drawable.google_logo),
+          contentDescription = "Google Logo",
+          modifier = Modifier.size(24.dp),
+      )
+      Spacer(modifier = Modifier.size(8.dp))
+      Text(
+          text = "Sign in with Google",
+          color = Color.Black,
+          fontWeight = FontWeight.Medium,
+          style = MaterialTheme.typography.bodyMedium,
+      )
+    }
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp = "8.6.1"
 androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
+dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
 json = "20240303"
 kotlin = "2.0.0"
@@ -101,6 +102,7 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref =
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
+dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
# Fix and complete UI tests for SignInScreen
## Description
This PR introduces new tests for the SignIn screen and fixes the old ones. It also fixes the problems pointed out by said new tests. It closes issue #71 and fixes part of #63 .
## Changes
Added dependencies to make mockito work in androidTests (this was also done in `main` and later merged into this branch, so I'll ignore it in the rest of this PR).
Properly mocked `NavigationActions` and added verification of correct navigation. Also added checks for the correct calls to the `AuthViewModel` on valid attempts and for no calls to the `AuthViewModel` on invalid attempts. Removed irrelevant tests (tested for behavior of VM, not the point here). 
Invalid attempts are ones which have an empty email or password.
Fixed the problems pointed out by the added tests (two calls to `logInWithEmail` instead of one on valid attempt, call to `navigationAction` not detected when trying to sign up).
## Files 
#### Added
None
#### Modified
- `app/src/androidTest/java/com/android/periodpals/ui/alert/SignInScreenTest.kt`: modified, removed and added tests
- `app/src/main/java/com/android/periodpals/ui/alert/SignInScreen.kt`: fixed problems pointed out by new tests
#### Removed
None
## Dependencies Added
None
## Testing
All UI tests for `SignInScreen` pass. They should be complete enough.