### PR TITLE
Fix/misc/input-fields-on-click: Prevent Navigation on Button Click with Empty Fields

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -221,8 +221,8 @@ dependencies {
 
   /// Mockito for android testing
   androidTestImplementation(libs.androidx.junit)
-  androidTestImplementation(libs.mockito.android)
   androidTestImplementation(libs.mockito.kotlin)
+  androidTestImplementation(libs.dexmaker.mockito.inline)
 
   // Mockito for unit testing
   testImplementation(libs.mockito.kotlin)

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -155,8 +155,6 @@ class AlertScreenTest {
 
     // Verify that the navigation action occurs
     // This can be done by checking that the current screen is not the AlertScreen
-    composeTestRule.onNodeWithTag("alertScreen").assertDoesNotExist()
     verify(navigationActions).navigateTo(screen = Screen.ALERT_LIST)
-    composeTestRule.onNodeWithTag("alertListScreen").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -10,11 +10,14 @@ import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.navigation.TopLevelDestination
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
 class AlertScreenTest {
@@ -72,7 +75,8 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -90,7 +94,8 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -109,7 +114,8 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -125,7 +131,8 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -134,7 +141,8 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -154,7 +162,6 @@ class AlertScreenTest {
     composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
 
     // Verify that the navigation action occurs
-    // This can be done by checking that the current screen is not the AlertScreen
     verify(navigationActions).navigateTo(screen = Screen.ALERT_LIST)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertScreenTest.kt
@@ -7,21 +7,29 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.rememberNavController
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 
 class AlertScreenTest {
-
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    composeTestRule.setContent { MaterialTheme { AlertScreen(navigationActions) } }
+  }
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent {
-      MaterialTheme { AlertScreen(NavigationActions(rememberNavController())) }
-    }
-
     composeTestRule.onNodeWithTag("alertInstruction").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed()
     composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed()
@@ -35,10 +43,6 @@ class AlertScreenTest {
 
   @Test
   fun interactWithComponents() {
-    composeTestRule.setContent {
-      MaterialTheme { AlertScreen(NavigationActions(rememberNavController())) }
-    }
-
     composeTestRule.onNodeWithTag("alertProduct").performClick()
     composeTestRule.onNodeWithTag("Pads").performClick()
     //        composeTestRule.onNodeWithTag("alertProduct").assertTextEquals("Pads")
@@ -51,5 +55,108 @@ class AlertScreenTest {
 
     // Cannot test navigation actions
     //    composeTestRule.onNodeWithTag("alertSubmit").performClick()
+  }
+
+  @Test
+  fun askForHelpButton_doesNotNavigate_whenProductNotPicked() {
+    // Leave product empty
+    composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("!! Medium").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed().performTextInput("Rolex")
+    composeTestRule
+        .onNodeWithTag("alertMessage")
+        .assertIsDisplayed()
+        .performTextInput("I need help finding a tampon")
+
+    // Click the "Ask for Help" button
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun askForHelpButton_doesNotNavigate_whenUrgencyNotPicked() {
+    // Leave urgency empty
+    composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("Pads").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed().performTextInput("Rolex")
+    composeTestRule
+        .onNodeWithTag("alertMessage")
+        .assertIsDisplayed()
+        .performTextInput("I need help finding a tampon")
+
+    // Click the "Ask for Help" button
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun askForHelpButton_doesNotNavigate_whenLocationNotFilled() {
+    // Leave location empty
+    composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("Pads").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("!! Medium").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("alertMessage")
+        .assertIsDisplayed()
+        .performTextInput("I need help finding a tampon")
+
+    // Click the "Ask for Help" button
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun askForHelpButton_doesNotNavigate_whenMessageNotFilled() {
+    // Leave message empty
+    composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("Pads").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("!! Medium").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed().performTextInput("Rolex")
+
+    // Click the "Ask for Help" button
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun askForHelpButton_doesNotNavigate_whenAllFieldsAreEmpty() {
+    // Click the "Ask for Help" button without filling any fields
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("alertScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun askForHelpButton_navigates_whenAllFieldsAreFilled() {
+    // Fill all fields
+    composeTestRule.onNodeWithTag("alertProduct").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("Pads").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertUrgency").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("!! Medium").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("alertLocation").assertIsDisplayed().performTextInput("Rolex")
+    composeTestRule
+        .onNodeWithTag("alertMessage")
+        .assertIsDisplayed()
+        .performTextInput("I need help finding a tampon")
+
+    // Click the "Ask for Help" button
+    composeTestRule.onNodeWithTag("alertSubmit").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action occurs
+    // This can be done by checking that the current screen is not the AlertScreen
+    composeTestRule.onNodeWithTag("alertScreen").assertDoesNotExist()
+    verify(navigationActions).navigateTo(screen = Screen.ALERT_LIST)
+    composeTestRule.onNodeWithTag("alertListScreen").assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.navigation.TopLevelDestination
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
@@ -17,7 +18,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -91,7 +94,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -111,7 +115,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -131,7 +136,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -148,7 +154,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -147,7 +147,6 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action occurs
-    composeTestRule.onNodeWithTag("createProfileScreen").assertDoesNotExist()
     verify(navigationActions).navigateTo(screen = Screen.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -6,9 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
@@ -84,7 +82,10 @@ class CreateProfileTest {
     // Leave email empty
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -96,9 +97,15 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenDobNotFilled() {
     // Leave date of birth empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -110,9 +117,15 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenNameNotFilled() {
     // Leave name empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -124,7 +137,10 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenDescriptionNotFilled() {
     // Leave description empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
 
@@ -138,10 +154,16 @@ class CreateProfileTest {
   @Test
   fun saveButton_navigates_whenAllFieldsAreFilled() {
     // Fill all fields
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.profile
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -7,30 +8,40 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class CreateProfileTest {
-
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    composeTestRule.setContent { MaterialTheme { CreateProfileScreen(navigationActions) } }
+  }
 
   @Test
   fun testProfileImageDisplayed() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Check if the profile image is displayed
     composeTestRule.onNodeWithTag("profile_image").assertIsDisplayed()
   }
 
   @Test
   fun testFormFieldsDisplayed() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Check if the form fields are displayed
     composeTestRule.onNodeWithTag("email_field").assertIsDisplayed()
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed()
@@ -40,8 +51,6 @@ class CreateProfileTest {
 
   @Test
   fun testSaveButtonClickWithValidDate() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Input valid date
     composeTestRule.onNodeWithTag("dob_field").performTextInput("01/01/2000")
 
@@ -56,8 +65,6 @@ class CreateProfileTest {
 
   @Test
   fun testSaveButtonClickWithInvalidDate() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Input invalid date
     composeTestRule.onNodeWithTag("dob_field").performTextInput("invalid_date")
 
@@ -70,5 +77,77 @@ class CreateProfileTest {
     assertFalse(validateDate("01/01/abcd")) // Invalid year
     assertFalse(validateDate("01-01-2000")) // Invalid format
     assertFalse(validateDate("01/01")) // Incomplete date
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenEmailNotFilled() {
+    // Leave email empty
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenDobNotFilled() {
+    // Leave date of birth empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenNameNotFilled() {
+    // Leave name empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenDescriptionNotFilled() {
+    // Leave description empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_navigates_whenAllFieldsAreFilled() {
+    // Fill all fields
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action occurs
+    composeTestRule.onNodeWithTag("createProfileScreen").assertDoesNotExist()
+    verify(navigationActions).navigateTo(screen = Screen.PROFILE)
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.alert
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -35,6 +37,10 @@ import com.android.periodpals.ui.navigation.TopAppBar
 
 @Composable
 fun AlertScreen(navigationActions: NavigationActions) {
+  // TODO: Change the component of dropdown menu
+  val context = LocalContext.current
+  var product by remember { mutableStateOf("Please choose one option") }
+  var urgency by remember { mutableStateOf("Please choose one option") }
   var location by remember { mutableStateOf("") }
   var message by remember { mutableStateOf("") }
 
@@ -66,11 +72,21 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
               // Product
               ExposedDropdownMenuSample(
-                  listOf("Tampons", "Pads", "No Preference"), "Product Needed", "alertProduct")
+                  listOf("Tampons", "Pads", "No Preference"),
+                  "Product Needed",
+                  "alertProduct",
+                  product) {
+                    product = it
+                  }
 
               // Urgency
               ExposedDropdownMenuSample(
-                  listOf("!!! High", "!! Medium", "! Low"), "Urgency level", "alertUrgency")
+                  listOf("!!! High", "!! Medium", "! Low"),
+                  "Urgency level",
+                  "alertUrgency",
+                  urgency) {
+                    urgency = it
+                  }
 
               // Location
               OutlinedTextField(
@@ -90,7 +106,20 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
               // Submit Button
               Button(
-                  onClick = { navigationActions.navigateTo(Screen.ALERT_LIST) },
+                  onClick = {
+                    if (!validateProduct(product)) {
+                      Toast.makeText(context, "Select a product", Toast.LENGTH_SHORT).show()
+                    } else if (!validateUrgency(urgency)) {
+                      Toast.makeText(context, "Select an urgency level", Toast.LENGTH_SHORT).show()
+                    } else if (!validateLocation(location)) {
+                      Toast.makeText(context, "Location must be filled", Toast.LENGTH_SHORT).show()
+                    } else if (!validateMessage(message)) {
+                      Toast.makeText(context, "Message must be filled", Toast.LENGTH_SHORT).show()
+                    } else {
+                      navigationActions.navigateTo(Screen.ALERT_LIST)
+                      Toast.makeText(context, "Alert sent!", Toast.LENGTH_SHORT).show()
+                    }
+                  },
                   modifier =
                       Modifier.width(300.dp).height(100.dp).testTag("alertSubmit").padding(16.dp),
               ) {
@@ -102,10 +131,14 @@ fun AlertScreen(navigationActions: NavigationActions) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String) {
-  var options = list
+fun ExposedDropdownMenuSample(
+    options: List<String>,
+    label: String,
+    testTag: String,
+    selectedItem: String,
+    onItemSelected: (String) -> Unit
+) {
   var expanded by remember { mutableStateOf(false) }
-  var text by remember { mutableStateOf("Please choose one option") }
 
   ExposedDropdownMenuBox(
       modifier = Modifier.testTag(testTag),
@@ -114,7 +147,7 @@ fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String
   ) {
     TextField(
         modifier = Modifier.menuAnchor(),
-        value = text,
+        value = selectedItem,
         onValueChange = {},
         readOnly = true,
         singleLine = true,
@@ -131,7 +164,7 @@ fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String
             modifier = Modifier.testTag(option),
             text = { Text(option) },
             onClick = {
-              text = option
+              onItemSelected(option)
               expanded = false
             },
             contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
@@ -139,4 +172,25 @@ fun ExposedDropdownMenuSample(list: List<String>, label: String, testTag: String
       }
     }
   }
+}
+
+/** Validates the product is not empty or unpicked. */
+fun validateProduct(product: String): Boolean {
+  return product.isNotEmpty() && product != "Please choose one option"
+}
+
+/** Validates the urgency is not empty or unpicked. */
+fun validateUrgency(urgency: String): Boolean {
+  return urgency.isNotEmpty() && urgency != "Please choose one option"
+}
+
+/** Validates the location is not empty. */
+fun validateLocation(location: String): Boolean {
+  // TODO: change while implementing the location / map
+  return location.isNotEmpty()
+}
+
+/** Validates the message is not empty. */
+fun validateMessage(message: String): Boolean {
+  return message.isNotEmpty()
 }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertScreen.kt
@@ -39,8 +39,8 @@ import com.android.periodpals.ui.navigation.TopAppBar
 fun AlertScreen(navigationActions: NavigationActions) {
   // TODO: Change the component of dropdown menu
   val context = LocalContext.current
-  var product by remember { mutableStateOf("Please choose one option") }
-  var urgency by remember { mutableStateOf("Please choose one option") }
+  var product by remember { mutableStateOf("Please choose a product") }
+  var urgency by remember { mutableStateOf("Please choose an urgency level") }
   var location by remember { mutableStateOf("") }
   var message by remember { mutableStateOf("") }
 
@@ -107,14 +107,9 @@ fun AlertScreen(navigationActions: NavigationActions) {
               // Submit Button
               Button(
                   onClick = {
-                    if (!validateProduct(product)) {
-                      Toast.makeText(context, "Select a product", Toast.LENGTH_SHORT).show()
-                    } else if (!validateUrgency(urgency)) {
-                      Toast.makeText(context, "Select an urgency level", Toast.LENGTH_SHORT).show()
-                    } else if (!validateLocation(location)) {
-                      Toast.makeText(context, "Location must be filled", Toast.LENGTH_SHORT).show()
-                    } else if (!validateMessage(message)) {
-                      Toast.makeText(context, "Message must be filled", Toast.LENGTH_SHORT).show()
+                    val errorMessage = validateFields(product, urgency, location, message)
+                    if (errorMessage != null) {
+                      Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
                     } else {
                       navigationActions.navigateTo(Screen.ALERT_LIST)
                       Toast.makeText(context, "Alert sent!", Toast.LENGTH_SHORT).show()
@@ -174,23 +169,34 @@ fun ExposedDropdownMenuSample(
   }
 }
 
-/** Validates the product is not empty or unpicked. */
-fun validateProduct(product: String): Boolean {
-  return product.isNotEmpty() && product != "Please choose one option"
+/** Validates the fields of the alert screen. */
+private fun validateFields(
+    product: String,
+    urgency: String,
+    location: String,
+    message: String
+): String? {
+  return when {
+    !validateProduct(product) -> "Please select a product"
+    !validateUrgency(urgency) -> "Please select an urgency level"
+    !validateOutlinedTextField(location) -> "Please enter a location"
+    !validateOutlinedTextField(message) -> "Please write your message"
+    else -> null
+  }
 }
 
-/** Validates the urgency is not empty or unpicked. */
-fun validateUrgency(urgency: String): Boolean {
-  return urgency.isNotEmpty() && urgency != "Please choose one option"
+/** Validates the product dropdown menu has chosen an option. */
+private fun validateProduct(product: String): Boolean {
+  return product.isNotEmpty() && product != "Please choose a product"
+}
+
+/** Validates the urgency dropdown menu has chosen an option. */
+private fun validateUrgency(urgency: String): Boolean {
+  return urgency.isNotEmpty() && urgency != "Please choose an urgency level"
 }
 
 /** Validates the location is not empty. */
-fun validateLocation(location: String): Boolean {
+private fun validateOutlinedTextField(text: String): Boolean {
   // TODO: change while implementing the location / map
-  return location.isNotEmpty()
-}
-
-/** Validates the message is not empty. */
-fun validateMessage(message: String): Boolean {
-  return message.isNotEmpty()
+  return text.isNotEmpty()
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -162,7 +162,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
 
           Button(
               onClick = {
-                if (validateDate(age)) {
+                if (validateName(name) && validateDate(age) && validateDescription(description)) {
                   // Save the profile (future implementation)
                   Toast.makeText(context, "Profile saved", Toast.LENGTH_SHORT).show()
                   navigationActions.navigateTo(Screen.PROFILE)
@@ -187,18 +187,28 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
   )
 }
 
+/** Validates the name is not empty. */
+private fun validateName(name: String): Boolean {
+  return name.isNotEmpty()
+}
+
+/** Validates the date is in the format DD/MM/YYYY and is a valid date. */
 fun validateDate(date: String): Boolean {
   val parts = date.split("/")
-  val calendar = GregorianCalendar.getInstance()
+  val calendar = GregorianCalendar()
   calendar.isLenient = false
   if (parts.size == 3) {
     return try {
-      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
-      calendar.time
+      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt(), 0, 0, 0)
       true
     } catch (e: Exception) {
       false
     }
   }
   return false
+}
+
+/** Validates the description is not empty. */
+private fun validateDescription(description: String): Boolean {
+  return description.isNotEmpty()
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -71,7 +71,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
           }
 
   Scaffold(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier.fillMaxSize().testTag("createProfileScreen"),
       content = { padding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
@@ -195,11 +195,12 @@ private fun validateName(name: String): Boolean {
 /** Validates the date is in the format DD/MM/YYYY and is a valid date. */
 fun validateDate(date: String): Boolean {
   val parts = date.split("/")
-  val calendar = GregorianCalendar()
+  val calendar = GregorianCalendar.getInstance()
   calendar.isLenient = false
   if (parts.size == 3) {
     return try {
-      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt(), 0, 0, 0)
+      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
+      calendar.time
       true
     } catch (e: Exception) {
       false

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -162,12 +162,13 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
 
           Button(
               onClick = {
-                if (validateName(name) && validateDate(age) && validateDescription(description)) {
+                val errorMessage = validateFields(email, name, age, description)
+                if (errorMessage != null) {
+                  Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                } else {
                   // Save the profile (future implementation)
                   Toast.makeText(context, "Profile saved", Toast.LENGTH_SHORT).show()
                   navigationActions.navigateTo(Screen.PROFILE)
-                } else {
-                  Toast.makeText(context, "Invalid date", Toast.LENGTH_SHORT).show()
                 }
               },
               enabled = true,
@@ -185,6 +186,27 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
         }
       },
   )
+}
+
+/** Validates the fields of the profile screen. */
+private fun validateFields(
+    email: String,
+    name: String,
+    date: String,
+    description: String
+): String? {
+  return when {
+    !validateEmail(email) -> "Please enter an email"
+    !validateName(name) -> "Please enter a name"
+    !validateDate(date) -> "Invalid date"
+    !validateDescription(description) -> "Please enter a description"
+    else -> null
+  }
+}
+
+/** Validates the email is not empty. */
+private fun validateEmail(email: String): Boolean {
+  return email.isNotEmpty()
 }
 
 /** Validates the name is not empty. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ agp = "8.6.1"
 androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
+dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
 json = "20240303"
 kotlin = "2.0.0"
@@ -101,6 +102,7 @@ androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref =
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
+dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }


### PR DESCRIPTION
## Description
This PR implements validation checks to prevent users from navigating to the next screen when required fields are empty. This enhancement ensures that all necessary information is provided before proceeding, improving user experience and preventing incomplete submissions.

## Changes
- Added validation logic to disable button clicks for navigation with empty fields in `CreateProfileScreen` and `CreateAlertScreen`. Other screens remain unaffected.
- Implemented tests to verify that navigation is blocked when required fields are empty.

## Files 
#### Modified
- `AlertScreen.kt`: Integrates validation to prevent navigation on the "Ask for Help" button.
- `CreateProfile.kt`: Integrates validation to prevent navigation on the "Save" button.

## Dependencies Added
- Fixed navigation mock for testing.

## Testing
- Ran unit tests to confirm navigation blocking behavior.