### PR TITLE
Fix/navigation/top app bar UI tests

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/navigation/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/navigation/TopAppBarTest.kt
@@ -1,7 +1,6 @@
 package com.android.periodpals.ui.navigation
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -14,31 +13,58 @@ class TopAppBarTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun topAppBar_displaysTitle() {
+  fun onlyTitleIsDisplayed() {
     composeTestRule.setContent { TopAppBar(title = "Tampon Timer") }
 
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertDoesNotExist()
+    composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
   }
 
   @Test
-  fun topAppBar_displaysBackButton() {
-    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", backButton = true) }
+  fun backButtonIsDisplayed() {
+    composeTestRule.setContent {
+      TopAppBar(title = "Tampon Timer", backButton = true, onBackButtonClick = { /* Do nothing */})
+    }
 
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
   }
 
   @Test
-  fun topAppBar_displaysEditButton() {
-    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", editButton = true) }
+  fun editButtonIsDisplayed() {
+    composeTestRule.setContent {
+      TopAppBar(title = "Tampon Timer", editButton = true, onEditButtonClick = { /* Do nothing */})
+    }
 
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertDoesNotExist()
+  }
+
+  @Test
+  fun backAndEditButtonsAreDisplayed() {
+    composeTestRule.setContent {
+      TopAppBar(
+          title = "Tampon Timer",
+          backButton = true,
+          onBackButtonClick = { /* Do nothing */},
+          editButton = true,
+          onEditButtonClick = { /* Do nothing */})
+    }
+
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("screenTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
   }
 
   @Test
-  fun topAppBar_backButtonClick() {
+  fun backButtonClickWorks() {
     var backButtonClicked = false
 
     composeTestRule.setContent {
@@ -53,7 +79,7 @@ class TopAppBarTest {
   }
 
   @Test
-  fun topAppBar_editButtonClick() {
+  fun editButtonClickWorks() {
     var editButtonClicked = false
 
     composeTestRule.setContent {
@@ -68,34 +94,16 @@ class TopAppBarTest {
   }
 
   @Test
-  fun topAppBar_noBackButton() {
-    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", backButton = false) }
-
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertDoesNotExist()
-  }
-
-  @Test
-  fun topAppBar_noEditButton() {
-    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", editButton = false) }
-
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
-  }
-
-  @Test
-  fun topAppBar_backButtonTrue_onBackButtonClickNull_throwsException() {
+  fun backButtonInvalidFunction() {
     val exception =
         assertThrows(IllegalArgumentException::class.java) {
-          composeTestRule.setContent {
-            TopAppBar(title = "Test Title", backButton = true, onBackButtonClick = null)
-          }
+          composeTestRule.setContent { TopAppBar(title = "Test Title", backButton = true) }
         }
     assert(exception.message == "onBackButtonClick must be provided when backButton is true")
   }
 
   @Test
-  fun topAppBar_editButtonTrue_onEditButtonClickNull_throwsException() {
+  fun editButtonInvalidFunction() {
     val exception =
         assertThrows(IllegalArgumentException::class.java) {
           composeTestRule.setContent {
@@ -103,59 +111,5 @@ class TopAppBarTest {
           }
         }
     assert(exception.message == "onEditButtonClick must be provided when editButton is true")
-  }
-
-  @Test
-  fun topAppBar_backButtonTrue_onBackButtonClickNotNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", backButton = true, onBackButtonClick = { /* Do nothing */})
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
-  }
-
-  @Test
-  fun topAppBar_editButtonTrue_onEditButtonClickNotNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", editButton = true, onEditButtonClick = { /* Do nothing */})
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
-  }
-
-  @Test
-  fun topAppBar_backButtonFalse_onBackButtonClickNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", backButton = false, onBackButtonClick = null)
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
-  }
-
-  @Test
-  fun topAppBar_editButtonFalse_onEditButtonClickNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", editButton = false, onEditButtonClick = null)
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("editButton").assertIsNotDisplayed()
-  }
-
-  @Test
-  fun topAppBar_backButtonFalse_onBackButtonClickNotNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", backButton = false, onBackButtonClick = { /* Do nothing */})
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
-  }
-
-  @Test
-  fun topAppBar_editButtonFalse_onEditButtonClickNotNull_doesNotThrowException() {
-    composeTestRule.setContent {
-      TopAppBar(title = "Test Title", editButton = false, onEditButtonClick = { /* Do nothing */})
-    }
-    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("editButton").assertIsNotDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/navigation/TopAppBarTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/navigation/TopAppBarTest.kt
@@ -30,6 +30,14 @@ class TopAppBarTest {
   }
 
   @Test
+  fun topAppBar_displaysEditButton() {
+    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", editButton = true) }
+
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
+  }
+
+  @Test
   fun topAppBar_backButtonClick() {
     var backButtonClicked = false
 
@@ -45,11 +53,34 @@ class TopAppBarTest {
   }
 
   @Test
+  fun topAppBar_editButtonClick() {
+    var editButtonClicked = false
+
+    composeTestRule.setContent {
+      TopAppBar(
+          title = "Tampon Timer",
+          editButton = true,
+          onEditButtonClick = { editButtonClicked = true })
+    }
+
+    composeTestRule.onNodeWithTag("editButton").performClick()
+    assert(editButtonClicked)
+  }
+
+  @Test
   fun topAppBar_noBackButton() {
     composeTestRule.setContent { TopAppBar(title = "Tampon Timer", backButton = false) }
 
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertDoesNotExist()
+  }
+
+  @Test
+  fun topAppBar_noEditButton() {
+    composeTestRule.setContent { TopAppBar(title = "Tampon Timer", editButton = false) }
+
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertDoesNotExist()
   }
 
   @Test
@@ -64,12 +95,32 @@ class TopAppBarTest {
   }
 
   @Test
+  fun topAppBar_editButtonTrue_onEditButtonClickNull_throwsException() {
+    val exception =
+        assertThrows(IllegalArgumentException::class.java) {
+          composeTestRule.setContent {
+            TopAppBar(title = "Test Title", editButton = true, onEditButtonClick = null)
+          }
+        }
+    assert(exception.message == "onEditButtonClick must be provided when editButton is true")
+  }
+
+  @Test
   fun topAppBar_backButtonTrue_onBackButtonClickNotNull_doesNotThrowException() {
     composeTestRule.setContent {
       TopAppBar(title = "Test Title", backButton = true, onBackButtonClick = { /* Do nothing */})
     }
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun topAppBar_editButtonTrue_onEditButtonClickNotNull_doesNotThrowException() {
+    composeTestRule.setContent {
+      TopAppBar(title = "Test Title", editButton = true, onEditButtonClick = { /* Do nothing */})
+    }
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
   }
 
   @Test
@@ -82,11 +133,29 @@ class TopAppBarTest {
   }
 
   @Test
+  fun topAppBar_editButtonFalse_onEditButtonClickNull_doesNotThrowException() {
+    composeTestRule.setContent {
+      TopAppBar(title = "Test Title", editButton = false, onEditButtonClick = null)
+    }
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsNotDisplayed()
+  }
+
+  @Test
   fun topAppBar_backButtonFalse_onBackButtonClickNotNull_doesNotThrowException() {
     composeTestRule.setContent {
       TopAppBar(title = "Test Title", backButton = false, onBackButtonClick = { /* Do nothing */})
     }
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
+  }
+
+  @Test
+  fun topAppBar_editButtonFalse_onEditButtonClickNotNull_doesNotThrowException() {
+    composeTestRule.setContent {
+      TopAppBar(title = "Test Title", editButton = false, onEditButtonClick = { /* Do nothing */})
+    }
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsNotDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -10,6 +10,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.navigation.TopLevelDestination
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
@@ -17,7 +18,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
@@ -91,7 +94,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -111,7 +115,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -131,7 +136,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
@@ -148,7 +154,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action does not occur
-    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -147,7 +147,6 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
 
     // Verify that the navigation action occurs
-    composeTestRule.onNodeWithTag("createProfileScreen").assertDoesNotExist()
     verify(navigationActions).navigateTo(screen = Screen.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -6,9 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
@@ -84,7 +82,10 @@ class CreateProfileTest {
     // Leave email empty
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -96,9 +97,15 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenDobNotFilled() {
     // Leave date of birth empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -110,9 +117,15 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenNameNotFilled() {
     // Leave name empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
@@ -124,7 +137,10 @@ class CreateProfileTest {
   @Test
   fun saveButton_doesNotNavigate_whenDescriptionNotFilled() {
     // Leave description empty
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
 
@@ -138,10 +154,16 @@ class CreateProfileTest {
   @Test
   fun saveButton_navigates_whenAllFieldsAreFilled() {
     // Fill all fields
-    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule
+        .onNodeWithTag("email_field")
+        .assertIsDisplayed()
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
-    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+    composeTestRule
+        .onNodeWithTag("description_field")
+        .assertIsDisplayed()
+        .performTextInput("A short bio")
 
     // Click the save button
     composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.profile
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -7,30 +8,40 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 
 @RunWith(AndroidJUnit4::class)
 class CreateProfileTest {
-
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    composeTestRule.setContent { MaterialTheme { CreateProfileScreen(navigationActions) } }
+  }
 
   @Test
   fun testProfileImageDisplayed() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Check if the profile image is displayed
     composeTestRule.onNodeWithTag("profile_image").assertIsDisplayed()
   }
 
   @Test
   fun testFormFieldsDisplayed() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Check if the form fields are displayed
     composeTestRule.onNodeWithTag("email_field").assertIsDisplayed()
     composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed()
@@ -40,8 +51,6 @@ class CreateProfileTest {
 
   @Test
   fun testSaveButtonClickWithValidDate() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Input valid date
     composeTestRule.onNodeWithTag("dob_field").performTextInput("01/01/2000")
 
@@ -56,8 +65,6 @@ class CreateProfileTest {
 
   @Test
   fun testSaveButtonClickWithInvalidDate() {
-    composeTestRule.setContent { CreateProfileScreen(NavigationActions(rememberNavController())) }
-
     // Input invalid date
     composeTestRule.onNodeWithTag("dob_field").performTextInput("invalid_date")
 
@@ -70,5 +77,77 @@ class CreateProfileTest {
     assertFalse(validateDate("01/01/abcd")) // Invalid year
     assertFalse(validateDate("01-01-2000")) // Invalid format
     assertFalse(validateDate("01/01")) // Incomplete date
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenEmailNotFilled() {
+    // Leave email empty
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenDobNotFilled() {
+    // Leave date of birth empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenNameNotFilled() {
+    // Leave name empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_doesNotNavigate_whenDescriptionNotFilled() {
+    // Leave description empty
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action does not occur
+    composeTestRule.onNodeWithTag("createProfileScreen").assertIsDisplayed()
+  }
+
+  @Test
+  fun saveButton_navigates_whenAllFieldsAreFilled() {
+    // Fill all fields
+    composeTestRule.onNodeWithTag("email_field").assertIsDisplayed().performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag("dob_field").assertIsDisplayed().performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag("name_field").assertIsDisplayed().performTextInput("John Doe")
+    composeTestRule.onNodeWithTag("description_field").assertIsDisplayed().performTextInput("A short bio")
+
+    // Click the save button
+    composeTestRule.onNodeWithTag("save_button").assertIsDisplayed().performClick()
+
+    // Verify that the navigation action occurs
+    composeTestRule.onNodeWithTag("createProfileScreen").assertDoesNotExist()
+    verify(navigationActions).navigateTo(screen = Screen.PROFILE)
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -45,14 +46,26 @@ import com.android.periodpals.ui.theme.PurpleGrey80
  * - Use the testTag "topBar" to verify the app bar is displayed.
  * - If the back button is shown, check for the "goBackButton" tag to confirm its presence and
  *   functionality.
+ * - If the edit button is shown, check for the "editButton" tag to confirm its presence and
+ *   functionality.
  * - The title can be checked using the "screenTitle" testTag.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopAppBar(title: String, backButton: Boolean = false, onBackButtonClick: (() -> Unit)? = {}) {
+fun TopAppBar(
+    title: String,
+    backButton: Boolean = false,
+    editButton: Boolean = false,
+    onBackButtonClick: (() -> Unit)? = {},
+    onEditButtonClick: (() -> Unit)? = {}
+) {
   require(!backButton || onBackButtonClick != null) {
     "onBackButtonClick must be provided when backButton is true"
   }
+  require(!editButton || onEditButtonClick != null) {
+    "onEditButtonClick must be provided when editButton is true"
+  }
+
   CenterAlignedTopAppBar(
       modifier = Modifier.fillMaxWidth().height(48.dp).testTag("topBar"),
       title = {
@@ -69,7 +82,17 @@ fun TopAppBar(title: String, backButton: Boolean = false, onBackButtonClick: (()
                 contentDescription = "Back",
                 modifier = Modifier.size(20.dp))
           }
-        } else null
+        }
+      },
+      actions = {
+        if (editButton) {
+          IconButton(onClick = onEditButtonClick!!, modifier = Modifier.testTag("editButton")) {
+            Icon(
+                imageVector = Icons.Outlined.Edit,
+                contentDescription = "Edit",
+                modifier = Modifier.size(20.dp))
+          }
+        }
       },
       colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = PurpleGrey80))
 }

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -25,7 +25,9 @@ import com.android.periodpals.ui.theme.PurpleGrey80
  *
  * @param title The title text to be displayed in the app bar.
  * @param backButton Whether to show a back button. Default is false.
- * @param onBackButtonClick Called when the back button is clicked.
+ * @param editButton Whether to show an edit button. Default is false.
+ * @param onBackButtonClick Called when the back button is clicked. Default is null.
+ * @param onEditButtonClick Called when the edit button is clicked. Default is null.
  *
  * ### Usage:
  * The top app bar can be displayed with a title:
@@ -55,14 +57,14 @@ import com.android.periodpals.ui.theme.PurpleGrey80
 fun TopAppBar(
     title: String,
     backButton: Boolean = false,
+    onBackButtonClick: (() -> Unit)? = null,
     editButton: Boolean = false,
-    onBackButtonClick: (() -> Unit)? = {},
-    onEditButtonClick: (() -> Unit)? = {}
+    onEditButtonClick: (() -> Unit)? = null
 ) {
-  require(!backButton || onBackButtonClick != null) {
+  require(!(backButton && onBackButtonClick == null)) {
     "onBackButtonClick must be provided when backButton is true"
   }
-  require(!editButton || onEditButtonClick != null) {
+  require(!(editButton && onEditButtonClick == null)) {
     "onEditButtonClick must be provided when editButton is true"
   }
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -162,7 +162,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
 
           Button(
               onClick = {
-                if (validateDate(age)) {
+                if (validateName(name) && validateDate(age) && validateDescription(description)) {
                   // Save the profile (future implementation)
                   Toast.makeText(context, "Profile saved", Toast.LENGTH_SHORT).show()
                   navigationActions.navigateTo(Screen.PROFILE)
@@ -187,18 +187,28 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
   )
 }
 
+/** Validates the name is not empty. */
+private fun validateName(name: String): Boolean {
+  return name.isNotEmpty()
+}
+
+/** Validates the date is in the format DD/MM/YYYY and is a valid date. */
 fun validateDate(date: String): Boolean {
   val parts = date.split("/")
-  val calendar = GregorianCalendar.getInstance()
+  val calendar = GregorianCalendar()
   calendar.isLenient = false
   if (parts.size == 3) {
     return try {
-      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
-      calendar.time
+      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt(), 0, 0, 0)
       true
     } catch (e: Exception) {
       false
     }
   }
   return false
+}
+
+/** Validates the description is not empty. */
+private fun validateDescription(description: String): Boolean {
+  return description.isNotEmpty()
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -71,7 +71,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
           }
 
   Scaffold(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier.fillMaxSize().testTag("createProfileScreen"),
       content = { padding ->
         Column(
             modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
@@ -195,11 +195,12 @@ private fun validateName(name: String): Boolean {
 /** Validates the date is in the format DD/MM/YYYY and is a valid date. */
 fun validateDate(date: String): Boolean {
   val parts = date.split("/")
-  val calendar = GregorianCalendar()
+  val calendar = GregorianCalendar.getInstance()
   calendar.isLenient = false
   if (parts.size == 3) {
     return try {
-      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt(), 0, 0, 0)
+      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
+      calendar.time
       true
     } catch (e: Exception) {
       false

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -162,12 +162,13 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
 
           Button(
               onClick = {
-                if (validateName(name) && validateDate(age) && validateDescription(description)) {
+                val errorMessage = validateFields(email, name, age, description)
+                if (errorMessage != null) {
+                  Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                } else {
                   // Save the profile (future implementation)
                   Toast.makeText(context, "Profile saved", Toast.LENGTH_SHORT).show()
                   navigationActions.navigateTo(Screen.PROFILE)
-                } else {
-                  Toast.makeText(context, "Invalid date", Toast.LENGTH_SHORT).show()
                 }
               },
               enabled = true,
@@ -185,6 +186,27 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
         }
       },
   )
+}
+
+/** Validates the fields of the profile screen. */
+private fun validateFields(
+    email: String,
+    name: String,
+    date: String,
+    description: String
+): String? {
+  return when {
+    !validateEmail(email) -> "Please enter an email"
+    !validateName(name) -> "Please enter a name"
+    !validateDate(date) -> "Invalid date"
+    !validateDescription(description) -> "Please enter a description"
+    else -> null
+  }
+}
+
+/** Validates the email is not empty. */
+private fun validateEmail(email: String): Boolean {
+  return email.isNotEmpty()
 }
 
 /** Validates the name is not empty. */


### PR DESCRIPTION
# Fix UI tests for M1: TopAppBar

## Description
This PR closes issue #90. It completes all features of the `TopAppBar` by adding an edit button! 
As for the back button, this feature is conditional, and can be set up by passing as argument `editButton = True` to the `TopAppBar()` composable, along with the a function of the desired navigation action when this button is clicked (passed as the `onEditButtonClick` argument). 

I must remark that no further tests were added, the tests for pre-existing features of the top bar were already very extensive and complete. Navigation should not be tested in `TopAppBarTest`. 

## Changes

## Files 

#### Added
none
#### Modified
- `TopAppBar.kt`: created arguments `editButton` (boolean, to indicate if this button should exist for the respective screen that calls the function) and `onEditButtonClick` (nullable lambda function, where the navigation action upon click should be specified)

#### Removed
none

## Testing
- `TopAppBarTest.kt`: added tests for `editButton` feature by ensuring its presence when argument respective argument is true, that upon click the `onEditButtonClick` function is called, that exception is thrown if no such function is provided in this case, and other edge cases...

## Screenshots
<img width="334" alt="Screenshot 2024-10-29 at 22 18 53" src="https://github.com/user-attachments/assets/cf3403e7-5780-436b-b55d-34e86aaae758">
