### PR TITLE
fix/authentication/signup-ui-tests : Fix UI tests for M1: SignUp

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.model.auth.AuthViewModel
 import com.android.periodpals.model.user.UserAuthState
 import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
@@ -46,9 +45,9 @@ class SignUpScreenTest {
     navigationActions = mock(NavigationActions::class.java)
     authViewModel = mock(AuthViewModel::class.java)
 
-    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.SIGN_UP)
     `when`(authViewModel.userAuthState)
-        .thenReturn(mutableStateOf(UserAuthState.Success("User is logged up")))
+        .thenReturn(mutableStateOf(UserAuthState.Success("User is signed up")))
     composeTestRule.setContent { SignUpScreen(authViewModel, navigationActions) }
   }
 
@@ -62,7 +61,6 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpEmail").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpPassword").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpPasswordVisibility").assertIsDisplayed()
-
     composeTestRule.onNodeWithTag("signUpConfirmText").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpConfirmPassword").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpConfirmVisibility").assertIsDisplayed()
@@ -73,6 +71,7 @@ class SignUpScreenTest {
   fun emptyEmailShowsCorrectError() {
 
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
     composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email cannot be empty")
@@ -82,9 +81,8 @@ class SignUpScreenTest {
   fun emptyEmailDoesNotCallVM() {
 
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email cannot be empty")
     verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
@@ -93,6 +91,7 @@ class SignUpScreenTest {
 
     composeTestRule.onNodeWithTag("signUpEmail").performTextInput(invalidEmail)
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
     composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email must contain @")
@@ -103,10 +102,9 @@ class SignUpScreenTest {
 
     composeTestRule.onNodeWithTag("signUpEmail").performTextInput(invalidEmail)
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email must contain @")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(invalidEmail), eq(password))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -125,11 +123,45 @@ class SignUpScreenTest {
 
     composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password cannot be empty")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
+  }
+
+  @Test
+  fun emptyConfirmedPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
+  }
+
+  @Test
+  fun emptyConfirmedPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
+  }
+
+  @Test
+  fun emptyPasswordOnlyShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
+  }
+
+  @Test
+  fun emptyPasswordOnlyDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -139,6 +171,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(tooShort)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(tooShort)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("signUpPasswordError")
         .assertTextEquals("Password must be at least 8 characters long")
@@ -151,10 +184,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(tooShort)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(tooShort)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password must be at least 8 characters long")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(tooShort))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -164,6 +194,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noCapital)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noCapital)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("signUpPasswordError")
         .assertTextEquals("Password must contain at least one capital letter")
@@ -176,10 +207,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noCapital)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noCapital)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password must contain at least one capital letter")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noCapital))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -189,6 +217,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("signUpPasswordError")
         .assertTextEquals("Password must contain at least one lower case letter")
@@ -201,10 +230,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password must contain at least one lower case letter")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noMinuscule))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -214,6 +240,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noNumber)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noNumber)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("signUpPasswordError")
         .assertTextEquals("Password must contain at least one number")
@@ -226,10 +253,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noNumber)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noNumber)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password must contain at least one number")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noNumber))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -238,6 +262,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noSpecial)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noSpecial)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
     composeTestRule
         .onNodeWithTag("signUpPasswordError")
         .assertTextEquals("Password must contain at least one special character")
@@ -249,10 +274,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noSpecial)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noSpecial)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule
-        .onNodeWithTag("signUpPasswordError")
-        .assertTextEquals("Password must contain at least one special character")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noSpecial))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -262,6 +284,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(doNotMatch1)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(doNotMatch2)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").assertIsDisplayed()
     composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
   }
 
@@ -272,9 +295,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpPassword").performTextInput(doNotMatch1)
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(doNotMatch2)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
-    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(doNotMatch1))
-    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(doNotMatch2))
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
   }
 
   @Test
@@ -285,8 +306,6 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
     verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
-
-    // TODO: Supabase integration for account creation
   }
 
   @Test
@@ -297,7 +316,5 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
     composeTestRule.onNodeWithTag("signUpButton").performClick()
     verify(authViewModel).signUpWithEmail(any(), eq(email), eq(password))
-
-    // TODO: Supabase integration for account creation
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -1,172 +1,303 @@
-// package com.android.periodpals.ui.authentication
-//
-// import androidx.compose.ui.test.assertIsDisplayed
-// import androidx.compose.ui.test.assertTextEquals
-// import androidx.compose.ui.test.junit4.createComposeRule
-// import androidx.compose.ui.test.onNodeWithTag
-// import androidx.compose.ui.test.performClick
-// import androidx.compose.ui.test.performTextInput
-// import androidx.navigation.compose.rememberNavController
-// import com.android.periodpals.ui.navigation.NavigationActions
-// import org.junit.Rule
-// import org.junit.Test
-//
-// class SignUpScreenTest {
-//
-//  @get:Rule val composeTestRule = createComposeRule()
-//
-//  @Test
-//  fun signUpScreen_displaysCorrectUI() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Assert visibility of UI elements
-//    composeTestRule.onNodeWithTag("signUpScreen").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpBackground").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpTitle").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpInstruction").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpEmail").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpPassword").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpPasswordVisibility").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpConfirmText").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpConfirmVisibility").assertIsDisplayed()
-//    composeTestRule.onNodeWithTag("signUpButton").assertIsDisplayed()
-//  }
-//
-//  @Test
-//  fun signUpScreen_emailValidation_emptyEmail_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Attempt to sign up with an empty email
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    // Assert the error message is displayed
-//    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email cannot be empty")
-//  }
-//
-//  @Test
-//  fun signUpScreen_emailValidation_invalidEmail_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Input an invalid email
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("invalidEmail")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    // Assert the error message is displayed
-//    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email must contain @")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_emptyPassword_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Input an email and attempt to sign up with an empty password
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    // Assert the error message is displayed
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password cannot be empty")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordTooShort_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("short")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("short")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password must be at least 8 characters long")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordNoCapital_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("password")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("password")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password must contain at least one capital letter")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordNoMinuscule_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("PASSWORD")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("PASSWORD")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password must contain at least one lower case letter")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordNoNumber_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("Password")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("Password")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password must contain at least one number")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordNoSpecial_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("Passw0rd")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("Passw0rd")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    composeTestRule
-//        .onNodeWithTag("signUpPasswordError")
-//        .assertTextEquals("Password must contain at least one special character")
-//  }
-//
-//  @Test
-//  fun signUpScreen_passwordValidation_passwordsDoNotMatch_showsError() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Input an email and mismatched passwords
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("Password123")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("Password456")
-//    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    // Assert the error message is displayed
-//    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
-//  }
-//
-//  @Test
-//  fun signUpScreen_signUp_successfulRegistration() {
-//    composeTestRule.setContent { SignUpScreen(NavigationActions(rememberNavController())) }
-//
-//    // Input valid data and perform sign up
-//    composeTestRule.onNodeWithTag("signUpEmail").performTextInput("test@example.com")
-//    composeTestRule.onNodeWithTag("signUpPassword").performTextInput("ValidPassword123!")
-//    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput("ValidPassword123!")
-//    // Cannot test navigation actions currently
-//    //    composeTestRule.onNodeWithTag("signUpButton").performClick()
-//
-//    // You can assert here for a visual change or a Toast message if possible
-//    // Since Toast can't be tested directly, consider an alternative for future testing
-//    // TODO: Supabase integration for account creation
-//  }
-// }
+package com.android.periodpals.ui.authentication
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import com.android.periodpals.model.auth.AuthViewModel
+import com.android.periodpals.model.user.UserAuthState
+import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class SignUpScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var authViewModel: AuthViewModel
+
+  companion object {
+    private const val email = "test@example.com"
+    private const val invalidEmail = "invalidEmail"
+    private const val password = "Passw0rd*"
+    private const val tooShort = "short"
+    private const val noCapital = "password"
+    private const val noMinuscule = "PASSWORD"
+    private const val noNumber = "Password"
+    private const val noSpecial = "Passw0rd"
+    private const val doNotMatch1 = "Password1*"
+    private const val doNotMatch2 = "Password2*"
+  }
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+    authViewModel = mock(AuthViewModel::class.java)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
+    `when`(authViewModel.userAuthState)
+        .thenReturn(mutableStateOf(UserAuthState.Success("User is logged up")))
+    composeTestRule.setContent { SignUpScreen(authViewModel, navigationActions) }
+  }
+
+  @Test
+  fun allComponentsAreDisplayed() {
+
+    composeTestRule.onNodeWithTag("signUpScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpBackground").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpTitle").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpInstruction").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpEmail").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpPassword").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpPasswordVisibility").assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag("signUpConfirmText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpConfirmVisibility").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpButton").assertIsDisplayed()
+  }
+
+  @Test
+  fun emptyEmailShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email cannot be empty")
+  }
+
+  @Test
+  fun emptyEmailDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email cannot be empty")
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any())
+  }
+
+  @Test
+  fun invalidEmailShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(invalidEmail)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email must contain @")
+  }
+
+  @Test
+  fun invalidEmailDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(invalidEmail)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("signUpEmailError").assertTextEquals("Email must contain @")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(invalidEmail), eq(password))
+  }
+
+  @Test
+  fun emptyPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password cannot be empty")
+  }
+
+  @Test
+  fun emptyPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpPasswordError").assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password cannot be empty")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), any())
+  }
+
+  @Test
+  fun tooShortPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(tooShort)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(tooShort)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must be at least 8 characters long")
+  }
+
+  @Test
+  fun tooShortPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(tooShort)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(tooShort)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must be at least 8 characters long")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(tooShort))
+  }
+
+  @Test
+  fun noCapitalPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noCapital)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noCapital)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one capital letter")
+  }
+
+  @Test
+  fun noCapitalPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noCapital)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noCapital)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one capital letter")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noCapital))
+  }
+
+  @Test
+  fun noMinusculePasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noMinuscule)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noMinuscule)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one lower case letter")
+  }
+
+  @Test
+  fun noMinusculePasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noMinuscule)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noMinuscule)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one lower case letter")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noMinuscule))
+  }
+
+  @Test
+  fun noNumberPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noNumber)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noNumber)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one number")
+  }
+
+  @Test
+  fun noNumberPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noNumber)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noNumber)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one number")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noNumber))
+  }
+
+  @Test
+  fun noSpecialPasswordShowsCorrectError() {
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one special character")
+  }
+
+  @Test
+  fun noSpecialPasswordDoesNotCallVM() {
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule
+        .onNodeWithTag("signUpPasswordError")
+        .assertTextEquals("Password must contain at least one special character")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(noSpecial))
+  }
+
+  @Test
+  fun doNotMatchPasswordShowsCorrectError() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(doNotMatch1)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(doNotMatch2)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
+  }
+
+  @Test
+  fun doNotMatchPasswordDoesNotCallVM() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(doNotMatch1)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(doNotMatch2)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    composeTestRule.onNodeWithTag("signUpConfirmError").assertTextEquals("Passwords do not match")
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(doNotMatch1))
+    verify(authViewModel, never()).signUpWithEmail(any(), eq(email), eq(doNotMatch2))
+  }
+
+  @Test
+  fun validSignUpAttemptNavigatesToCreateProfileScreen() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
+
+    // TODO: Supabase integration for account creation
+  }
+
+  @Test
+  fun validSignUpAttemptCallsVMLogInWithEmail() {
+
+    composeTestRule.onNodeWithTag("signUpEmail").performTextInput(email)
+    composeTestRule.onNodeWithTag("signUpPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpConfirmPassword").performTextInput(password)
+    composeTestRule.onNodeWithTag("signUpButton").performClick()
+    verify(authViewModel).signUpWithEmail(any(), eq(email), eq(password))
+
+    // TODO: Supabase integration for account creation
+  }
+}


### PR DESCRIPTION
# Fix UI tests for M1: SignUp

## Description
This PR introduces UI tests for the SignUpScreen component in the authentication module. It validates various user input scenarios to ensure proper error handling and navigation flow. It closes issue #76.

## Changes
I added more tests, including tests for the calls to the ViewModel. Now the navigation tests also work.

## Files 

#### Modified
- `SignUpScreenTest.kt`
