### PR TITLE
Fix/profile/profile UI tests: Fix and complete tests for ProfileScreen 

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -1,31 +1,48 @@
 package com.android.periodpals.ui.profile
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.navigation.compose.rememberNavController
+import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class ProfileScreenTest {
 
+  private lateinit var navigationActions: NavigationActions
   @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+
+    composeTestRule.setContent { AlertScreen(navigationActions) }
+  }
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent { ProfileScreen(NavigationActions(rememberNavController())) }
+    composeTestRule.setContent { ProfileScreen(navigationActions) }
     composeTestRule.onNodeWithTag("profileAvatar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileName").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Description").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("reviewOne").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("reviewTwo").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("noReviewsCardText").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
   }
 
   @Test
   fun profileScreen_hasCorrectContent() {
-    composeTestRule.setContent { ProfileScreen(NavigationActions(rememberNavController())) }
+    composeTestRule.setContent { ProfileScreen(navigationActions) }
     composeTestRule.onNodeWithTag("profileName").assertTextEquals("Name")
     composeTestRule.onNodeWithTag("Description").assertTextEquals("Description")
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import com.android.periodpals.ui.alert.AlertScreen
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import org.junit.Before
@@ -23,14 +22,13 @@ class ProfileScreenTest {
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
 
-    `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    `when`(navigationActions.currentRoute()).thenReturn(Route.PROFILE)
 
-    composeTestRule.setContent { AlertScreen(navigationActions) }
+    composeTestRule.setContent { ProfileScreen(navigationActions) }
   }
 
   @Test
   fun displayAllComponents() {
-    composeTestRule.setContent { ProfileScreen(navigationActions) }
     composeTestRule.onNodeWithTag("profileAvatar").assertIsDisplayed()
     composeTestRule.onNodeWithTag("profileName").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Description").assertIsDisplayed()
@@ -42,7 +40,6 @@ class ProfileScreenTest {
 
   @Test
   fun profileScreen_hasCorrectContent() {
-    composeTestRule.setContent { ProfileScreen(navigationActions) }
     composeTestRule.onNodeWithTag("profileName").assertTextEquals("Name")
     composeTestRule.onNodeWithTag("Description").assertTextEquals("Description")
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -1,16 +1,18 @@
 package com.android.periodpals.ui.profile
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
+import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
 class ProfileScreenTest {
@@ -35,11 +37,17 @@ class ProfileScreenTest {
     composeTestRule.onNodeWithTag("noReviewsCardText").assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
     composeTestRule.onNodeWithTag("topBar").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("goBackButton").assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag("editButton").assertIsDisplayed()
   }
 
   @Test
-  fun profileScreen_hasCorrectContent() {
+  fun editButtonNavigatesToEditProfileScreen() {
+    composeTestRule.onNodeWithTag("editButton").performClick()
+    verify(navigationActions).navigateTo(Screen.EDIT_PROFILE)
+  }
+
+  @Test
+  fun profileScreenHasCorrectContent() {
     composeTestRule.onNodeWithTag("profileName").assertTextEquals("Name")
     composeTestRule.onNodeWithTag("Description").assertTextEquals("Description")
   }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -4,16 +4,25 @@ package com.android.periodpals.ui.profile
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -51,7 +60,10 @@ fun ProfileScreen(navigationActions: NavigationActions) {
         Uri.parse("android.resource://com.android.periodpals/${R.drawable.generic_avatar}"))
   }
 
-  Scaffold(
+  // Number of interactions placeholder
+  val numberInteractions = 0
+
+    Scaffold(
       modifier = Modifier.fillMaxSize().testTag("profileScreen"),
       bottomBar = {
         BottomNavigationMenu(
@@ -73,7 +85,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
           // Display the user's profile image.
           GlideImage(
               model = profileImageUri,
-              contentDescription = "Avatar Imagee",
+              contentDescription = "Avatar Image",
               contentScale = ContentScale.Crop,
               modifier =
                   Modifier.size(190.dp)
@@ -83,7 +95,12 @@ fun ProfileScreen(navigationActions: NavigationActions) {
           )
 
           ProfileName() // Display the user's profile name.
-          ProfileDetails() // Display additional details like description and reviews.
+
+            if(numberInteractions > 0){
+                ProfileDetails("Number of interactions: $numberInteractions")
+            }else{
+                ProfileDetails("New user")
+            }
         }
       },
   )
@@ -100,24 +117,48 @@ private fun ProfileName() {
 }
 
 @Composable
-private fun ProfileDetails() {
-  Column(
+private fun ProfileDetails(text: String) {
+    Column(
       modifier = Modifier.fillMaxWidth(),
       verticalArrangement = Arrangement.spacedBy(8.dp), // Space items by 8dp vertically.
   ) {
+    // Placeholder for the user's description.
+    val description = ""
+
     // Box for the description.
     Text(
         text = "Description",
         fontSize = 20.sp,
         modifier = Modifier.padding(vertical = 8.dp).testTag("Description"),
     )
-    ProfileInfoBox(text = "", minHeight = 100.dp, Modifier)
-    Text(text = "New user / Number of interactions", fontSize = 16.sp, color = Color(101, 116, 193))
+    ProfileInfoBox(text = description, minHeight = 100.dp, Modifier)
+    Text(text = text, fontSize = 16.sp, color = Color(101, 116, 193))
     Text(text = "Reviews", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp))
-    // Boxes for reviews.
-    ProfileInfoBox(text = "", minHeight = 20.dp, Modifier.testTag("reviewOne"))
-    ProfileInfoBox(text = "", minHeight = 20.dp, Modifier.testTag("reviewTwo"))
   }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // No reviews yet
+        Card(
+            elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+            modifier = Modifier.testTag("noAlertsCard")
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.padding(7.dp)) {
+                Icon(
+                    imageVector = Icons.Outlined.SentimentVeryDissatisfied,
+                    contentDescription = "NoReviews",
+                    modifier = Modifier.testTag("noReviewsIcon"))
+
+                Text(
+                    text = "No reviews yet...",
+                    modifier = Modifier.testTag("noReviewsCardText"))
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -146,8 +146,7 @@ private fun ProfileDetails(text: String) {
                 Icon(
                     imageVector = Icons.Outlined.SentimentVeryDissatisfied,
                     contentDescription = "NoReviews",
-                    modifier = Modifier.testTag("noReviewsIcon"))
-
+                    )
                 Text(text = "No reviews yet...", modifier = Modifier.testTag("noReviewsCardText"))
               }
         }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -41,6 +41,7 @@ import com.android.periodpals.R
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
@@ -68,6 +69,8 @@ fun ProfileScreen(navigationActions: NavigationActions) {
       topBar = {
         TopAppBar(
             title = "Profile",
+            editButton = true,
+            onEditButtonClick = { navigationActions.navigateTo(Screen.EDIT_PROFILE) },
         )
       },
       content = { padding ->

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -4,22 +4,18 @@ package com.android.periodpals.ui.profile
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
-import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -63,7 +59,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
   // Number of interactions placeholder
   val numberInteractions = 0
 
-    Scaffold(
+  Scaffold(
       modifier = Modifier.fillMaxSize().testTag("profileScreen"),
       bottomBar = {
         BottomNavigationMenu(
@@ -96,11 +92,11 @@ fun ProfileScreen(navigationActions: NavigationActions) {
 
           ProfileName() // Display the user's profile name.
 
-            if(numberInteractions > 0){
-                ProfileDetails("Number of interactions: $numberInteractions")
-            }else{
-                ProfileDetails("New user")
-            }
+          if (numberInteractions > 0) {
+            ProfileDetails("Number of interactions: $numberInteractions")
+          } else {
+            ProfileDetails("New user")
+          }
         }
       },
   )
@@ -118,7 +114,7 @@ private fun ProfileName() {
 
 @Composable
 private fun ProfileDetails(text: String) {
-    Column(
+  Column(
       modifier = Modifier.fillMaxWidth(),
       verticalArrangement = Arrangement.spacedBy(8.dp), // Space items by 8dp vertically.
   ) {
@@ -135,30 +131,27 @@ private fun ProfileDetails(text: String) {
     Text(text = text, fontSize = 16.sp, color = Color(101, 116, 193))
     Text(text = "Reviews", fontSize = 20.sp, modifier = Modifier.padding(vertical = 8.dp))
   }
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        // No reviews yet
-        Card(
-            elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
-            modifier = Modifier.testTag("noAlertsCard")
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-                modifier = Modifier.padding(7.dp)) {
+  Column(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    // No reviews yet
+    Card(
+        elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+        modifier = Modifier.testTag("noAlertsCard")) {
+          Column(
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(10.dp),
+              modifier = Modifier.padding(7.dp)) {
                 Icon(
                     imageVector = Icons.Outlined.SentimentVeryDissatisfied,
                     contentDescription = "NoReviews",
                     modifier = Modifier.testTag("noReviewsIcon"))
 
-                Text(
-                    text = "No reviews yet...",
-                    modifier = Modifier.testTag("noReviewsCardText"))
-            }
+                Text(text = "No reviews yet...", modifier = Modifier.testTag("noReviewsCardText"))
+              }
         }
-    }
+  }
 }
 
 @Composable

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -1,6 +1,5 @@
 package com.android.periodpals.ui.profile
 
-// import androidx.compose.ui.tooling.preview.Preview
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -47,7 +46,6 @@ import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 
 @OptIn(ExperimentalGlideComposeApi::class)
-// @Preview
 @Composable
 fun ProfileScreen(navigationActions: NavigationActions) {
   // Declare and remember the profile image URI
@@ -146,7 +144,7 @@ private fun ProfileDetails(text: String) {
                 Icon(
                     imageVector = Icons.Outlined.SentimentVeryDissatisfied,
                     contentDescription = "NoReviews",
-                    )
+                )
                 Text(text = "No reviews yet...", modifier = Modifier.testTag("noReviewsCardText"))
               }
         }


### PR DESCRIPTION
# Fix and complete tests for ProfileScreen 

## Description
This PR closes issue #83. It completes the `ProfileScreen` by adding the edit button (on the top bar) that navigates to `EditProfileScreen`.  Tests were also modified to test all functionalities of this screen (mostly the correct displays of component) and added a test for the navigation of the edit button. 

## Changes
## Files 
#### Added
- none
#### Modified
- `ProfileScreen`:  modified UI by adding a card when there are no reviews for the profile (matching the Figma) and 
- `ProfileScreenTest`: used proper navigation mock for the tests using `Mockito`, tests all components in the screen

#### Removed
- none

## Tests
- `ProfileScreenTest`: added a test to ensure that the edit button navigates to `EditProfileScreen` when clicked 

## Dependencies Added
- none

## Screenshots 
<img width="440" alt="Screenshot 2024-10-30 at 15 46 30" src="https://github.com/user-attachments/assets/b3e7709d-05e2-4070-b7e3-6bc3ccbea58a">
