### PR TITLE
fix/style/layout-orientation : Make layout responsive to all screen orientations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.PeriodPals"
-            android:screenOrientation="portrait">>
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
             android:name="com.android.periodpals.MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.PeriodPals">
+            android:theme="@style/Theme.PeriodPals"
+            android:screenOrientation="portrait">>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
# Make layout responsive to all screen orientations

## Description
This PR introduces a restriction on the orientation of `MainActivity`, ensuring it can only be displayed in portrait mode. This change enhances user experience by preventing unexpected landscape orientation. It closes issue #75 .

## Changes
- Added `android:screenOrientation="portrait"` to `MainActivity` in  `AndroidManifest.xml`.

## Files 

#### Modified
- `AndroidManifest.xml`

## Testing
Tested the application on multiple devices to confirm that `MainActivity` remains in portrait mode and does not switch to landscape.
