### PR TITLE
ci: setup branch that build

### DIFF
--- a/.github/workflows/AndroidBuild.yml
+++ b/.github/workflows/AndroidBuild.yml
@@ -1,10 +1,9 @@
 name: AndroidBuild
 
 on:
-  pull_request:
-    branches: [ main ]
   push:
-    branches: [ main ]
+    branches:
+      - 'build/**'
 
 jobs:
   build:


### PR DESCRIPTION
# CI: Setup branch that build

## Description
This PR introduces an updated workflow that will generate an android build for every push for any branch with the prefix `build/**`, allowing for a cleaner repo for the project.

## Changes
Modified the yml file to only run if

## Files 
- `.github/workflow/AndroidBuild.yml`

#### Modified
- `.github/workflow/AndroidBuild.yml`
