### PR TITLE
Misc/sonarcloud-setup: fix sonarCloud report 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --parallel --build-cache
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - 'setup/**'
       - 'feat/**'
+      - 'release/**'
 
   pull_request:
     types:
@@ -97,13 +98,13 @@ jobs:
           ./gradlew assemble lint --parallel --build-cache
 
       # Run Unit tests
-      - name: Run tests
+      - name: Run unit tests
         run: |
           # To run the CI with debug information, add --info
           ./gradlew check --parallel --build-cache
 
       # Run connected tests on the emulator
-      - name: run tests
+      - name: Run connected tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
@@ -121,9 +122,9 @@ jobs:
           ./gradlew jacocoTestReport
 
       # Upload the various reports to sonar
-      - name: Upload report to SonarCloud
+      - name: SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar --parallel --build-cache
+        run: ./gradlew build sonar --parallel --build-cache --info
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,8 +112,8 @@ android {
 
 sonar {
   properties {
-    property("sonar.projectKey", "periodpals_periodpals")
-    property("sonar.organization", "periodpals")
+    property("sonar.projectKey", "PeriodPals_periodpals")
+    property("sonar.organization", "periodpals-1")
     property("sonar.host.url", "https://sonarcloud.io")
     // Comma-separated paths to the various directories containing the *.xml JUnit report files.
     // Each path may be absolute or relative to the project base directory.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,0 @@
-sonar.organization=periodpals
-sonar.projectKey=periodpals_periodpals
-sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
# Fix sonarCloud coverag report 

## Description
This PR attempts to fix the bug on sonar cloud that makes all PRs coverage 0%.

## Changes
We have created a new organization on SonarCloud and have updated the `build.gradle.kts` (app) and CI workflow accordingly, as well as the GitHub secrets.

## Files 
#### Modified
- `.github/workflows/ci.yml`: removed sonarcloud scan
- `app/build.gradle.kts`: updated keys

#### Removed
- `sonar-project.properties`: this file was useless since properties were already properly defined in `build.gradle.kts`

