### PR TITLE
fix: add sleep in `isUserLoggedIn()`

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -87,6 +87,7 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
 
   /** Checks if a user is logged in. */
   fun isUserLoggedIn() {
+    Thread.sleep(1500)
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
           onSuccess = {


### PR DESCRIPTION
# Fix Authentication Requiring Double Click to Sign-In and Sign-Up

## Description
This PR addresses the issue of requiring a double click to sign in or sign up by adding a 1.5-second delay to the `isUserLoggedIn` method in `AuthenticationViewModel`. This change improves timing control and prevents immediate state checks that could lead to user interface issues. Closes issue #...

## Changes
- Introduced `Thread.sleep(1500)` in the `isUserLoggedIn` method.

## Files Modified
- `app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt`

## Testing
- To be done in #48.