### PR TITLE
Fix/profile/create profile UI tests: Fix UI tests fro CreateProfile

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -63,7 +63,6 @@ class CreateProfileTest {
 
   @Test
   fun testValidDateRecognition() {
-    // Input valid date
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     assertTrue(validateDate("01/01/2000"))
     assertTrue(validateDate("31/12/1999"))
@@ -71,9 +70,7 @@ class CreateProfileTest {
 
   @Test
   fun testInvalidDateRecognition() {
-    // Input invalid date
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("invalid_date")
-    assertFalse(validateDate("DD/MM/YYYY")) // Field not filled
     assertFalse(validateDate("32/01/2000")) // Invalid day
     assertFalse(validateDate("01/13/2000")) // Invalid month
     assertFalse(validateDate("01/01/abcd")) // Invalid year
@@ -83,24 +80,19 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoEmail() {
-    // Leave email empty
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
-
-    // Click the save button
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
-    // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun createInvalidProfileNoDob() {
-    // Leave date of birth empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
         .performTextInput("john.doe@example.com")
@@ -108,18 +100,14 @@ class CreateProfileTest {
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
-
-    // Click the save button
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
-    // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun createInvalidProfileNoName() {
-    // Leave name empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
         .performTextInput("john.doe@example.com")
@@ -127,35 +115,27 @@ class CreateProfileTest {
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
-
-    // Click the save button
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
-    // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun createInvalidProfileNoDescription() {
-    // Leave description empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
         .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
-
-    // Click the save button
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
-    // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun createValidProfile() {
-    // Fill all fields
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
         .performTextInput("john.doe@example.com")
@@ -164,11 +144,8 @@ class CreateProfileTest {
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
-
-    // Click the save button
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
-    // Verify that the navigation action occurs
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.CreateProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -41,8 +42,10 @@ class CreateProfileTest {
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.PROFILE_PICTURE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.MANDATORY_TEXT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.PROFILE_TEXT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
@@ -53,6 +56,9 @@ class CreateProfileTest {
         .assertTextEquals("Create Your Account")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule
+        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
+        .assertIsNotDisplayed()
   }
 
   @Test
@@ -76,26 +82,16 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonDoesNotNavigateWithEmptyEmail() {
+  fun createInvalidProfileNoEmail() {
     // Leave email empty
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DOB_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("01/01/2000")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.NAME_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .assertIsDisplayed()
         .performTextInput("A short bio")
 
     // Click the save button
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.SAVE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
@@ -103,26 +99,18 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonDoesNotNavigateWithEmptyDoB() {
+  fun createInvalidProfileNoDob() {
     // Leave date of birth empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .assertIsDisplayed()
         .performTextInput("john.doe@example.com")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.NAME_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .assertIsDisplayed()
         .performTextInput("A short bio")
 
     // Click the save button
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.SAVE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
@@ -130,26 +118,18 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonDoesNotNavigateWithEmptyName() {
+  fun createInvalidProfileNoName() {
     // Leave name empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .assertIsDisplayed()
         .performTextInput("john.doe@example.com")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DOB_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .assertIsDisplayed()
         .performTextInput("A short bio")
 
     // Click the save button
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.SAVE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
@@ -157,26 +137,16 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonDoesNotNavigateWithEmptyDescription() {
+  fun createInvalidProfileNoDescription() {
     // Leave description empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .assertIsDisplayed()
         .performTextInput("john.doe@example.com")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DOB_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("01/01/2000")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.NAME_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
 
     // Click the save button
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.SAVE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     // Verify that the navigation action does not occur
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
@@ -184,30 +154,19 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonWithValidFields() {
+  fun createValidProfile() {
     // Fill all fields
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .assertIsDisplayed()
         .performTextInput("john.doe@example.com")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DOB_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("01/01/2000")
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.NAME_FIELD)
-        .assertIsDisplayed()
-        .performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .assertIsDisplayed()
         .performTextInput("A short bio")
 
     // Click the save button
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.SAVE_BUTTON)
-        .assertIsDisplayed()
-        .performClick()
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     // Verify that the navigation action occurs
     verify(navigationActions).navigateTo(Screen.PROFILE)

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -56,28 +56,18 @@ class CreateProfileTest {
   }
 
   @Test
-  fun testSaveButtonClickWithValidDate() {
+  fun testValidDateRecognition() {
     // Input valid date
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
-
-    // Perform click on the save button
-    // Cannot test navigation actions currently
-    //    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
-    //    composeTestRule.waitForIdle()
-
     assertTrue(validateDate("01/01/2000"))
     assertTrue(validateDate("31/12/1999"))
   }
 
   @Test
-  fun testSaveButtonClickWithInvalidDate() {
+  fun testInvalidDateRecognition() {
     // Input invalid date
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("invalid_date")
-
-    // Perform click on the save button
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
-    composeTestRule.waitForIdle()
-
+    assertFalse(validateDate("DD/MM/YYYY")) // Field not filled
     assertFalse(validateDate("32/01/2000")) // Invalid day
     assertFalse(validateDate("01/13/2000")) // Invalid month
     assertFalse(validateDate("01/01/abcd")) // Invalid year
@@ -86,7 +76,7 @@ class CreateProfileTest {
   }
 
   @Test
-  fun saveButton_doesNotNavigate_whenEmailNotFilled() {
+  fun testSaveButtonDoesNotNavigateWithEmptyEmail() {
     // Leave email empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DOB_FIELD)
@@ -113,7 +103,7 @@ class CreateProfileTest {
   }
 
   @Test
-  fun saveButton_doesNotNavigate_whenDobNotFilled() {
+  fun testSaveButtonDoesNotNavigateWithEmptyDoB() {
     // Leave date of birth empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
@@ -140,7 +130,7 @@ class CreateProfileTest {
   }
 
   @Test
-  fun saveButton_doesNotNavigate_whenNameNotFilled() {
+  fun testSaveButtonDoesNotNavigateWithEmptyName() {
     // Leave name empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
@@ -167,7 +157,7 @@ class CreateProfileTest {
   }
 
   @Test
-  fun saveButton_doesNotNavigate_whenDescriptionNotFilled() {
+  fun testSaveButtonDoesNotNavigateWithEmptyDescription() {
     // Leave description empty
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
@@ -194,7 +184,7 @@ class CreateProfileTest {
   }
 
   @Test
-  fun saveButton_navigates_whenAllFieldsAreFilled() {
+  fun testSaveButtonWithValidFields() {
     // Fill all fields
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
@@ -220,6 +210,6 @@ class CreateProfileTest {
         .performClick()
 
     // Verify that the navigation action occurs
-    verify(navigationActions).navigateTo(screen = Screen.PROFILE)
+    verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 }

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -98,8 +98,10 @@ object C {
     object CreateProfileScreen {
       const val SCREEN = "screen"
       const val PROFILE_PICTURE = "profilePicture"
+      const val MANDATORY_TEXT = "mandatoryText"
       const val EMAIL_FIELD = "emailField"
       const val DOB_FIELD = "dobField"
+      const val PROFILE_TEXT = "profileText"
       const val NAME_FIELD = "nameField"
       const val DESCRIPTION_FIELD = "descriptionField"
       const val SAVE_BUTTON = "saveButton"

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -52,6 +52,11 @@ import com.bumptech.glide.integration.compose.GlideImage
 
 private const val SCREEN_TITLE = "Create Your Account"
 
+/**
+ * Composable function for the Create Profile screen.
+ *
+ * @param navigationActions Actions to handle navigation events.
+ */
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun CreateProfileScreen(navigationActions: NavigationActions) {
@@ -64,7 +69,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
     mutableStateOf<Uri?>(
         Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
   }
-  var context = LocalContext.current
+  val context = LocalContext.current
 
   val launcher =
       rememberLauncherForActivityResult(
@@ -193,7 +198,15 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
   )
 }
 
-/** Validates the fields of the profile screen. */
+/**
+ * Validates the fields of the profile screen.
+ *
+ * @param email The email address entered by the user.
+ * @param name The name entered by the user.
+ * @param date The date of birth entered by the user.
+ * @param description The description entered by the user.
+ * @return An error message if validation fails, otherwise null.
+ */
 private fun validateFields(
     email: String,
     name: String,
@@ -202,14 +215,19 @@ private fun validateFields(
 ): String? {
   return when {
     email.isEmpty() -> "Please enter an email"
-    name.isEmpty() -> "Please enter a name"
     !validateDate(date) -> "Invalid date"
+    name.isEmpty() -> "Please enter a name"
     description.isEmpty() -> "Please enter a description"
     else -> null
   }
 }
 
-/** Validates the date is in the format DD/MM/YYYY and is a valid date. */
+/**
+ * Validates the date is in the format DD/MM/YYYY and is a valid date.
+ *
+ * @param date The date string to validate.
+ * @return True if the date is valid, otherwise false.
+ */
 fun validateDate(date: String): Boolean {
   val parts = date.split("/")
   val calendar = GregorianCalendar.getInstance()
@@ -224,9 +242,4 @@ fun validateDate(date: String): Boolean {
     }
   }
   return false
-}
-
-/** Validates the description is not empty. */
-private fun validateDescription(description: String): Boolean {
-  return description.isNotEmpty()
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -114,18 +113,17 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               }
 
           // Mandatory fields
-          Box(modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = "Mandatory",
-                style =
-                    TextStyle(
-                        fontSize = 20.sp,
-                        lineHeight = 20.sp,
-                        fontWeight = FontWeight(500),
-                        letterSpacing = 0.2.sp,
-                    ),
-                modifier = Modifier.testTag(CreateProfileScreen.MANDATORY_TEXT))
-          }
+          Text(
+              text = "Mandatory",
+              style =
+                  TextStyle(
+                      fontSize = 20.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      letterSpacing = 0.2.sp,
+                  ),
+              modifier =
+                  Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT))
           // Email field
           OutlinedTextField(
               value = email,
@@ -143,18 +141,17 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
           )
           // Profile field
-          Box(modifier = Modifier.fillMaxWidth()) {
-            Text(
-                text = "Your profile",
-                style =
-                    TextStyle(
-                        fontSize = 20.sp,
-                        lineHeight = 20.sp,
-                        fontWeight = FontWeight(500),
-                        letterSpacing = 0.2.sp,
-                    ),
-                modifier = Modifier.testTag(CreateProfileScreen.PROFILE_TEXT))
-          }
+          Text(
+              text = "Your profile",
+              style =
+                  TextStyle(
+                      fontSize = 20.sp,
+                      lineHeight = 20.sp,
+                      fontWeight = FontWeight(500),
+                      letterSpacing = 0.2.sp,
+                  ),
+              modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT))
+
           // Name field
           OutlinedTextField(
               value = name,

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -88,6 +88,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+          // Profile picture
           Box(
               modifier =
                   Modifier.size(124.dp)
@@ -112,6 +113,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
                 )
               }
 
+          // Mandatory fields
           Box(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = "Mandatory",
@@ -122,9 +124,9 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
                         fontWeight = FontWeight(500),
                         letterSpacing = 0.2.sp,
                     ),
-            )
+                modifier = Modifier.testTag(CreateProfileScreen.MANDATORY_TEXT))
           }
-
+          // Email field
           OutlinedTextField(
               value = email,
               onValueChange = { email = it },
@@ -132,7 +134,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               placeholder = { Text("Enter your email") },
               modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
           )
-
+          // Date of birth field
           OutlinedTextField(
               value = age,
               onValueChange = { age = it },
@@ -140,7 +142,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               placeholder = { Text("DD/MM/YYYY") },
               modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
           )
-
+          // Profile field
           Box(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = "Your profile",
@@ -151,9 +153,9 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
                         fontWeight = FontWeight(500),
                         letterSpacing = 0.2.sp,
                     ),
-            )
+                modifier = Modifier.testTag(CreateProfileScreen.PROFILE_TEXT))
           }
-
+          // Name field
           OutlinedTextField(
               value = name,
               onValueChange = { name = it },
@@ -161,7 +163,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               placeholder = { Text("Enter your name") },
               modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
           )
-
+          // Description field
           OutlinedTextField(
               value = description,
               onValueChange = { description = it },
@@ -169,7 +171,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               placeholder = { Text("Enter a description") },
               modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
           )
-
+          // Save button
           Button(
               onClick = {
                 val errorMessage = validateFields(email, name, age, description)
@@ -183,8 +185,7 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
               },
               enabled = true,
               modifier =
-                  Modifier.padding(0.dp)
-                      .width(84.dp)
+                  Modifier.width(84.dp)
                       .height(40.dp)
                       .testTag(CreateProfileScreen.SAVE_BUTTON)
                       .background(
@@ -203,19 +204,19 @@ fun CreateProfileScreen(navigationActions: NavigationActions) {
  *
  * @param email The email address entered by the user.
  * @param name The name entered by the user.
- * @param date The date of birth entered by the user.
+ * @param dob The date of birth entered by the user.
  * @param description The description entered by the user.
  * @return An error message if validation fails, otherwise null.
  */
 private fun validateFields(
     email: String,
     name: String,
-    date: String,
+    dob: String,
     description: String,
 ): String? {
   return when {
     email.isEmpty() -> "Please enter an email"
-    !validateDate(date) -> "Invalid date"
+    !validateDate(dob) -> "Invalid date"
     name.isEmpty() -> "Please enter a name"
     description.isEmpty() -> "Please enter a description"
     else -> null


### PR DESCRIPTION
# Fix UI tests for CreateProfile

## Description
This PR closes issue #74 and #63, by fixing tests for the `CreateProfile` screen. 

## Changes

## Files 
#### Modified
- `main/.../ui/profile/CreateProfile.kt`: added documentation and removed unused functions. 

## Testing
- `androidTests/.../ui/profile/CreateProfileTest`: ensured proper and complete testing of the verification of validity for all fields as well as the correct functionality of the navigation actions.