### PR TITLE
Fix/style/layout responsivness/sign up

### DIFF
--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -9,6 +9,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,7 +25,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthState
 import com.android.periodpals.resources.C.Tag.SignUpScreen
@@ -39,6 +41,7 @@ import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.Pink40
 import com.android.periodpals.ui.theme.Purple40
 import com.android.periodpals.ui.theme.PurpleGrey80
+import com.android.periodpals.ui.theme.dimens
 
 @Composable
 fun SignUpScreen(
@@ -68,119 +71,138 @@ fun SignUpScreen(
         // Purple-ish background
         GradedBackground(Pink40, Purple40, PurpleGrey80, SignUpScreen.BACKGROUND)
 
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding).padding(60.dp),
+        LazyColumn(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(padding)
+                    .padding(
+                        horizontal = MaterialTheme.dimens.large,
+                        vertical = MaterialTheme.dimens.medium3),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(48.dp, Alignment.CenterVertically),
+            verticalArrangement =
+                Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
         ) {
           // Welcome text
-          AuthWelcomeText(
-              text = "Welcome to PeriodPals",
-              color = Color.White,
-              testTag = SignUpScreen.TITLE_TEXT,
-          )
+          item {
+            AuthWelcomeText(
+                text = "Welcome to PeriodPals",
+                color = Color.White,
+                testTag = SignUpScreen.TITLE_TEXT,
+            )
+          }
 
           // Rectangle with login fields and button
-          Box(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .border(1.dp, Color.Gray, RectangleShape)
-                      .background(Color.White)
-                      .padding(24.dp)) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
-                ) {
-                  // Sign up instruction
-                  AuthInstruction(
-                      text = "Create your account", testTag = SignUpScreen.INSTRUCTION_TEXT)
+          item {
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .wrapContentHeight()
+                        .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
+                        .background(Color.White)
+                        .padding(
+                            horizontal = MaterialTheme.dimens.medium1,
+                            vertical = MaterialTheme.dimens.small3)) {
+                  Column(
+                      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+                      horizontalAlignment = Alignment.CenterHorizontally,
+                      verticalArrangement =
+                          Arrangement.spacedBy(
+                              MaterialTheme.dimens.small2, Alignment.CenterVertically),
+                  ) {
+                    // Sign up instruction
+                    AuthInstruction(
+                        text = "Create your account", testTag = SignUpScreen.INSTRUCTION_TEXT)
 
-                  // Email input and error message
-                  AuthEmailInput(
-                      email = email,
-                      onEmailChange = { email = it },
-                      testTag = SignUpScreen.EMAIL_FIELD,
-                  )
-                  if (emailErrorMessage.isNotEmpty()) {
-                    ErrorText(message = emailErrorMessage, testTag = SignUpScreen.EMAIL_ERROR_TEXT)
-                  }
-
-                  // Password input and error message
-                  AuthPasswordInput(
-                      password = password,
-                      onPasswordChange = {
-                        password = it
-                        passwordErrorMessage = validatePassword(password)
-                      },
-                      passwordVisible = passwordVisible,
-                      onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                      testTag = SignUpScreen.PASSWORD_FIELD,
-                      visibilityTestTag = SignUpScreen.PASSWORD_VISIBILITY_BUTTON,
-                  )
-                  if (passwordErrorMessage.isNotEmpty()) {
-                    ErrorText(
-                        message = passwordErrorMessage, testTag = SignUpScreen.PASSWORD_ERROR_TEXT)
-                  }
-
-                  // Confirm password text
-                  AuthSecondInstruction(
-                      text = "Confirm your password",
-                      testTag = SignUpScreen.CONFIRM_PASSWORD_TEXT,
-                  )
-
-                  // Confirm password input and error message
-                  AuthPasswordInput(
-                      password = confirm,
-                      onPasswordChange = { confirm = it },
-                      passwordVisible = confirmVisible,
-                      onPasswordVisibilityChange = { confirmVisible = !confirmVisible },
-                      testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-                      visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
-                  )
-                  if (confirmErrorMessage.isNotEmpty()) {
-                    ErrorText(
-                        message = confirmErrorMessage,
-                        testTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+                    // Email input and error message
+                    AuthEmailInput(
+                        email = email,
+                        onEmailChange = { email = it },
+                        testTag = SignUpScreen.EMAIL_FIELD,
                     )
-                  }
+                    if (emailErrorMessage.isNotEmpty()) {
+                      ErrorText(
+                          message = emailErrorMessage, testTag = SignUpScreen.EMAIL_ERROR_TEXT)
+                    }
 
-                  // Sign up button
-                  AuthButton(
-                      text = "Sign up",
-                      onClick = {
-                        emailErrorMessage = validateEmail(email)
-                        passwordErrorMessage = validatePassword(password)
-                        confirmErrorMessage = validateConfirmPassword(password, confirm)
+                    // Password input and error message
+                    AuthPasswordInput(
+                        password = password,
+                        onPasswordChange = {
+                          password = it
+                          passwordErrorMessage = validatePassword(password)
+                        },
+                        passwordVisible = passwordVisible,
+                        onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+                        testTag = SignUpScreen.PASSWORD_FIELD,
+                        visibilityTestTag = SignUpScreen.PASSWORD_VISIBILITY_BUTTON,
+                    )
+                    if (passwordErrorMessage.isNotEmpty()) {
+                      ErrorText(
+                          message = passwordErrorMessage,
+                          testTag = SignUpScreen.PASSWORD_ERROR_TEXT)
+                    }
 
-                        if (emailErrorMessage.isEmpty() &&
-                            passwordErrorMessage.isEmpty() &&
-                            confirmErrorMessage.isEmpty()) {
-                          if (email.isNotEmpty() && password.isNotEmpty()) {
-                            authenticationViewModel.signUpWithEmail(email, password)
-                            authenticationViewModel.isUserLoggedIn()
-                            val loginSuccess = userState is UserAuthState.Success
-                            if (loginSuccess) {
-                              Toast.makeText(
-                                      context, "Account Creation Successful", Toast.LENGTH_SHORT)
-                                  .show()
-                              navigationActions.navigateTo(Screen.CREATE_PROFILE)
+                    // Confirm password text
+                    AuthSecondInstruction(
+                        text = "Confirm your password",
+                        testTag = SignUpScreen.CONFIRM_PASSWORD_TEXT,
+                    )
+
+                    // Confirm password input and error message
+                    AuthPasswordInput(
+                        password = confirm,
+                        onPasswordChange = { confirm = it },
+                        passwordVisible = confirmVisible,
+                        onPasswordVisibilityChange = { confirmVisible = !confirmVisible },
+                        testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+                        visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+                    )
+                    if (confirmErrorMessage.isNotEmpty()) {
+                      ErrorText(
+                          message = confirmErrorMessage,
+                          testTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+                      )
+                    }
+
+                    // Sign up button
+                    AuthButton(
+                        text = "Sign up",
+                        onClick = {
+                          emailErrorMessage = validateEmail(email)
+                          passwordErrorMessage = validatePassword(password)
+                          confirmErrorMessage = validateConfirmPassword(password, confirm)
+
+                          if (emailErrorMessage.isEmpty() &&
+                              passwordErrorMessage.isEmpty() &&
+                              confirmErrorMessage.isEmpty()) {
+                            if (email.isNotEmpty() && password.isNotEmpty()) {
+                              authenticationViewModel.signUpWithEmail(email, password)
+                              authenticationViewModel.isUserLoggedIn()
+                              val loginSuccess = userState is UserAuthState.Success
+                              if (loginSuccess) {
+                                Toast.makeText(
+                                        context, "Account Creation Successful", Toast.LENGTH_SHORT)
+                                    .show()
+                                navigationActions.navigateTo(Screen.CREATE_PROFILE)
+                              } else {
+                                Toast.makeText(
+                                        context, "Account Creation Failed", Toast.LENGTH_SHORT)
+                                    .show()
+                              }
                             } else {
-                              Toast.makeText(context, "Account Creation Failed", Toast.LENGTH_SHORT)
+                              Toast.makeText(context, "Email cannot be empty", Toast.LENGTH_SHORT)
                                   .show()
                             }
                           } else {
-                            Toast.makeText(context, "Email cannot be empty", Toast.LENGTH_SHORT)
+                            Toast.makeText(context, "Invalid email or password", Toast.LENGTH_SHORT)
                                 .show()
                           }
-                        } else {
-                          Toast.makeText(context, "Invalid email or password", Toast.LENGTH_SHORT)
-                              .show()
-                        }
-                      },
-                      testTag = SignUpScreen.SIGN_UP_BUTTON,
-                  )
+                        },
+                        testTag = SignUpScreen.SIGN_UP_BUTTON,
+                    )
+                  }
                 }
-              }
+          }
         }
       },
   )

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthComponents.kt
@@ -73,7 +73,7 @@ fun AuthWelcomeText(text: String, color: Color, testTag: String) {
       text = text,
       textAlign = TextAlign.Center,
       color = color,
-      style = MaterialTheme.typography.headlineLarge)
+      style = MaterialTheme.typography.titleLarge)
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/theme/Type.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Type.kt
@@ -47,7 +47,7 @@ val Nunito_Sans =
                 style = FontStyle.Italic)))
 
 fun createTypography(
-    headlineLargeSize: Int,
+    titleLargeSize: Int,
     titleMediumSize: Int,
     bodyLargeSize: Int,
     bodyMediumSize: Int,
@@ -55,13 +55,13 @@ fun createTypography(
     labelSmallSize: Int
 ): Typography {
   return Typography(
-      headlineLarge =
+      titleLarge =
           TextStyle(
               fontFamily = Nunito_Sans,
               fontWeight = FontWeight.Black,
               fontStyle = FontStyle.Normal,
-              fontSize = headlineLargeSize.sp,
-              lineHeight = (headlineLargeSize * 1.5).sp),
+              fontSize = titleLargeSize.sp,
+              lineHeight = (titleLargeSize * 1.5).sp),
       titleMedium =
           TextStyle(
               fontFamily = Nunito_Sans,
@@ -96,7 +96,7 @@ fun createTypography(
 
 val CompactSmallTypography =
     createTypography(
-        headlineLargeSize = 32,
+        titleLargeSize = 32,
         titleMediumSize = 10,
         bodyLargeSize = 18,
         bodyMediumSize = 16,
@@ -105,7 +105,7 @@ val CompactSmallTypography =
 
 val CompactMediumTypography =
     createTypography(
-        headlineLargeSize = 40,
+        titleLargeSize = 40,
         titleMediumSize = 14,
         bodyLargeSize = 20,
         bodyMediumSize = 18,
@@ -114,7 +114,7 @@ val CompactMediumTypography =
 
 val CompactLargeTypography =
     createTypography(
-        headlineLargeSize = 48,
+        titleLargeSize = 48,
         titleMediumSize = 14,
         bodyLargeSize = 24,
         bodyMediumSize = 20,
@@ -123,7 +123,7 @@ val CompactLargeTypography =
 
 val MediumTypography =
     createTypography(
-        headlineLargeSize = 56,
+        titleLargeSize = 56,
         titleMediumSize = 16,
         bodyLargeSize = 24,
         bodyMediumSize = 22,
@@ -132,7 +132,7 @@ val MediumTypography =
 
 val ExpandedTypography =
     createTypography(
-        headlineLargeSize = 64,
+        titleLargeSize = 64,
         titleMediumSize = 18,
         bodyLargeSize = 24,
         bodyMediumSize = 22,


### PR DESCRIPTION
# Update Padding and Typography in `SignUpScreen`

## Description
This PR updates the `SignUpScreen` layout to match Figma specifications, ensuring consistent padding, spacing, and typography across different screen sizes. It addresses subtask #82, closes issue #94, enhancing visual alignment, responsiveness, and UI consistency by using `LazyColumn` and `MaterialTheme` dimensions for improved structure.

## Changes
- Replaced `Column` with `LazyColumn` for improved handling of dynamic content in `SignUpScreen`.
- Applied consistent padding and spacing using `MaterialTheme.dimens`.
- Updated text styles to align with `MaterialTheme.typography`.
- Adjusted component wrapping with `wrapContentHeight` for better layout control.
- Refined alignment and spacing for error messages.
- Improved toast message formatting for account creation failures.

## Files 
#### Modified
- `SignUpScreen.kt`: Updated padding, spacing, and typography.

## Dependencies Added
- None

## Testing
- Verified on multiple emulators to ensure consistent styling and responsiveness across different screen sizes.

## Screenshots
| Screen              | Before                              | After                               |
|---------------------|-------------------------------------|-------------------------------------|
| **Compact S**       | ![Before Compact S](https://github.com/user-attachments/assets/098a27de-e831-4e4c-a30d-8fa7d75ef087)     | ![After Compact S](https://github.com/user-attachments/assets/1d08efa0-4508-42fd-8cde-429c8f784dc1)      |
| **Compact M**       | ![Before Compact M](https://github.com/user-attachments/assets/f4dd5251-900c-47cc-9399-c63c7263cb46)     | ![After Compact M](https://github.com/user-attachments/assets/ec736eeb-5999-4dac-833d-a8fcdcf57366)      |
| **Compact L**       | ![Before Compact L](https://github.com/user-attachments/assets/f4a47922-9aff-45a2-8333-fcd3c5de4b10)     | ![After Compact L](https://github.com/user-attachments/assets/96c9a128-8f5c-44a5-94f2-3a477a2c532b)      |
| **Medium (horizontal)** | ![Before Medium horizontal](https://github.com/user-attachments/assets/6b8db21c-7c55-4df4-9eca-f241725a94a8) | ![After Medium horizontal](https://github.com/user-attachments/assets/88af736d-0562-41ab-9d1e-31005ea5051d) |
| **Medium**          | ![Before Medium](https://github.com/user-attachments/assets/e7b6b2b1-440b-4cfd-ad08-e4564e87271e)        | ![After Medium](https://github.com/user-attachments/assets/85a95a4d-15d6-46f6-ba82-4947abb8c688)        |
| **Extended**        | ![Before Extended](https://github.com/user-attachments/assets/3a03478b-0569-4677-82e6-447a2d82d539)     | ![After Extended](https://github.com/user-attachments/assets/9286add4-9293-420c-964e-581cb11f40b4)      |