### PR TITLE
Feat/profile/integrate-vm-createprofile : Integrate profile VM into CreateProfile screen

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -42,7 +42,7 @@ class CreateProfileTest {
     userViewModel = mock(UserViewModel::class.java)
 
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
 
     `when`(userViewModel.user).thenReturn(userState)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.CREATE_PROFILE)
@@ -62,14 +62,14 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
-      .onNodeWithTag(TopAppBar.TITLE_TEXT)
-      .assertIsDisplayed()
-      .assertTextEquals("Create Your Account")
+        .onNodeWithTag(TopAppBar.TITLE_TEXT)
+        .assertIsDisplayed()
+        .assertTextEquals("Create Your Account")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
     composeTestRule
-      .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
-      .assertIsNotDisplayed()
+        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
+        .assertIsNotDisplayed()
   }
 
   @Test
@@ -94,8 +94,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -107,12 +107,12 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDob() {
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -124,12 +124,12 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoName() {
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -141,8 +141,8 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDescription() {
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
@@ -156,13 +156,13 @@ class CreateProfileTest {
   @Test
   fun createValidProfile() {
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -59,14 +59,14 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
-      .onNodeWithTag(TopAppBar.TITLE_TEXT)
-      .assertIsDisplayed()
-      .assertTextEquals("Create Your Account")
+        .onNodeWithTag(TopAppBar.TITLE_TEXT)
+        .assertIsDisplayed()
+        .assertTextEquals("Create Your Account")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
     composeTestRule
-      .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
-      .assertIsNotDisplayed()
+        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
+        .assertIsNotDisplayed()
   }
 
   @Test
@@ -93,7 +93,7 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoEmail() {
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
@@ -101,8 +101,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -114,18 +114,18 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDob() {
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -137,18 +137,18 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoName() {
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -160,14 +160,14 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDescription() {
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
@@ -185,13 +185,13 @@ class CreateProfileTest {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())
@@ -202,19 +202,19 @@ class CreateProfileTest {
   @Test
   fun createValidProfileVMSuccess() {
     val userState =
-      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-      .performTextInput("john.doe@example.com")
+        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+        .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-      .performTextInput("A short bio")
+        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -29,13 +29,15 @@ import org.mockito.kotlin.verify
 @RunWith(AndroidJUnit4::class)
 class CreateProfileTest {
   private lateinit var navigationActions: NavigationActions
+  private lateinit var userViewModel: UserViewModel
+
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.CREATE_PROFILE)
-    composeTestRule.setContent { CreateProfileScreen(navigationActions) }
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
   }
 
   @Test
@@ -87,6 +89,8 @@ class CreateProfileTest {
         .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
+    verify(userViewModel, never()).saveUser(any())
+
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -101,6 +105,8 @@ class CreateProfileTest {
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+
+    verify(userViewModel, never()).saveUser(any())
 
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
@@ -117,6 +123,8 @@ class CreateProfileTest {
         .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
+    verify(userViewModel, never()).saveUser(any())
+
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -129,6 +137,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+
+    verify(userViewModel, never()).saveUser(any())
 
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
@@ -145,6 +155,8 @@ class CreateProfileTest {
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
         .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+
+    verify(userViewModel).saveUser(any())
 
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.profile
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -8,6 +9,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.periodpals.model.user.User
+import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.CreateProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
@@ -36,6 +39,12 @@ class CreateProfileTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    userViewModel = mock(UserViewModel::class.java)
+
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+
+    `when`(userViewModel.user).thenReturn(userState)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.CREATE_PROFILE)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
   }
@@ -53,14 +62,14 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(TopAppBar.TITLE_TEXT)
-        .assertIsDisplayed()
-        .assertTextEquals("Create Your Account")
+      .onNodeWithTag(TopAppBar.TITLE_TEXT)
+      .assertIsDisplayed()
+      .assertTextEquals("Create Your Account")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
     composeTestRule
-        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
-        .assertIsNotDisplayed()
+      .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
+      .assertIsNotDisplayed()
   }
 
   @Test
@@ -85,8 +94,8 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -98,12 +107,12 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDob() {
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -115,12 +124,12 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoName() {
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -132,8 +141,8 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDescription() {
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
@@ -147,13 +156,13 @@ class CreateProfileTest {
   @Test
   fun createValidProfile() {
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -41,16 +41,13 @@ class CreateProfileTest {
     navigationActions = mock(NavigationActions::class.java)
     userViewModel = mock(UserViewModel::class.java)
 
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
-
-    `when`(userViewModel.user).thenReturn(userState)
     `when`(navigationActions.currentRoute()).thenReturn(Screen.CREATE_PROFILE)
-    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
   }
 
   @Test
   fun allComponentsAreDisplayed() {
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.PROFILE_PICTURE).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateProfileScreen.MANDATORY_TEXT).assertIsDisplayed()
@@ -62,18 +59,20 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(TopAppBar.TITLE_TEXT)
-        .assertIsDisplayed()
-        .assertTextEquals("Create Your Account")
+      .onNodeWithTag(TopAppBar.TITLE_TEXT)
+      .assertIsDisplayed()
+      .assertTextEquals("Create Your Account")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
     composeTestRule
-        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
-        .assertIsNotDisplayed()
+      .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
+      .assertIsNotDisplayed()
   }
 
   @Test
   fun testValidDateRecognition() {
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     assertTrue(validateDate("01/01/2000"))
     assertTrue(validateDate("31/12/1999"))
@@ -81,6 +80,8 @@ class CreateProfileTest {
 
   @Test
   fun testInvalidDateRecognition() {
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("invalid_date")
     assertFalse(validateDate("32/01/2000")) // Invalid day
     assertFalse(validateDate("01/13/2000")) // Invalid month
@@ -91,11 +92,17 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoEmail() {
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -106,13 +113,19 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoDob() {
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -123,13 +136,19 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoName() {
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -140,9 +159,15 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoDescription() {
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
@@ -154,15 +179,42 @@ class CreateProfileTest {
   }
 
   @Test
-  fun createValidProfile() {
+  fun createValidProfileVMFailure() {
+    `when`(userViewModel.user).thenReturn(mutableStateOf(null))
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
     composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
     composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+
+    verify(userViewModel).saveUser(any())
+
+    verify(navigationActions, never()).navigateTo(Screen.PROFILE)
+  }
+
+  @Test
+  fun createValidProfileVMSuccess() {
+    val userState =
+      mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
+    composeTestRule
+      .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
+      .performTextInput("john.doe@example.com")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule
+      .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+      .performTextInput("A short bio")
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -36,6 +36,16 @@ class CreateProfileTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
+  companion object {
+    private val email = "test@email.com"
+    private val name = "John Doe"
+    private val imageUrl = "https://example.com"
+    private val description = "A short description"
+    private val dob = "01/01/2000"
+    private val userState =
+        mutableStateOf(User(name = name, imageUrl = imageUrl, description = description, dob = dob))
+  }
+
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
@@ -92,17 +102,15 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoEmail() {
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -113,19 +121,15 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoDob() {
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -136,19 +140,15 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoName() {
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -159,17 +159,13 @@ class CreateProfileTest {
 
   @Test
   fun createInvalidProfileNoDescription() {
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
@@ -184,14 +180,12 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())
@@ -201,20 +195,16 @@ class CreateProfileTest {
 
   @Test
   fun createValidProfileVMSuccess() {
-    val userState =
-        mutableStateOf(User("John Doe", "https://example.com", "A short bio", "01/01/2000"))
     `when`(userViewModel.user).thenReturn(userState)
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule
-        .onNodeWithTag(CreateProfileScreen.EMAIL_FIELD)
-        .performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(CreateProfileScreen.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())

--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -41,13 +41,13 @@ class MainActivity : ComponentActivity() {
   private val locationService = GPSServiceImpl(this)
 
   private val supabaseClient =
-    createSupabaseClient(
-      supabaseUrl = BuildConfig.SUPABASE_URL,
-      supabaseKey = BuildConfig.SUPABASE_KEY,
-    ) {
-      install(Auth)
-      install(Postgrest)
-    }
+      createSupabaseClient(
+          supabaseUrl = BuildConfig.SUPABASE_URL,
+          supabaseKey = BuildConfig.SUPABASE_KEY,
+      ) {
+        install(Auth)
+        install(Postgrest)
+      }
 
   private val authModel = AuthenticationModelSupabase(supabaseClient)
   private val authenticationViewModel = AuthenticationViewModel(authModel)
@@ -74,9 +74,9 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun PeriodPalsApp(
-  locationService: GPSServiceImpl,
-  authenticationViewModel: AuthenticationViewModel,
-  userViewModel: UserViewModel,
+    locationService: GPSServiceImpl,
+    authenticationViewModel: AuthenticationViewModel,
+    userViewModel: UserViewModel,
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)

--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.android.periodpals.model.authentication.AuthenticationModelSupabase
 import com.android.periodpals.model.authentication.AuthenticationViewModel
+import com.android.periodpals.model.user.UserRepositorySupabase
+import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.services.GPSServiceImpl
 import com.android.periodpals.ui.alert.AlertListsScreen
 import com.android.periodpals.ui.alert.CreateAlertScreen
@@ -31,6 +33,7 @@ import com.android.periodpals.ui.theme.PeriodPalsAppTheme
 import com.android.periodpals.ui.timer.TimerScreen
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
 import org.osmdroid.config.Configuration
 
 class MainActivity : ComponentActivity() {
@@ -38,15 +41,19 @@ class MainActivity : ComponentActivity() {
   private val locationService = GPSServiceImpl(this)
 
   private val supabaseClient =
-      createSupabaseClient(
-          supabaseUrl = BuildConfig.SUPABASE_URL,
-          supabaseKey = BuildConfig.SUPABASE_KEY,
-      ) {
-        install(Auth)
-      }
+    createSupabaseClient(
+      supabaseUrl = BuildConfig.SUPABASE_URL,
+      supabaseKey = BuildConfig.SUPABASE_KEY,
+    ) {
+      install(Auth)
+      install(Postgrest)
+    }
 
   private val authModel = AuthenticationModelSupabase(supabaseClient)
   private val authenticationViewModel = AuthenticationViewModel(authModel)
+
+  private val userModel = UserRepositorySupabase(supabaseClient)
+  private val userViewModel = UserViewModel(userModel)
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -58,7 +65,7 @@ class MainActivity : ComponentActivity() {
       PeriodPalsAppTheme {
         // A surface container using the 'background' color from the theme
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-          PeriodPalsApp(locationService, authenticationViewModel)
+          PeriodPalsApp(locationService, authenticationViewModel, userViewModel)
         }
       }
     }
@@ -67,8 +74,9 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun PeriodPalsApp(
-    locationService: GPSServiceImpl,
-    authenticationViewModel: AuthenticationViewModel,
+  locationService: GPSServiceImpl,
+  authenticationViewModel: AuthenticationViewModel,
+  userViewModel: UserViewModel,
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -78,7 +86,7 @@ fun PeriodPalsApp(
     navigation(startDestination = Screen.SIGN_IN, route = Route.AUTH) {
       composable(Screen.SIGN_IN) { SignInScreen(authenticationViewModel, navigationActions) }
       composable(Screen.SIGN_UP) { SignUpScreen(authenticationViewModel, navigationActions) }
-      composable(Screen.CREATE_PROFILE) { CreateProfileScreen(navigationActions) }
+      composable(Screen.CREATE_PROFILE) { CreateProfileScreen(userViewModel, navigationActions) }
     }
 
     // Alert push notifications

--- a/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
@@ -23,14 +23,14 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
   fun loadUser() {
     viewModelScope.launch {
       userRepository.loadUserProfile(
-        onSuccess = { userDto ->
-          Log.d(TAG, "loadUserProfile: Succesful")
-          _user.value = userDto.asUser()
-        },
-        onFailure = {
-          Log.d(TAG, "loadUserProfile: fail to load user profile: ${it.message}")
-          _user.value = null
-        },
+          onSuccess = { userDto ->
+            Log.d(TAG, "loadUserProfile: Succesful")
+            _user.value = userDto.asUser()
+          },
+          onFailure = {
+            Log.d(TAG, "loadUserProfile: fail to load user profile: ${it.message}")
+            _user.value = null
+          },
       )
     }
   }
@@ -43,15 +43,15 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
   fun saveUser(user: User) {
     viewModelScope.launch {
       userRepository.createUserProfile(
-        user,
-        onSuccess = {
-          Log.d(TAG, "saveUser: Success")
-          _user.value = user
-        },
-        onFailure = {
-          Log.d(TAG, "saveUser: fail to save user: ${it.message}")
-          _user.value = null
-        },
+          user,
+          onSuccess = {
+            Log.d(TAG, "saveUser: Success")
+            _user.value = user
+          },
+          onFailure = {
+            Log.d(TAG, "saveUser: fail to save user: ${it.message}")
+            _user.value = null
+          },
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
@@ -1,10 +1,10 @@
 package com.android.periodpals.model.user
 
 import android.util.Log
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -16,21 +16,22 @@ private const val TAG = "UserViewModel"
 
 class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewModel() {
 
-  private val _user = MutableStateFlow<User?>(null)
-  val user: StateFlow<User?> = _user
+  private val _user = mutableStateOf<User?>(null)
+  val user: State<User?> = _user
 
   /** Loads the user profile and updates the user state. */
   fun loadUser() {
     viewModelScope.launch {
       userRepository.loadUserProfile(
-          onSuccess = { userDto ->
-            Log.d(TAG, "loadUserProfile: Succesful")
-            _user.value = userDto.asUser()
-          },
-          onFailure = {
-            Log.d(TAG, "loadUserProfile: fail to load user profile: ${it.message}")
-            _user.value = null
-          })
+        onSuccess = { userDto ->
+          Log.d(TAG, "loadUserProfile: Succesful")
+          _user.value = userDto.asUser()
+        },
+        onFailure = {
+          Log.d(TAG, "loadUserProfile: fail to load user profile: ${it.message}")
+          _user.value = null
+        },
+      )
     }
   }
 
@@ -42,15 +43,16 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
   fun saveUser(user: User) {
     viewModelScope.launch {
       userRepository.createUserProfile(
-          user,
-          onSuccess = {
-            Log.d(TAG, "saveUser: Success")
-            _user.value = user
-          },
-          onFailure = {
-            Log.d(TAG, "saveUser: fail to save user: ${it.message}")
-            _user.value = null
-          })
+        user,
+        onSuccess = {
+          Log.d(TAG, "saveUser: Success")
+          _user.value = user
+        },
+        onFailure = {
+          Log.d(TAG, "saveUser: fail to save user: ${it.message}")
+          _user.value = null
+        },
+      )
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -73,132 +72,134 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var description by remember { mutableStateOf("") }
   var profileImageUri by remember {
     mutableStateOf<Uri?>(
-        Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
+      Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
+    )
   }
-  val userState = userViewModel.user.collectAsState()
+  val userState = userViewModel.user
   val context = LocalContext.current
 
   val launcher =
-      rememberLauncherForActivityResult(
-          contract = ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == Activity.RESULT_OK) {
-              profileImageUri = result.data?.data
-            }
-          }
+    rememberLauncherForActivityResult(
+      contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+      if (result.resultCode == Activity.RESULT_OK) {
+        profileImageUri = result.data?.data
+      }
+    }
 
   Scaffold(
-      modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
-      topBar = { TopAppBar(title = SCREEN_TITLE) },
+    modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
+    topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { padding ->
     Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
+      modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       // Profile picture
       Box(
-          modifier =
-              Modifier.size(124.dp)
-                  .clip(shape = RoundedCornerShape(100.dp))
-                  .background(
-                      color = MaterialTheme.colorScheme.background,
-                      shape = RoundedCornerShape(100.dp),
-                  )
-                  .testTag(CreateProfileScreen.PROFILE_PICTURE)
-                  .clickable {
-                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                    launcher.launch(pickImageIntent)
-                  }) {
-            GlideImage(
-                model = profileImageUri,
-                contentDescription = "profile picture",
-                contentScale = ContentScale.Crop,
-                modifier =
-                    Modifier.size(124.dp)
-                        .background(
-                            color = MaterialTheme.colorScheme.background, shape = CircleShape),
+        modifier =
+          Modifier.size(124.dp)
+            .clip(shape = RoundedCornerShape(100.dp))
+            .background(
+              color = MaterialTheme.colorScheme.background,
+              shape = RoundedCornerShape(100.dp),
             )
-          }
+            .testTag(CreateProfileScreen.PROFILE_PICTURE)
+            .clickable {
+              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+              launcher.launch(pickImageIntent)
+            }
+      ) {
+        GlideImage(
+          model = profileImageUri,
+          contentDescription = "profile picture",
+          contentScale = ContentScale.Crop,
+          modifier =
+            Modifier.size(124.dp)
+              .background(color = MaterialTheme.colorScheme.background, shape = CircleShape),
+        )
+      }
 
       // Mandatory fields
       Text(
-          text = "Mandatory",
-          style =
-              TextStyle(
-                  fontSize = 20.sp,
-                  lineHeight = 20.sp,
-                  fontWeight = FontWeight(500),
-                  letterSpacing = 0.2.sp,
-              ),
-          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
+        text = "Mandatory",
+        style =
+          TextStyle(
+            fontSize = 20.sp,
+            lineHeight = 20.sp,
+            fontWeight = FontWeight(500),
+            letterSpacing = 0.2.sp,
+          ),
+        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
       )
       // Email field
       OutlinedTextField(
-          value = email,
-          onValueChange = { email = it },
-          label = { Text("Email") },
-          placeholder = { Text("Enter your email") },
-          modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
+        value = email,
+        onValueChange = { email = it },
+        label = { Text("Email") },
+        placeholder = { Text("Enter your email") },
+        modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
       )
       // Date of birth field
       OutlinedTextField(
-          value = age,
-          onValueChange = { age = it },
-          label = { Text("Date of Birth") },
-          placeholder = { Text("DD/MM/YYYY") },
-          modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
+        value = age,
+        onValueChange = { age = it },
+        label = { Text("Date of Birth") },
+        placeholder = { Text("DD/MM/YYYY") },
+        modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
       )
       // Profile field
       Text(
-          text = "Your profile",
-          style =
-              TextStyle(
-                  fontSize = 20.sp,
-                  lineHeight = 20.sp,
-                  fontWeight = FontWeight(500),
-                  letterSpacing = 0.2.sp,
-              ),
-          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
+        text = "Your profile",
+        style =
+          TextStyle(
+            fontSize = 20.sp,
+            lineHeight = 20.sp,
+            fontWeight = FontWeight(500),
+            letterSpacing = 0.2.sp,
+          ),
+        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
       )
 
       // Name field
       OutlinedTextField(
-          value = name,
-          onValueChange = { name = it },
-          label = { Text("Displayed Name") },
-          placeholder = { Text("Enter your name") },
-          modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
+        value = name,
+        onValueChange = { name = it },
+        label = { Text("Displayed Name") },
+        placeholder = { Text("Enter your name") },
+        modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
       )
       // Description field
       OutlinedTextField(
-          value = description,
-          onValueChange = { description = it },
-          label = { Text("Description") },
-          placeholder = { Text("Enter a description") },
-          modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
+        value = description,
+        onValueChange = { description = it },
+        label = { Text("Description") },
+        placeholder = { Text("Enter a description") },
+        modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
       )
       // Save button
       Button(
-          onClick = {
-            attemptSaveUserData(
-                email = email,
-                name = name,
-                age = age,
-                description = description,
-                profileImageUri = profileImageUri,
-                context = context,
-                userViewModel = userViewModel,
-                userState = userState,
-                navigationActions = navigationActions,
-            )
-          },
-          enabled = true,
-          modifier =
-              Modifier.width(84.dp)
-                  .height(40.dp)
-                  .testTag(CreateProfileScreen.SAVE_BUTTON)
-                  .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
-          colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
+        onClick = {
+          attemptSaveUserData(
+            email = email,
+            name = name,
+            age = age,
+            description = description,
+            profileImageUri = profileImageUri,
+            context = context,
+            userViewModel = userViewModel,
+            userState = userState,
+            navigationActions = navigationActions,
+          )
+        },
+        enabled = true,
+        modifier =
+          Modifier.width(84.dp)
+            .height(40.dp)
+            .testTag(CreateProfileScreen.SAVE_BUTTON)
+            .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
+        colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
       ) {
         Text("Save", color = Color.White)
       }
@@ -220,15 +221,15 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSaveUserData(
-    email: String,
-    name: String,
-    age: String,
-    description: String,
-    profileImageUri: Uri?,
-    context: Context,
-    userViewModel: UserViewModel,
-    userState: State<User?>,
-    navigationActions: NavigationActions,
+  email: String,
+  name: String,
+  age: String,
+  description: String,
+  profileImageUri: Uri?,
+  context: Context,
+  userViewModel: UserViewModel,
+  userState: State<User?>,
+  navigationActions: NavigationActions,
 ) {
   val errorMessage = validateFields(email, name, age, description)
   if (errorMessage != null) {
@@ -239,7 +240,7 @@ private fun attemptSaveUserData(
 
   Log.d(TAG, "Saving user profile")
   val newUser =
-      User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
+    User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
   userViewModel.saveUser(newUser)
   if (userState.value == null) {
     Log.d(TAG, "Failed to save profile")

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -73,134 +73,132 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var description by remember { mutableStateOf("") }
   var profileImageUri by remember {
     mutableStateOf<Uri?>(
-      Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
-    )
+        Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
   }
   val userState = userViewModel.user.collectAsState()
   val context = LocalContext.current
 
   val launcher =
-    rememberLauncherForActivityResult(
-      contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-      if (result.resultCode == Activity.RESULT_OK) {
-        profileImageUri = result.data?.data
-      }
-    }
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+              profileImageUri = result.data?.data
+            }
+          }
 
   Scaffold(
-    modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
-    topBar = { TopAppBar(title = SCREEN_TITLE) },
+      modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
+      topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { padding ->
     Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-      horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       // Profile picture
       Box(
-        modifier =
-          Modifier.size(124.dp)
-            .clip(shape = RoundedCornerShape(100.dp))
-            .background(
-              color = MaterialTheme.colorScheme.background,
-              shape = RoundedCornerShape(100.dp),
-            )
-            .testTag(CreateProfileScreen.PROFILE_PICTURE)
-            .clickable {
-              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-              launcher.launch(pickImageIntent)
-            }
-      ) {
-        GlideImage(
-          model = profileImageUri,
-          contentDescription = "profile picture",
-          contentScale = ContentScale.Crop,
           modifier =
-            Modifier.size(124.dp)
-              .background(color = MaterialTheme.colorScheme.background, shape = CircleShape),
-        )
-      }
+              Modifier.size(124.dp)
+                  .clip(shape = RoundedCornerShape(100.dp))
+                  .background(
+                      color = MaterialTheme.colorScheme.background,
+                      shape = RoundedCornerShape(100.dp),
+                  )
+                  .testTag(CreateProfileScreen.PROFILE_PICTURE)
+                  .clickable {
+                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+                    launcher.launch(pickImageIntent)
+                  }) {
+            GlideImage(
+                model = profileImageUri,
+                contentDescription = "profile picture",
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier.size(124.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.background, shape = CircleShape),
+            )
+          }
 
       // Mandatory fields
       Text(
-        text = "Mandatory",
-        style =
-          TextStyle(
-            fontSize = 20.sp,
-            lineHeight = 20.sp,
-            fontWeight = FontWeight(500),
-            letterSpacing = 0.2.sp,
-          ),
-        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
+          text = "Mandatory",
+          style =
+              TextStyle(
+                  fontSize = 20.sp,
+                  lineHeight = 20.sp,
+                  fontWeight = FontWeight(500),
+                  letterSpacing = 0.2.sp,
+              ),
+          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
       )
       // Email field
       OutlinedTextField(
-        value = email,
-        onValueChange = { email = it },
-        label = { Text("Email") },
-        placeholder = { Text("Enter your email") },
-        modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
+          value = email,
+          onValueChange = { email = it },
+          label = { Text("Email") },
+          placeholder = { Text("Enter your email") },
+          modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
       )
       // Date of birth field
       OutlinedTextField(
-        value = age,
-        onValueChange = { age = it },
-        label = { Text("Date of Birth") },
-        placeholder = { Text("DD/MM/YYYY") },
-        modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
+          value = age,
+          onValueChange = { age = it },
+          label = { Text("Date of Birth") },
+          placeholder = { Text("DD/MM/YYYY") },
+          modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
       )
       // Profile field
       Text(
-        text = "Your profile",
-        style =
-          TextStyle(
-            fontSize = 20.sp,
-            lineHeight = 20.sp,
-            fontWeight = FontWeight(500),
-            letterSpacing = 0.2.sp,
-          ),
-        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
+          text = "Your profile",
+          style =
+              TextStyle(
+                  fontSize = 20.sp,
+                  lineHeight = 20.sp,
+                  fontWeight = FontWeight(500),
+                  letterSpacing = 0.2.sp,
+              ),
+          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
       )
 
       // Name field
       OutlinedTextField(
-        value = name,
-        onValueChange = { name = it },
-        label = { Text("Displayed Name") },
-        placeholder = { Text("Enter your name") },
-        modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
+          value = name,
+          onValueChange = { name = it },
+          label = { Text("Displayed Name") },
+          placeholder = { Text("Enter your name") },
+          modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
       )
       // Description field
       OutlinedTextField(
-        value = description,
-        onValueChange = { description = it },
-        label = { Text("Description") },
-        placeholder = { Text("Enter a description") },
-        modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
+          value = description,
+          onValueChange = { description = it },
+          label = { Text("Description") },
+          placeholder = { Text("Enter a description") },
+          modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
       )
       // Save button
       Button(
-        onClick = {
-          attemptSaveUserData(
-            email = email,
-            name = name,
-            age = age,
-            description = description,
-            profileImageUri = profileImageUri,
-            context = context,
-            userViewModel = userViewModel,
-            userState = userState,
-            navigationActions = navigationActions,
-          )
-        },
-        enabled = true,
-        modifier =
-          Modifier.width(84.dp)
-            .height(40.dp)
-            .testTag(CreateProfileScreen.SAVE_BUTTON)
-            .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
-        colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
+          onClick = {
+            attemptSaveUserData(
+                email = email,
+                name = name,
+                age = age,
+                description = description,
+                profileImageUri = profileImageUri,
+                context = context,
+                userViewModel = userViewModel,
+                userState = userState,
+                navigationActions = navigationActions,
+            )
+          },
+          enabled = true,
+          modifier =
+              Modifier.width(84.dp)
+                  .height(40.dp)
+                  .testTag(CreateProfileScreen.SAVE_BUTTON)
+                  .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
+          colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
       ) {
         Text("Save", color = Color.White)
       }
@@ -222,15 +220,15 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSaveUserData(
-  email: String,
-  name: String,
-  age: String,
-  description: String,
-  profileImageUri: Uri?,
-  context: Context,
-  userViewModel: UserViewModel,
-  userState: State<User?>,
-  navigationActions: NavigationActions,
+    email: String,
+    name: String,
+    age: String,
+    description: String,
+    profileImageUri: Uri?,
+    context: Context,
+    userViewModel: UserViewModel,
+    userState: State<User?>,
+    navigationActions: NavigationActions,
 ) {
   val errorMessage = validateFields(email, name, age, description)
   if (errorMessage != null) {
@@ -241,7 +239,7 @@ private fun attemptSaveUserData(
 
   Log.d(TAG, "Saving user profile")
   val newUser =
-    User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
+      User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
   userViewModel.saveUser(newUser)
   if (userState.value == null) {
     Log.d(TAG, "Failed to save profile")

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -72,134 +72,132 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var description by remember { mutableStateOf("") }
   var profileImageUri by remember {
     mutableStateOf<Uri?>(
-      Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
-    )
+        Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
   }
   val userState = userViewModel.user
   val context = LocalContext.current
 
   val launcher =
-    rememberLauncherForActivityResult(
-      contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-      if (result.resultCode == Activity.RESULT_OK) {
-        profileImageUri = result.data?.data
-      }
-    }
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+              profileImageUri = result.data?.data
+            }
+          }
 
   Scaffold(
-    modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
-    topBar = { TopAppBar(title = SCREEN_TITLE) },
+      modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
+      topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { padding ->
     Column(
-      modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
-      verticalArrangement = Arrangement.spacedBy(16.dp),
-      horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       // Profile picture
       Box(
-        modifier =
-          Modifier.size(124.dp)
-            .clip(shape = RoundedCornerShape(100.dp))
-            .background(
-              color = MaterialTheme.colorScheme.background,
-              shape = RoundedCornerShape(100.dp),
-            )
-            .testTag(CreateProfileScreen.PROFILE_PICTURE)
-            .clickable {
-              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-              launcher.launch(pickImageIntent)
-            }
-      ) {
-        GlideImage(
-          model = profileImageUri,
-          contentDescription = "profile picture",
-          contentScale = ContentScale.Crop,
           modifier =
-            Modifier.size(124.dp)
-              .background(color = MaterialTheme.colorScheme.background, shape = CircleShape),
-        )
-      }
+              Modifier.size(124.dp)
+                  .clip(shape = RoundedCornerShape(100.dp))
+                  .background(
+                      color = MaterialTheme.colorScheme.background,
+                      shape = RoundedCornerShape(100.dp),
+                  )
+                  .testTag(CreateProfileScreen.PROFILE_PICTURE)
+                  .clickable {
+                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+                    launcher.launch(pickImageIntent)
+                  }) {
+            GlideImage(
+                model = profileImageUri,
+                contentDescription = "profile picture",
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier.size(124.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.background, shape = CircleShape),
+            )
+          }
 
       // Mandatory fields
       Text(
-        text = "Mandatory",
-        style =
-          TextStyle(
-            fontSize = 20.sp,
-            lineHeight = 20.sp,
-            fontWeight = FontWeight(500),
-            letterSpacing = 0.2.sp,
-          ),
-        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
+          text = "Mandatory",
+          style =
+              TextStyle(
+                  fontSize = 20.sp,
+                  lineHeight = 20.sp,
+                  fontWeight = FontWeight(500),
+                  letterSpacing = 0.2.sp,
+              ),
+          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
       )
       // Email field
       OutlinedTextField(
-        value = email,
-        onValueChange = { email = it },
-        label = { Text("Email") },
-        placeholder = { Text("Enter your email") },
-        modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
+          value = email,
+          onValueChange = { email = it },
+          label = { Text("Email") },
+          placeholder = { Text("Enter your email") },
+          modifier = Modifier.testTag(CreateProfileScreen.EMAIL_FIELD),
       )
       // Date of birth field
       OutlinedTextField(
-        value = age,
-        onValueChange = { age = it },
-        label = { Text("Date of Birth") },
-        placeholder = { Text("DD/MM/YYYY") },
-        modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
+          value = age,
+          onValueChange = { age = it },
+          label = { Text("Date of Birth") },
+          placeholder = { Text("DD/MM/YYYY") },
+          modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
       )
       // Profile field
       Text(
-        text = "Your profile",
-        style =
-          TextStyle(
-            fontSize = 20.sp,
-            lineHeight = 20.sp,
-            fontWeight = FontWeight(500),
-            letterSpacing = 0.2.sp,
-          ),
-        modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
+          text = "Your profile",
+          style =
+              TextStyle(
+                  fontSize = 20.sp,
+                  lineHeight = 20.sp,
+                  fontWeight = FontWeight(500),
+                  letterSpacing = 0.2.sp,
+              ),
+          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
       )
 
       // Name field
       OutlinedTextField(
-        value = name,
-        onValueChange = { name = it },
-        label = { Text("Displayed Name") },
-        placeholder = { Text("Enter your name") },
-        modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
+          value = name,
+          onValueChange = { name = it },
+          label = { Text("Displayed Name") },
+          placeholder = { Text("Enter your name") },
+          modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
       )
       // Description field
       OutlinedTextField(
-        value = description,
-        onValueChange = { description = it },
-        label = { Text("Description") },
-        placeholder = { Text("Enter a description") },
-        modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
+          value = description,
+          onValueChange = { description = it },
+          label = { Text("Description") },
+          placeholder = { Text("Enter a description") },
+          modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
       )
       // Save button
       Button(
-        onClick = {
-          attemptSaveUserData(
-            email = email,
-            name = name,
-            age = age,
-            description = description,
-            profileImageUri = profileImageUri,
-            context = context,
-            userViewModel = userViewModel,
-            userState = userState,
-            navigationActions = navigationActions,
-          )
-        },
-        enabled = true,
-        modifier =
-          Modifier.width(84.dp)
-            .height(40.dp)
-            .testTag(CreateProfileScreen.SAVE_BUTTON)
-            .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
-        colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
+          onClick = {
+            attemptSaveUserData(
+                email = email,
+                name = name,
+                age = age,
+                description = description,
+                profileImageUri = profileImageUri,
+                context = context,
+                userViewModel = userViewModel,
+                userState = userState,
+                navigationActions = navigationActions,
+            )
+          },
+          enabled = true,
+          modifier =
+              Modifier.width(84.dp)
+                  .height(40.dp)
+                  .testTag(CreateProfileScreen.SAVE_BUTTON)
+                  .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
+          colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
       ) {
         Text("Save", color = Color.White)
       }
@@ -221,15 +219,15 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSaveUserData(
-  email: String,
-  name: String,
-  age: String,
-  description: String,
-  profileImageUri: Uri?,
-  context: Context,
-  userViewModel: UserViewModel,
-  userState: State<User?>,
-  navigationActions: NavigationActions,
+    email: String,
+    name: String,
+    age: String,
+    description: String,
+    profileImageUri: Uri?,
+    context: Context,
+    userViewModel: UserViewModel,
+    userState: State<User?>,
+    navigationActions: NavigationActions,
 ) {
   val errorMessage = validateFields(email, name, age, description)
   if (errorMessage != null) {
@@ -240,7 +238,7 @@ private fun attemptSaveUserData(
 
   Log.d(TAG, "Saving user profile")
   val newUser =
-    User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
+      User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
   userViewModel.saveUser(newUser)
   if (userState.value == null) {
     Log.d(TAG, "Failed to save profile")


### PR DESCRIPTION
# Integrate profile VM into CreateProfile screen
## Description
This PR introduces syncing between our Supabase repository and the Create Profile screen: when users create their profile, it gets saved to the repository and is therefore available for fetching. It closes issue #155 and part of #154.

## Changes
Updated the `onClick` of the "Save" button to call the view model and attempt to save the user to the database. Extracted it to an auxiliary function `attemptSaveUserData`. If not successful, shows toast.

Updated `MainActivity` to initialize the user view model with a Supabase user model, and pass it as parameter to the `CreateProfile` screen.

Added checks for calling (or not) the user view model when the user attempts to save their profile.

Modified the `user: StateFlow` to be a `State` (as was done in `AuthenticationViewModel`). This does not change behavior on the view model side and fixes NPE that was thrown when trying `UserViewModel.user.collectAsState()`. Updated `CreateProfile` and `CreateProfileTest` to account for the changes.

## Files 
#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt`: integrated the user VM into the screen
- `app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt`: changed `user` and `_user` variables from `StateFlow`s to `State`s to fix problem pointed out by the updated tests
- `app/src/main/java/com/android/periodpals/MainActivity.kt`: updated `MainActivity` to initialize the user view model
- `app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt`: updated the tests
#### Removed
None
## Dependencies Added
None

## Testing
Updated androidTests to check for calls (or lack thereof) to the VM depending on input validity, and for behavior when VM succeeds or fails.