### PR TITLE
Feat/profile/shared components

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -1,6 +1,7 @@
 package com.android.periodpals.ui.profile
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -12,7 +13,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
-import com.android.periodpals.resources.C.Tag.CreateProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.CreateProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
@@ -58,13 +60,18 @@ class CreateProfileTest {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.MANDATORY_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.PROFILE_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.MANDATORY_SECTION).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.SAVE_BUTTON)
+        .assertIsDisplayed()
+        .assertIsDisplayed()
+        .assertTextEquals("Save")
+        .assertHasClickAction()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
@@ -81,7 +88,7 @@ class CreateProfileTest {
   fun testValidDateRecognition() {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("01/01/2000")
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/2000")
     assertTrue(validateDate("01/01/2000"))
     assertTrue(validateDate("31/12/1999"))
   }
@@ -90,7 +97,7 @@ class CreateProfileTest {
   fun testInvalidDateRecognition() {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput("invalid_date")
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("invalid_date")
     assertFalse(validateDate("32/01/2000")) // Invalid day
     assertFalse(validateDate("01/13/2000")) // Invalid month
     assertFalse(validateDate("01/01/abcd")) // Invalid year
@@ -104,11 +111,11 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
 
@@ -122,11 +129,11 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
 
@@ -140,9 +147,9 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
     verify(userViewModel, never()).saveUser(any())
 
@@ -156,12 +163,12 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())
 
@@ -174,12 +181,12 @@ class CreateProfileTest {
 
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(CreateProfileScreen.DOB_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.NAME_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
     composeTestRule
-        .onNodeWithTag(CreateProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(CreateProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
     verify(userViewModel).saveUser(any())
 

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -1,3 +1,4 @@
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -8,7 +9,8 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
-import com.android.periodpals.resources.C.Tag.EditProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
@@ -40,17 +42,18 @@ class EditProfileTest {
   @Test
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.EDIT_ICON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.MANDATORY_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.YOUR_PROFILE_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(EditProfileScreen.EDIT_PROFILE_PICTURE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.MANDATORY_SECTION).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(EditProfileScreen.SAVE_BUTTON)
+        .onNodeWithTag(ProfileScreens.SAVE_BUTTON)
         .assertIsDisplayed()
         .assertTextEquals("Save")
+        .assertHasClickAction()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
@@ -63,61 +66,61 @@ class EditProfileTest {
 
   @Test
   fun editValidProfile() {
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
     composeTestRule
-        .onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(EditProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 
   @Test
   fun editInvalidProfileNoName() {
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
     composeTestRule
-        .onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(EditProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileNoDOB() {
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
     composeTestRule
-        .onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD)
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(EditProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileNoDescription() {
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextInput("01/01/1990")
-    composeTestRule.onNodeWithTag(EditProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileAllEmptyFields() {
-    composeTestRule.onNodeWithTag(EditProfileScreen.NAME_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DOB_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.DESCRIPTION_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(EditProfileScreen.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -7,7 +7,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
-import com.android.periodpals.resources.C.Tag.ProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
@@ -34,7 +35,7 @@ class ProfileScreenTest {
   @Test
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.PROFILE_PICTURE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
     composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(ProfileScreen.CONTRIBUTION_FIELD).assertIsDisplayed()

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -11,7 +11,7 @@ object C {
 
     /** Constants for tagging UI components in the CreateAlertScreen. */
     object CreateAlertScreen {
-      const val SCREEN = "screen"
+      const val SCREEN = "creatAlertScreen"
       const val INSTRUCTION_TEXT = "instructionText"
       const val PRODUCT_FIELD = "productField"
       const val URGENCY_FIELD = "urgencyField"
@@ -23,7 +23,7 @@ object C {
 
     /** Constants for tagging UI components in the AlertListsScreen. */
     object AlertListsScreen {
-      const val SCREEN = "screen"
+      const val SCREEN = "alertListScreen"
       const val TAB_ROW = "tabRow"
       const val MY_ALERTS_TAB = "myAlertsTab"
       const val PALS_ALERTS_TAB = "palsAlertsTab"
@@ -44,7 +44,7 @@ object C {
     object AuthenticationScreens {
       /** Constants for tagging UI components in the SignInScreen. */
       object SignInScreen {
-        const val SCREEN = "screen"
+        const val SCREEN = "signInScreen"
         const val INSTRUCTION_TEXT = "instructionText"
         const val SIGN_IN_BUTTON = "signInButton"
         const val CONTINUE_WITH_TEXT = "continueWith"
@@ -54,7 +54,7 @@ object C {
 
       /** Constants for tagging UI components in the SignUpScreen. */
       object SignUpScreen {
-        const val SCREEN = "screen"
+        const val SCREEN = "signUpScreen"
         const val INSTRUCTION_TEXT = "instructionText"
         const val CONFIRM_PASSWORD_TEXT = "confirmText"
         const val CONFIRM_PASSWORD_FIELD = "confirmPasswordField"
@@ -67,7 +67,7 @@ object C {
       const val PASSWORD_ERROR_TEXT = "passwordErrorText"
       const val EMAIL_ERROR_TEXT = "emailErrorText"
       const val BACKGROUND = "background"
-      const val WELCOME_TEXT = "titleText"
+      const val WELCOME_TEXT = "welcomeText"
       const val EMAIL_FIELD = "emailField"
       const val PASSWORD_FIELD = "passwordField"
       const val PASSWORD_VISIBILITY_BUTTON = "passwordVisibilityButton"
@@ -75,7 +75,7 @@ object C {
 
     /** Constants for tagging UI components in the MapScreen. */
     object MapScreen {
-      const val SCREEN = "screen"
+      const val SCREEN = "mapScreen"
     }
 
     /** Constants for tagging UI components in the BottomNavigationMenu. */
@@ -92,49 +92,46 @@ object C {
       const val TITLE_TEXT = "titleText"
     }
 
-    /** Constants for tagging UI components in the CreateProfileScreen. */
-    object CreateProfileScreen {
-      const val SCREEN = "screen"
-      const val PROFILE_PICTURE = "profilePicture"
-      const val MANDATORY_TEXT = "mandatoryText"
-      const val DOB_FIELD = "dobField"
-      const val PROFILE_TEXT = "profileText"
-      const val NAME_FIELD = "nameField"
-      const val DESCRIPTION_FIELD = "descriptionField"
-      const val SAVE_BUTTON = "saveButton"
-    }
+    /** Constants for tagging UI components in the profile screens. */
+    object ProfileScreens {
+      /** Constants for tagging UI components in the CreateProfileScreen. */
+      object CreateProfileScreen {
+        const val SCREEN = "createProfileScreen"
+      }
 
-    /** Constants for tagging UI components in the EditProfileScreen. */
-    object EditProfileScreen {
-      const val SCREEN = "screen"
+      /** Constants for tagging UI components in the EditProfileScreen. */
+      object EditProfileScreen {
+        const val SCREEN = "editProfileScreen"
+        const val EDIT_PROFILE_PICTURE = "editProfilePicture"
+      }
+
+      /** Constants for tagging UI components in the ProfileScreen. */
+      object ProfileScreen {
+        const val SCREEN = "profileScreen"
+        const val NAME_FIELD = "nameField"
+        const val DESCRIPTION_FIELD = "descriptionField"
+        const val CONTRIBUTION_FIELD = "contributionField"
+        const val REVIEWS_SECTION = "reviewsSection"
+        const val REVIEW_ONE = "reviewOne"
+        const val REVIEW_TWO = "reviewTwo"
+        const val NO_REVIEWS_ICON = "noReviewsIcon"
+        const val NO_REVIEWS_TEXT = "noReviewsText"
+        const val NO_REVIEWS_CARD = "noReviewsCard"
+      }
+
+      // Shared profile components
       const val PROFILE_PICTURE = "profilePicture"
-      const val EDIT_ICON = "editIcon"
       const val MANDATORY_SECTION = "mandatorySection"
-      const val NAME_FIELD = "nameField"
-      const val DOB_FIELD = "dobField"
       const val YOUR_PROFILE_SECTION = "yourProfileSection"
-      const val DESCRIPTION_FIELD = "descriptionField"
+      const val NAME_INPUT_FIELD = "nameInputField"
+      const val DOB_INPUT_FIELD = "dobInputField"
+      const val DESCRIPTION_INPUT_FIELD = "descriptionInputField"
       const val SAVE_BUTTON = "saveButton"
-    }
-
-    /** Constants for tagging UI components in the ProfileScreen. */
-    object ProfileScreen {
-      const val SCREEN = "screen"
-      const val PROFILE_PICTURE = "profilePicture"
-      const val NAME_FIELD = "nameField"
-      const val DESCRIPTION_FIELD = "descriptionField"
-      const val CONTRIBUTION_FIELD = "contributionField"
-      const val REVIEWS_SECTION = "reviewsSection"
-      const val REVIEW_ONE = "reviewOne"
-      const val REVIEW_TWO = "reviewTwo"
-      const val NO_REVIEWS_ICON = "noReviewsIcon"
-      const val NO_REVIEWS_TEXT = "noReviewsText"
-      const val NO_REVIEWS_CARD = "noReviewsCard"
     }
 
     /** Constants for tagging UI components in the TimerScreen. */
     object TimerScreen {
-      const val SCREEN = "screen"
+      const val SCREEN = "timerScreen"
       const val TIMER_TEXT = "timerText"
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -70,7 +70,8 @@ fun ProfileSection(text: String, testTag: String) {
       text = text,
       textAlign = TextAlign.Start,
       style =
-          MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Medium))
+          MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Medium),
+  )
 }
 
 /**
@@ -83,9 +84,27 @@ fun ProfileSection(text: String, testTag: String) {
 @Composable
 fun ProfileInputName(name: String, onValueChange: (String) -> Unit, testTag: String) {
   OutlinedTextField(
+      modifier = Modifier.testTag(testTag),
       value = name,
       onValueChange = onValueChange,
       label = { Text(NAME_LABEL) },
       placeholder = { Text(NAME_PLACEHOLDER) },
+  )
+}
+
+/**
+ * A composable function that displays an outlined text field for the date of birth input.
+ *
+ * @param dob The current value of the date of birth input.
+ * @param onValueChange A lambda function to handle changes to the date of birth input.
+ * @param testTag A tag used for testing purposes.
+ */
+@Composable
+fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit, testTag: String) {
+  OutlinedTextField(
+      value = dob,
+      onValueChange = onValueChange,
+      label = { Text(DOB_LABEL) },
+      placeholder = { Text(DOB_PLACEHOLDER) },
       modifier = Modifier.testTag(testTag))
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -44,20 +44,16 @@ const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
  */
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
-fun ProfilePicture(
-    profileImageUri: Uri?,
-    onClick: (() -> Unit)? = null,
-    testTag: String
-) {
-    GlideImage(
-        model = profileImageUri,
-        contentDescription = "profile picture",
-        modifier = Modifier
-            .size(190.dp)
-            .clip(shape = CircleShape)
-            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-            .testTag(testTag),
-    )
+fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null, testTag: String) {
+  GlideImage(
+      model = profileImageUri,
+      contentDescription = "profile picture",
+      modifier =
+          Modifier.size(190.dp)
+              .clip(shape = CircleShape)
+              .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+              .testTag(testTag),
+  )
 }
 /**
  * A composable that displays an instruction text with [text] and [testTag] for testing purposes.

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -56,8 +56,7 @@ fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null) {
           Modifier.size(190.dp)
               .clip(shape = CircleShape)
               .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-              .testTag(ProfileScreens.PROFILE_PICTURE)
-  )
+              .testTag(ProfileScreens.PROFILE_PICTURE))
 }
 
 /**
@@ -90,8 +89,7 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
       value = name,
       onValueChange = onValueChange,
       label = { Text(NAME_LABEL) },
-      placeholder = { Text(NAME_PLACEHOLDER) }
-  )
+      placeholder = { Text(NAME_PLACEHOLDER) })
 }
 
 /**
@@ -124,8 +122,7 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
       label = { Text(DESCRIPTION_LABEL) },
       placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
       minLines = 3,
-      modifier = Modifier.testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-  )
+      modifier = Modifier.testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD))
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -4,7 +4,9 @@ import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -23,12 +25,12 @@ import com.bumptech.glide.integration.compose.GlideImage
 const val MANDATORY_TEXT = "Mandatory"
 private const val NAME_LABEL = "Name"
 private const val NAME_PLACEHOLDER = "Enter your name"
-const val DOB_LABEL = "Date of Birth"
-const val DOB_PLACEHOLDER = "DD/MM/YYYY"
+private const val DOB_LABEL = "Date of Birth"
+private const val DOB_PLACEHOLDER = "DD/MM/YYYY"
 const val PROFILE_TEXT = "Your Profile"
-const val DESCRIPTION_LABEL = "Description"
-const val DESCRIPTION_PLACEHOLDER = "Describe yourself"
-const val SAVE_BUTTON_TEXT = "Save"
+private const val DESCRIPTION_LABEL = "Description"
+private const val DESCRIPTION_PLACEHOLDER = "Describe yourself"
+private const val SAVE_BUTTON_TEXT = "Save"
 const val LOG_TAG = "CreateProfileScreen"
 const val LOG_FAILURE = "Failed to save profile"
 const val LOG_SAVING_PROFILE = "Saving user profile"
@@ -126,4 +128,15 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
       minLines = 3,
       modifier = Modifier.testTag(testTag),
   )
+}
+
+@Composable
+fun ProfileSaveButton(onClick: () -> Unit, testTag: String) {
+  Button(
+      onClick = onClick,
+      enabled = true,
+      modifier = Modifier.wrapContentSize().testTag(testTag),
+  ) {
+    Text(SAVE_BUTTON_TEXT)
+  }
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -1,14 +1,22 @@
 package com.android.periodpals.ui.components
 
+import android.net.Uri
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 
 /** Shared constants for the profile screen. */
 const val MANDATORY_TEXT = "Mandatory"
@@ -30,6 +38,27 @@ const val ERROR_INVALID_DATE = "Invalid date"
 const val ERROR_INVALID_NAME = "Please enter a name"
 const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
 
+/**
+ * A composable that displays a profile picture with [profileImageUri] and [testTag] for testing
+ * purposes.
+ */
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun ProfilePicture(
+    profileImageUri: Uri?,
+    onClick: (() -> Unit)? = null,
+    testTag: String
+) {
+    GlideImage(
+        model = profileImageUri,
+        contentDescription = "profile picture",
+        modifier = Modifier
+            .size(190.dp)
+            .clip(shape = CircleShape)
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+            .testTag(testTag),
+    )
+}
 /**
  * A composable that displays an instruction text with [text] and [testTag] for testing purposes.
  */

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 
@@ -47,7 +48,7 @@ const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
  */
 @OptIn(ExperimentalGlideComposeApi::class)
 @Composable
-fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null, testTag: String) {
+fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null) {
   GlideImage(
       model = profileImageUri,
       contentDescription = "profile picture",
@@ -55,7 +56,7 @@ fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null, testTag
           Modifier.size(190.dp)
               .clip(shape = CircleShape)
               .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-              .testTag(testTag),
+              .testTag(ProfileScreens.PROFILE_PICTURE)
   )
 }
 
@@ -81,16 +82,15 @@ fun ProfileSection(text: String, testTag: String) {
  *
  * @param name The current value of the name input.
  * @param onValueChange A lambda function to handle changes to the name input.
- * @param testTag A tag used for testing purposes.
  */
 @Composable
-fun ProfileInputName(name: String, onValueChange: (String) -> Unit, testTag: String) {
+fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
   OutlinedTextField(
-      modifier = Modifier.testTag(testTag),
+      modifier = Modifier.testTag(ProfileScreens.NAME_INPUT_FIELD),
       value = name,
       onValueChange = onValueChange,
       label = { Text(NAME_LABEL) },
-      placeholder = { Text(NAME_PLACEHOLDER) },
+      placeholder = { Text(NAME_PLACEHOLDER) }
   )
 }
 
@@ -99,16 +99,15 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit, testTag: Str
  *
  * @param dob The current value of the date of birth input.
  * @param onValueChange A lambda function to handle changes to the date of birth input.
- * @param testTag A tag used for testing purposes.
  */
 @Composable
-fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit, testTag: String) {
+fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
   OutlinedTextField(
       value = dob,
       onValueChange = onValueChange,
       label = { Text(DOB_LABEL) },
       placeholder = { Text(DOB_PLACEHOLDER) },
-      modifier = Modifier.testTag(testTag))
+      modifier = Modifier.testTag(ProfileScreens.DOB_INPUT_FIELD))
 }
 
 /**
@@ -116,26 +115,31 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit, testTag: Strin
  *
  * @param description The current value of the description input.
  * @param onValueChange A lambda function to handle changes to the description input.
- * @param testTag A tag used for testing purposes.
  */
 @Composable
-fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit, testTag: String) {
+fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit) {
   OutlinedTextField(
       value = description,
       onValueChange = onValueChange,
       label = { Text(DESCRIPTION_LABEL) },
       placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
       minLines = 3,
-      modifier = Modifier.testTag(testTag),
+      modifier = Modifier.testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
   )
 }
 
+/**
+ * A composable function that displays a save button with [onClick] as the action to be executed
+ * when the button is clicked.
+ *
+ * @param onClick The action to be executed when the button is clicked.
+ */
 @Composable
-fun ProfileSaveButton(onClick: () -> Unit, testTag: String) {
+fun ProfileSaveButton(onClick: () -> Unit) {
   Button(
       onClick = onClick,
       enabled = true,
-      modifier = Modifier.wrapContentSize().testTag(testTag),
+      modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
   ) {
     Text(SAVE_BUTTON_TEXT)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -108,3 +108,22 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit, testTag: Strin
       placeholder = { Text(DOB_PLACEHOLDER) },
       modifier = Modifier.testTag(testTag))
 }
+
+/**
+ * A composable function that displays an outlined text field for the description input.
+ *
+ * @param description The current value of the description input.
+ * @param onValueChange A lambda function to handle changes to the description input.
+ * @param testTag A tag used for testing purposes.
+ */
+@Composable
+fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit, testTag: String) {
+  OutlinedTextField(
+      value = description,
+      onValueChange = onValueChange,
+      label = { Text(DESCRIPTION_LABEL) },
+      placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
+      minLines = 3,
+      modifier = Modifier.testTag(testTag),
+  )
+}

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -20,8 +21,8 @@ import com.bumptech.glide.integration.compose.GlideImage
 
 /** Shared constants for the profile screen. */
 const val MANDATORY_TEXT = "Mandatory"
-const val NAME_LABEL = "Name"
-const val NAME_PLACEHOLDER = "Enter your name"
+private const val NAME_LABEL = "Name"
+private const val NAME_PLACEHOLDER = "Enter your name"
 const val DOB_LABEL = "Date of Birth"
 const val DOB_PLACEHOLDER = "DD/MM/YYYY"
 const val PROFILE_TEXT = "Your Profile"
@@ -55,8 +56,12 @@ fun ProfilePicture(profileImageUri: Uri?, onClick: (() -> Unit)? = null, testTag
               .testTag(testTag),
   )
 }
+
 /**
- * A composable that displays an instruction text with [text] and [testTag] for testing purposes.
+ * A composable function that displays a section's text in the profile screen.
+ *
+ * @param text The section's text to be displayed.
+ * @param testTag A tag used for testing purposes.
  */
 @Composable
 fun ProfileSection(text: String, testTag: String) {
@@ -66,4 +71,21 @@ fun ProfileSection(text: String, testTag: String) {
       textAlign = TextAlign.Start,
       style =
           MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Medium))
+}
+
+/**
+ * A composable function that displays an outlined text field for the name input.
+ *
+ * @param name The current value of the name input.
+ * @param onValueChange A lambda function to handle changes to the name input.
+ * @param testTag A tag used for testing purposes.
+ */
+@Composable
+fun ProfileInputName(name: String, onValueChange: (String) -> Unit, testTag: String) {
+  OutlinedTextField(
+      value = name,
+      onValueChange = onValueChange,
+      label = { Text(NAME_LABEL) },
+      placeholder = { Text(NAME_PLACEHOLDER) },
+      modifier = Modifier.testTag(testTag))
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -9,17 +9,11 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
@@ -28,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -49,8 +42,8 @@ import com.android.periodpals.ui.components.ProfileInputDescription
 import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
+import com.android.periodpals.ui.components.ProfileSaveButton
 import com.android.periodpals.ui.components.ProfileSection
-import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
 import com.android.periodpals.ui.components.TOAST_FAILURE
 import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -139,7 +132,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       )
 
       // Save button
-      Button(
+      ProfileSaveButton(
           onClick = {
             attemptSaveUserData(
                 name = name,
@@ -152,15 +145,8 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
                 navigationActions = navigationActions,
             )
           },
-          enabled = true,
-          modifier =
-              Modifier.wrapContentSize()
-                  .testTag(CreateProfileScreen.SAVE_BUTTON)
-                  .background(color = Color(0xFF65558F), shape = RoundedCornerShape(size = 100.dp)),
-          colors = ButtonDefaults.buttonColors(Color(0xFF65558F)),
-      ) {
-        Text(SAVE_BUTTON_TEXT, color = Color.White)
-      }
+          testTag = CreateProfileScreen.SAVE_BUTTON,
+      )
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -43,8 +43,6 @@ import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.CreateProfileScreen
 import com.android.periodpals.ui.components.DESCRIPTION_LABEL
 import com.android.periodpals.ui.components.DESCRIPTION_PLACEHOLDER
-import com.android.periodpals.ui.components.DOB_LABEL
-import com.android.periodpals.ui.components.DOB_PLACEHOLDER
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
@@ -54,6 +52,7 @@ import com.android.periodpals.ui.components.LOG_SUCCESS
 import com.android.periodpals.ui.components.LOG_TAG
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
@@ -126,12 +125,10 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       )
 
       // Date of birth field
-      OutlinedTextField(
-          value = age,
+      ProfileInputDob(
+          dob = age,
           onValueChange = { age = it },
-          label = { Text(DOB_LABEL) },
-          placeholder = { Text(DOB_PLACEHOLDER) },
-          modifier = Modifier.testTag(CreateProfileScreen.DOB_FIELD),
+          testTag = CreateProfileScreen.DOB_FIELD,
       )
 
       // Profile field

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -31,10 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.android.periodpals.R
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
@@ -128,17 +125,10 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
           testTag = CreateProfileScreen.DOB_FIELD,
       )
 
-      // Profile field
-      Text(
+      // Your profile section
+      ProfileSection(
           text = PROFILE_TEXT,
-          style =
-              TextStyle(
-                  fontSize = 20.sp,
-                  lineHeight = 20.sp,
-                  fontWeight = FontWeight(500),
-                  letterSpacing = 0.2.sp,
-              ),
-          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.PROFILE_TEXT),
+          testTag = CreateProfileScreen.PROFILE_TEXT,
       )
 
       // Description field

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -13,13 +13,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,8 +39,6 @@ import com.android.periodpals.R
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.CreateProfileScreen
-import com.android.periodpals.ui.components.DESCRIPTION_LABEL
-import com.android.periodpals.ui.components.DESCRIPTION_PLACEHOLDER
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
@@ -52,6 +48,7 @@ import com.android.periodpals.ui.components.LOG_SUCCESS
 import com.android.periodpals.ui.components.LOG_TAG
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputDescription
 import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
@@ -145,12 +142,10 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       )
 
       // Description field
-      OutlinedTextField(
-          value = description,
+      ProfileInputDescription(
+          description = description,
           onValueChange = { description = it },
-          label = { Text(DESCRIPTION_LABEL) },
-          placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
-          modifier = Modifier.height(124.dp).testTag(CreateProfileScreen.DESCRIPTION_FIELD),
+          testTag = CreateProfileScreen.DESCRIPTION_FIELD,
       )
 
       // Save button

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -10,15 +10,12 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -33,9 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
@@ -69,7 +64,6 @@ import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
 
 private const val SCREEN_TITLE = "Create Your Account"
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -61,6 +61,7 @@ import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.NAME_LABEL
 import com.android.periodpals.ui.components.NAME_PLACEHOLDER
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
 import com.android.periodpals.ui.components.TOAST_FAILURE
 import com.android.periodpals.ui.components.TOAST_SUCCESS
@@ -108,18 +109,14 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       // Profile picture
-      GlideImage(
-          model = profileImageUri,
-          contentDescription = "profile picture",
-          contentScale = ContentScale.Crop,
-          modifier =
-              Modifier.size(190.dp)
-                  .clip(shape = CircleShape)
-                  .testTag(CreateProfileScreen.PROFILE_PICTURE)
-                  .clickable {
-                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                    launcher.launch(pickImageIntent)
-                  })
+      ProfilePicture(
+          profileImageUri = profileImageUri,
+          onClick = {
+            val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+            launcher.launch(pickImageIntent)
+          },
+          testTag = CreateProfileScreen.PROFILE_PICTURE,
+      )
 
       // Mandatory fields
       Text(

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -28,7 +28,8 @@ import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
-import com.android.periodpals.resources.C.Tag.CreateProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.CreateProfileScreen
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
@@ -95,41 +96,28 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
             val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
             launcher.launch(pickImageIntent)
           },
-          testTag = CreateProfileScreen.PROFILE_PICTURE,
       )
 
-      // Mandatory fields
+      // Mandatory section title
       ProfileSection(
           text = MANDATORY_TEXT,
-          testTag = CreateProfileScreen.MANDATORY_TEXT,
+          testTag = ProfileScreens.MANDATORY_SECTION,
       )
 
       // Name field
-      ProfileInputName(
-          name = name,
-          onValueChange = { name = it },
-          testTag = CreateProfileScreen.NAME_FIELD,
-      )
+      ProfileInputName(name = name, onValueChange = { name = it })
 
       // Date of birth field
-      ProfileInputDob(
-          dob = age,
-          onValueChange = { age = it },
-          testTag = CreateProfileScreen.DOB_FIELD,
-      )
+      ProfileInputDob(dob = age, onValueChange = { age = it })
 
-      // Your profile section
+      // Your profile section title
       ProfileSection(
           text = PROFILE_TEXT,
-          testTag = CreateProfileScreen.PROFILE_TEXT,
+          testTag = ProfileScreens.YOUR_PROFILE_SECTION,
       )
 
       // Description field
-      ProfileInputDescription(
-          description = description,
-          onValueChange = { description = it },
-          testTag = CreateProfileScreen.DESCRIPTION_FIELD,
-      )
+      ProfileInputDescription(description = description, onValueChange = { description = it })
 
       // Save button
       ProfileSaveButton(
@@ -145,7 +133,6 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
                 navigationActions = navigationActions,
             )
           },
-          testTag = CreateProfileScreen.SAVE_BUTTON,
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -53,10 +53,10 @@ import com.android.periodpals.ui.components.LOG_SAVING_PROFILE
 import com.android.periodpals.ui.components.LOG_SUCCESS
 import com.android.periodpals.ui.components.LOG_TAG
 import com.android.periodpals.ui.components.MANDATORY_TEXT
-import com.android.periodpals.ui.components.NAME_LABEL
-import com.android.periodpals.ui.components.NAME_PLACEHOLDER
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
+import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
 import com.android.periodpals.ui.components.TOAST_FAILURE
 import com.android.periodpals.ui.components.TOAST_SUCCESS
@@ -113,24 +113,16 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       )
 
       // Mandatory fields
-      Text(
+      ProfileSection(
           text = MANDATORY_TEXT,
-          style =
-              TextStyle(
-                  fontSize = 20.sp,
-                  lineHeight = 20.sp,
-                  fontWeight = FontWeight(500),
-                  letterSpacing = 0.2.sp,
-              ),
-          modifier = Modifier.align(Alignment.Start).testTag(CreateProfileScreen.MANDATORY_TEXT),
+          testTag = CreateProfileScreen.MANDATORY_TEXT,
       )
+
       // Name field
-      OutlinedTextField(
-          value = name,
+      ProfileInputName(
+          name = name,
           onValueChange = { name = it },
-          label = { Text(NAME_LABEL) },
-          placeholder = { Text(NAME_PLACEHOLDER) },
-          modifier = Modifier.testTag(CreateProfileScreen.NAME_FIELD),
+          testTag = CreateProfileScreen.NAME_FIELD,
       )
 
       // Date of birth field

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -30,12 +30,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
-import com.android.periodpals.resources.C.Tag.CreateProfileScreen.PROFILE_TEXT
 import com.android.periodpals.resources.C.Tag.EditProfileScreen
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
 import com.android.periodpals.ui.components.MANDATORY_TEXT
+import com.android.periodpals.ui.components.PROFILE_TEXT
 import com.android.periodpals.ui.components.ProfileInputDescription
 import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -44,9 +44,8 @@ import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
 import com.android.periodpals.ui.components.MANDATORY_TEXT
-import com.android.periodpals.ui.components.NAME_LABEL
-import com.android.periodpals.ui.components.NAME_PLACEHOLDER
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
@@ -133,12 +132,10 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
           ProfileSection(MANDATORY_TEXT, EditProfileScreen.MANDATORY_SECTION)
 
           // Name input field
-          OutlinedTextField(
-              value = name,
+          ProfileInputName(
+              name = name,
               onValueChange = { name = it },
-              label = { Text(NAME_LABEL) },
-              placeholder = { Text(NAME_PLACEHOLDER) },
-              modifier = Modifier.testTag(EditProfileScreen.NAME_FIELD).fillMaxWidth(),
+              testTag = EditProfileScreen.NAME_FIELD,
           )
 
           // Date of Birth input field

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -140,7 +140,7 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
               testTag = EditProfileScreen.DOB_FIELD,
           )
 
-          // Section title
+          // Your profile section
           ProfileSection(PROFILE_TEXT, EditProfileScreen.YOUR_PROFILE_SECTION)
 
           // Description input field

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -50,6 +50,7 @@ import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.NAME_LABEL
 import com.android.periodpals.ui.components.NAME_PLACEHOLDER
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
 import com.android.periodpals.ui.components.TOAST_SUCCESS
@@ -105,14 +106,13 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
         ) {
           // Profile image and its edit icon
           Box(modifier = Modifier.size(190.dp)) {
-            GlideImage(
-                model = profileImageUri,
-                contentDescription = "profile picture",
-                contentScale = ContentScale.Crop,
-                modifier =
-                    Modifier.size(190.dp)
-                        .clip(shape = CircleShape)
-                        .testTag(EditProfileScreen.PROFILE_PICTURE),
+            ProfilePicture(
+                profileImageUri,
+                onClick = {
+                  val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+                  launcher.launch(pickImageIntent)
+                },
+                testTag = EditProfileScreen.PROFILE_PICTURE,
             )
 
             IconButton(

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Button
@@ -20,7 +19,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,13 +33,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.EditProfileScreen
-import com.android.periodpals.ui.components.DESCRIPTION_LABEL
-import com.android.periodpals.ui.components.DESCRIPTION_PLACEHOLDER
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputDescription
 import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
@@ -147,13 +144,10 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
           ProfileSection(PROFILE_TEXT, EditProfileScreen.YOUR_PROFILE_SECTION)
 
           // Description input field
-          OutlinedTextField(
-              value = description,
+          ProfileInputDescription(
+              description = description,
               onValueChange = { description = it },
-              label = { Text(DESCRIPTION_LABEL) },
-              placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
-              minLines = 3,
-              modifier = Modifier.wrapContentHeight().testTag(EditProfileScreen.DESCRIPTION_FIELD),
+              testTag = EditProfileScreen.DESCRIPTION_FIELD,
           )
 
           // Save Changes button

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -14,13 +14,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,18 +30,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
+import com.android.periodpals.resources.C.Tag.CreateProfileScreen.PROFILE_TEXT
 import com.android.periodpals.resources.C.Tag.EditProfileScreen
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
 import com.android.periodpals.ui.components.MANDATORY_TEXT
-import com.android.periodpals.ui.components.PROFILE_TEXT
 import com.android.periodpals.ui.components.ProfileInputDescription
 import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
+import com.android.periodpals.ui.components.ProfileSaveButton
 import com.android.periodpals.ui.components.ProfileSection
-import com.android.periodpals.ui.components.SAVE_BUTTON_TEXT
 import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
@@ -151,25 +149,19 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
           )
 
           // Save Changes button
-          Button(
+          ProfileSaveButton(
               onClick = {
                 val errorMessage = validateFields(name, dob, description)
                 if (errorMessage != null) {
                   Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
                 } else {
-                  // Save the profile (future implementation)
+                  // TODO: Save the profile (future implementation)
                   Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
                   navigationActions.navigateTo(Screen.PROFILE)
                 }
               },
-              enabled = true,
-              modifier =
-                  Modifier.padding(1.dp)
-                      .testTag(EditProfileScreen.SAVE_BUTTON)
-                      .align(Alignment.CenterHorizontally),
-          ) {
-            Text(SAVE_BUTTON_TEXT)
-          }
+              testTag = EditProfileScreen.SAVE_BUTTON,
+          )
         }
       })
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -38,13 +37,12 @@ import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.EditProfileScreen
 import com.android.periodpals.ui.components.DESCRIPTION_LABEL
 import com.android.periodpals.ui.components.DESCRIPTION_PLACEHOLDER
-import com.android.periodpals.ui.components.DOB_LABEL
-import com.android.periodpals.ui.components.DOB_PLACEHOLDER
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
+import com.android.periodpals.ui.components.ProfileInputDob
 import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
@@ -139,12 +137,10 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
           )
 
           // Date of Birth input field
-          OutlinedTextField(
-              value = dob,
+          ProfileInputDob(
+              dob = dob,
               onValueChange = { dob = it },
-              label = { Text(DOB_LABEL) },
-              placeholder = { Text(DOB_PLACEHOLDER) },
-              modifier = Modifier.testTag(EditProfileScreen.DOB_FIELD).fillMaxWidth(),
+              testTag = EditProfileScreen.DOB_FIELD,
           )
 
           // Section title

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -30,7 +30,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
-import com.android.periodpals.resources.C.Tag.EditProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
@@ -94,10 +95,7 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
         ) {
           // Profile image and its edit icon
           Box(modifier = Modifier.size(190.dp)) {
-            ProfilePicture(
-                profileImageUri,
-                testTag = EditProfileScreen.PROFILE_PICTURE,
-            )
+            ProfilePicture(profileImageUri)
 
             IconButton(
                 onClick = {
@@ -112,7 +110,7 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
                 modifier =
                     Modifier.align(Alignment.TopEnd)
                         .size(40.dp)
-                        .testTag(EditProfileScreen.EDIT_ICON),
+                        .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
             ) {
               Icon(
                   imageVector = Icons.Outlined.Edit,
@@ -121,32 +119,20 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
             }
           }
 
-          // Section title
-          ProfileSection(MANDATORY_TEXT, EditProfileScreen.MANDATORY_SECTION)
+          // Mandatory section title
+          ProfileSection(MANDATORY_TEXT, ProfileScreens.MANDATORY_SECTION)
 
           // Name input field
-          ProfileInputName(
-              name = name,
-              onValueChange = { name = it },
-              testTag = EditProfileScreen.NAME_FIELD,
-          )
+          ProfileInputName(name = name, onValueChange = { name = it })
 
           // Date of Birth input field
-          ProfileInputDob(
-              dob = dob,
-              onValueChange = { dob = it },
-              testTag = EditProfileScreen.DOB_FIELD,
-          )
+          ProfileInputDob(dob = dob, onValueChange = { dob = it })
 
-          // Your profile section
-          ProfileSection(PROFILE_TEXT, EditProfileScreen.YOUR_PROFILE_SECTION)
+          // Your profile section title
+          ProfileSection(PROFILE_TEXT, ProfileScreens.YOUR_PROFILE_SECTION)
 
           // Description input field
-          ProfileInputDescription(
-              description = description,
-              onValueChange = { description = it },
-              testTag = EditProfileScreen.DESCRIPTION_FIELD,
-          )
+          ProfileInputDescription(description = description, onValueChange = { description = it })
 
           // Save Changes button
           ProfileSaveButton(
@@ -160,7 +146,6 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
                   navigationActions.navigateTo(Screen.PROFILE)
                 }
               },
-              testTag = EditProfileScreen.SAVE_BUTTON,
           )
         }
       })

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Button
@@ -32,8 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -58,7 +55,6 @@ import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
 
 private const val SCREEN_TITLE = "Edit Your Profile"
 
@@ -108,10 +104,6 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
           Box(modifier = Modifier.size(190.dp)) {
             ProfilePicture(
                 profileImageUri,
-                onClick = {
-                  val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                  launcher.launch(pickImageIntent)
-                },
                 testTag = EditProfileScreen.PROFILE_PICTURE,
             )
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.ProfileScreen
+import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -82,14 +83,9 @@ fun ProfileScreen(navigationActions: NavigationActions) {
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
     ) {
       // Profile picture
-      GlideImage(
-          model = profileImageUri,
-          contentDescription = "profile picture",
-          contentScale = ContentScale.Crop,
-          modifier =
-              Modifier.size(190.dp)
-                  .clip(shape = CircleShape)
-                  .testTag(ProfileScreen.PROFILE_PICTURE),
+      ProfilePicture(
+          profileImageUri = profileImageUri,
+          testTag = ProfileScreen.PROFILE_PICTURE,
       )
 
       // Name

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
 import androidx.compose.material3.Card
@@ -22,8 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -38,7 +34,6 @@ import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
 
 private const val SCREEN_TITLE = "Your Profile"
 private const val DESCRIPTION = // TODO: to be deleted when VM of profile implemented

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.periodpals.R
-import com.android.periodpals.resources.C.Tag.ProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
@@ -79,10 +79,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
     ) {
       // Profile picture
-      ProfilePicture(
-          profileImageUri = profileImageUri,
-          testTag = ProfileScreen.PROFILE_PICTURE,
-      )
+      ProfilePicture(profileImageUri = profileImageUri)
 
       // Name
       Text(
@@ -108,7 +105,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
           modifier = Modifier.align(Alignment.Start).testTag(ProfileScreen.CONTRIBUTION_FIELD),
       )
 
-      // Review section text
+      // Review section title
       ProfileSection(text = REVIEWS, testTag = ProfileScreen.REVIEWS_SECTION)
 
       // Reviews or no reviews card

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.sp
 import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.ProfileScreen
 import com.android.periodpals.ui.components.ProfilePicture
+import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -108,14 +109,7 @@ fun ProfileScreen(navigationActions: NavigationActions) {
       )
 
       // Review section text
-      Text(
-          text = REVIEWS,
-          fontSize = 20.sp,
-          modifier =
-              Modifier.align(Alignment.Start)
-                  .padding(vertical = 8.dp)
-                  .testTag(ProfileScreen.REVIEWS_SECTION),
-      )
+      ProfileSection(text = REVIEWS, testTag = ProfileScreen.REVIEWS_SECTION)
 
       // Reviews or no reviews card
       if (numberInteractions == 0) {


### PR DESCRIPTION
# Extract shared components across profile screens

### Description
This PR introduces shared components for the profile screens to reduce code duplication and simplify future adjustments to padding, typography, and color. It addresses issue #157, a subtask of #82.

**Note:** Uncertain whether to use the `contentScale` on the `GlideImage`.

### Key Changes

1. **Tag Naming and Consistency:**
   - Updated tag references in test files for consistency:
     - `CreateProfileTest.kt`, `EditProfileTest.kt`, and `ProfileScreenTest.kt`: Used shared components and updated test tags.

2. **Added Assertions:**
   - **CreateProfileTest.kt**: Added assertions for save button click actions and text equality.
   - **EditProfileTest.kt**: Added assertions for save button click actions.

3. **Import Statement Updates:**
   - Aligned imports in `CreateProfileTest.kt` and `EditProfileTest.kt` with updated tag references.

4. **Improvements in `C.kt`:**
   - Updated tag constants in `C.kt` for consistency.
   - Added `ProfileScreens` object with shared and individual tag constants for the profile screens.

---

### File Changes

#### Modified
- `ProfileComponents.kt`
- `CreateProfile.kt`
- `EditProfile.kt`
- `ProfileScreen.kt`
- `CreateProfileTest.kt`
- `EditProfileTest.kt`
- `ProfileScreenTest.kt`
- `C.kt`

#### Added
None

#### Removed
None

---

### Dependencies Added
None

---

### Testing

- Ensured updated tag names are reflected in tests.
- Verified save button assertions across profile screens.