### PR TITLE
Fix/style/layout responsivness/create profile

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -57,6 +57,7 @@ class CreateProfileTest {
 
   @Test
   fun allComponentsAreDisplayed() {
+    `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
@@ -86,6 +87,7 @@ class CreateProfileTest {
 
   @Test
   fun testValidDateRecognition() {
+    `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/2000")
@@ -95,6 +97,7 @@ class CreateProfileTest {
 
   @Test
   fun testInvalidDateRecognition() {
+    `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("invalid_date")
@@ -108,7 +111,6 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDob() {
     `when`(userViewModel.user).thenReturn(userState)
-
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
@@ -126,7 +128,6 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoName() {
     `when`(userViewModel.user).thenReturn(userState)
-
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
@@ -144,7 +145,6 @@ class CreateProfileTest {
   @Test
   fun createInvalidProfileNoDescription() {
     `when`(userViewModel.user).thenReturn(userState)
-
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
@@ -160,7 +160,6 @@ class CreateProfileTest {
   @Test
   fun createValidProfileVMFailure() {
     `when`(userViewModel.user).thenReturn(mutableStateOf(null))
-
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
@@ -178,7 +177,6 @@ class CreateProfileTest {
   @Test
   fun createValidProfileVMSuccess() {
     `when`(userViewModel.user).thenReturn(userState)
-
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -221,7 +221,7 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
             .show()
       },
       colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-      shape = RoundedCornerShape(50),
+      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
       border = BorderStroke(MaterialTheme.dimens.borderLine, Color.LightGray),
   ) {
     Row(

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -210,7 +210,7 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
       modifier = Modifier.wrapContentSize().testTag(testTag),
       onClick = onClick,
       colors = ButtonDefaults.buttonColors(containerColor = Purple40),
-      shape = RoundedCornerShape(50),
+      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
   ) {
     Text(text = text, color = Color.White, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -2,6 +2,7 @@ package com.android.periodpals.ui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
@@ -71,7 +72,7 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
 @Composable
 fun ProfileSection(text: String, testTag: String) {
   Text(
-      modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(testTag),
+      modifier = Modifier.fillMaxWidth().padding(top = MaterialTheme.dimens.small2).wrapContentHeight().testTag(testTag),
       text = text,
       textAlign = TextAlign.Start,
       style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -184,7 +184,7 @@ fun ProfileSaveButton(onClick: () -> Unit) {
       modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
       onClick = onClick,
       enabled = true,
-      shape = RoundedCornerShape(50),
+      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
   ) {
     Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -3,22 +3,27 @@ package com.android.periodpals.ui.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
 
@@ -51,7 +56,7 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
       contentDescription = "profile picture",
       contentScale = ContentScale.Crop,
       modifier =
-          Modifier.size(190.dp)
+          Modifier.size(MaterialTheme.dimens.profilePictureSize)
               .clip(shape = CircleShape)
               .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
               .testTag(ProfileScreens.PROFILE_PICTURE))
@@ -66,11 +71,10 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
 @Composable
 fun ProfileSection(text: String, testTag: String) {
   Text(
-      modifier = Modifier.fillMaxWidth().testTag(testTag),
+      modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(testTag),
       text = text,
       textAlign = TextAlign.Start,
-      style =
-          MaterialTheme.typography.bodyLarge.copy(fontSize = 20.sp, fontWeight = FontWeight.Medium),
+      style = MaterialTheme.typography.titleSmall,
   )
 }
 
@@ -82,12 +86,24 @@ fun ProfileSection(text: String, testTag: String) {
  */
 @Composable
 fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
+  var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
-      modifier = Modifier.testTag(ProfileScreens.NAME_INPUT_FIELD),
+      modifier =
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.NAME_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = name,
       onValueChange = onValueChange,
-      label = { Text(NAME_LABEL) },
-      placeholder = { Text(NAME_PLACEHOLDER) })
+      textStyle = MaterialTheme.typography.labelLarge,
+      label = {
+        Text(
+            text = NAME_LABEL,
+            style =
+                if (isFocused || name.isNotEmpty()) MaterialTheme.typography.labelMedium
+                else MaterialTheme.typography.labelLarge)
+      },
+      placeholder = { Text(text = NAME_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) })
 }
 
 /**
@@ -98,12 +114,25 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
  */
 @Composable
 fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
+  var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
+      modifier =
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.DOB_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = dob,
       onValueChange = onValueChange,
-      label = { Text(DOB_LABEL) },
-      placeholder = { Text(DOB_PLACEHOLDER) },
-      modifier = Modifier.testTag(ProfileScreens.DOB_INPUT_FIELD))
+      textStyle = MaterialTheme.typography.labelLarge,
+      label = {
+        Text(
+            text = DOB_LABEL,
+            style =
+                if (isFocused || dob.isNotEmpty()) MaterialTheme.typography.labelMedium
+                else MaterialTheme.typography.labelLarge)
+      },
+      placeholder = { Text(text = DOB_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
+  )
 }
 
 /**
@@ -114,13 +143,28 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
  */
 @Composable
 fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit) {
+  var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
+      modifier =
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = description,
       onValueChange = onValueChange,
-      label = { Text(DESCRIPTION_LABEL) },
-      placeholder = { Text(DESCRIPTION_PLACEHOLDER) },
+      textStyle = MaterialTheme.typography.labelLarge,
+      label = {
+        Text(
+            text = DESCRIPTION_LABEL,
+            style =
+                if (isFocused || description.isNotEmpty()) MaterialTheme.typography.labelMedium
+                else MaterialTheme.typography.labelLarge)
+      },
+      placeholder = {
+        Text(text = DESCRIPTION_PLACEHOLDER, style = MaterialTheme.typography.labelLarge)
+      },
       minLines = 3,
-      modifier = Modifier.testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD))
+  )
 }
 
 /**
@@ -132,10 +176,11 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
 @Composable
 fun ProfileSaveButton(onClick: () -> Unit) {
   Button(
+      modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
       onClick = onClick,
       enabled = true,
-      modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
+      shape = RoundedCornerShape(50),
   ) {
-    Text(SAVE_BUTTON_TEXT)
+    Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -72,7 +72,11 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
 @Composable
 fun ProfileSection(text: String, testTag: String) {
   Text(
-      modifier = Modifier.fillMaxWidth().padding(top = MaterialTheme.dimens.small2).wrapContentHeight().testTag(testTag),
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(top = MaterialTheme.dimens.small2)
+              .wrapContentHeight()
+              .testTag(testTag),
       text = text,
       textAlign = TextAlign.Start,
       style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.ui.theme.dimens
 
@@ -36,7 +35,7 @@ fun BottomNavigationMenu(
           NavigationBarItem(
               modifier =
                   Modifier.wrapContentSize()
-                      .clip(RoundedCornerShape(50.dp))
+                      .clip(RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent))
                       .align(Alignment.CenterVertically)
                       .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU_ITEM + tab.textId),
               icon = {

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -10,9 +10,10 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -24,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
@@ -50,6 +50,7 @@ import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 
 private const val SCREEN_TITLE = "Create Your Account"
@@ -84,56 +85,76 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { padding ->
-    Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp).padding(padding),
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+    LazyColumn(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(padding)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3),
         horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       // Profile picture
-      ProfilePicture(
-          model = profileImageUri,
-          onClick = {
-            val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-            launcher.launch(pickImageIntent)
-          },
-      )
+      item {
+          ProfilePicture(
+              model = profileImageUri,
+              onClick = {
+                  val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+                  launcher.launch(pickImageIntent)
+              },
+          )
+      }
 
       // Mandatory section title
-      ProfileSection(
-          text = MANDATORY_TEXT,
-          testTag = ProfileScreens.MANDATORY_SECTION,
-      )
+      item  {
+          ProfileSection(
+              text = MANDATORY_TEXT,
+              testTag = ProfileScreens.MANDATORY_SECTION,
+          )
+      }
 
       // Name field
-      ProfileInputName(name = name, onValueChange = { name = it })
+      item {
+          ProfileInputName(name = name, onValueChange = { name = it })
+      }
 
       // Date of birth field
-      ProfileInputDob(dob = age, onValueChange = { age = it })
+      item {
+          ProfileInputDob(dob = age, onValueChange = { age = it })
+      }
 
       // Your profile section title
-      ProfileSection(
-          text = PROFILE_TEXT,
-          testTag = ProfileScreens.YOUR_PROFILE_SECTION,
-      )
+      item {
+          ProfileSection(
+              text = PROFILE_TEXT,
+              testTag = ProfileScreens.YOUR_PROFILE_SECTION,
+          )
+      }
 
       // Description field
-      ProfileInputDescription(description = description, onValueChange = { description = it })
+      item {
+          ProfileInputDescription(description = description, onValueChange = { description = it })
+      }
 
       // Save button
-      ProfileSaveButton(
-          onClick = {
-            attemptSaveUserData(
-                name = name,
-                age = age,
-                description = description,
-                profileImageUri = profileImageUri,
-                context = context,
-                userViewModel = userViewModel,
-                userState = userState,
-                navigationActions = navigationActions,
-            )
-          },
-      )
+      item {
+          ProfileSaveButton(
+              onClick = {
+                  attemptSaveUserData(
+                      name = name,
+                      age = age,
+                      description = description,
+                      profileImageUri = profileImageUri,
+                      context = context,
+                      userViewModel = userViewModel,
+                      userState = userState,
+                      navigationActions = navigationActions,
+                  )
+              },
+          )
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -98,62 +98,58 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
     ) {
       // Profile picture
       item {
-          ProfilePicture(
-              model = profileImageUri,
-              onClick = {
-                  val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                  launcher.launch(pickImageIntent)
-              },
-          )
+        ProfilePicture(
+            model = profileImageUri,
+            onClick = {
+              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+              launcher.launch(pickImageIntent)
+            },
+        )
       }
 
       // Mandatory section title
-      item  {
-          ProfileSection(
-              text = MANDATORY_TEXT,
-              testTag = ProfileScreens.MANDATORY_SECTION,
-          )
+      item {
+        ProfileSection(
+            text = MANDATORY_TEXT,
+            testTag = ProfileScreens.MANDATORY_SECTION,
+        )
       }
 
       // Name field
-      item {
-          ProfileInputName(name = name, onValueChange = { name = it })
-      }
+      item { ProfileInputName(name = name, onValueChange = { name = it }) }
 
       // Date of birth field
-      item {
-          ProfileInputDob(dob = age, onValueChange = { age = it })
-      }
+      item { ProfileInputDob(dob = age, onValueChange = { age = it }) }
 
       // Your profile section title
       item {
-          ProfileSection(
-              text = PROFILE_TEXT,
-              testTag = ProfileScreens.YOUR_PROFILE_SECTION,
-          )
+        ProfileSection(
+            text = PROFILE_TEXT,
+            testTag = ProfileScreens.YOUR_PROFILE_SECTION,
+        )
       }
 
       // Description field
       item {
-          ProfileInputDescription(description = description, onValueChange = { description = it })
+        ProfileInputDescription(description = description, onValueChange = { description = it })
       }
 
       // Save button
       item {
-          ProfileSaveButton(
-              onClick = {
-                  attemptSaveUserData(
-                      name = name,
-                      age = age,
-                      description = description,
-                      profileImageUri = profileImageUri,
-                      context = context,
-                      userViewModel = userViewModel,
-                      userState = userState,
-                      navigationActions = navigationActions,
-                  )
-              },
-          )
+        ProfileSaveButton(
+            onClick = {
+              attemptSaveUserData(
+                  name = name,
+                  age = age,
+                  description = description,
+                  profileImageUri = profileImageUri,
+                  context = context,
+                  userViewModel = userViewModel,
+                  userState = userState,
+                  navigationActions = navigationActions,
+              )
+            },
+        )
       }
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -21,6 +21,7 @@ data class Dimens(
     val large: Dp = 0.dp,
     val borderLine: Dp = 1.dp,
     val buttonHeight: Dp = 40.dp,
+    val buttonRoundedPercent: Int = 50,
     val iconSize: Dp = 0.dp,
     val profilePictureSize: Dp = 190.dp,
 )

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -21,7 +21,8 @@ data class Dimens(
     val large: Dp = 0.dp,
     val borderLine: Dp = 1.dp,
     val buttonHeight: Dp = 40.dp,
-    val iconSize: Dp = 0.dp
+    val iconSize: Dp = 0.dp,
+    val profilePictureSize: Dp = 190.dp,
 )
 
 // Width <= 360dp

--- a/app/src/main/java/com/android/periodpals/ui/theme/Type.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Type.kt
@@ -50,6 +50,7 @@ fun createTypography(
     headlineMediumSize: Int,
     titleLargeSize: Int,
     titleMediumSize: Int,
+    titleSmallSize: Int,
     bodyLargeSize: Int,
     bodyMediumSize: Int,
     labelLargeSize: Int,
@@ -73,9 +74,15 @@ fun createTypography(
       titleMedium =
           TextStyle(
               fontFamily = Nunito_Sans,
-              fontWeight = FontWeight.Medium,
+              fontWeight = FontWeight.SemiBold,
               fontStyle = FontStyle.Normal,
               fontSize = titleMediumSize.sp),
+      titleSmall =
+          TextStyle(
+              fontFamily = Nunito_Sans,
+              fontWeight = FontWeight.Bold,
+              fontStyle = FontStyle.Normal,
+              fontSize = titleSmallSize.sp),
       bodyLarge =
           TextStyle(
               fontFamily = Nunito_Sans,
@@ -85,7 +92,7 @@ fun createTypography(
       bodyMedium =
           TextStyle(
               fontFamily = Nunito_Sans,
-              fontWeight = FontWeight.Medium,
+              fontWeight = FontWeight.SemiBold,
               fontStyle = FontStyle.Normal,
               fontSize = bodyMediumSize.sp),
       labelLarge =
@@ -113,6 +120,7 @@ val CompactSmallTypography =
         headlineMediumSize = 20,
         titleLargeSize = 32,
         titleMediumSize = 20,
+        titleSmallSize = 18,
         bodyLargeSize = 18,
         bodyMediumSize = 16,
         labelLargeSize = 14,
@@ -124,6 +132,7 @@ val CompactMediumTypography =
         headlineMediumSize = 24,
         titleLargeSize = 40,
         titleMediumSize = 22,
+        titleSmallSize = 20,
         bodyLargeSize = 20,
         bodyMediumSize = 18,
         labelLargeSize = 16,
@@ -134,7 +143,8 @@ val CompactLargeTypography =
     createTypography(
         headlineMediumSize = 28,
         titleLargeSize = 48,
-        titleMediumSize = 24,
+        titleMediumSize = 28,
+        titleSmallSize = 24,
         bodyLargeSize = 24,
         bodyMediumSize = 20,
         labelLargeSize = 18,
@@ -145,7 +155,8 @@ val MediumTypography =
     createTypography(
         headlineMediumSize = 32,
         titleLargeSize = 56,
-        titleMediumSize = 20,
+        titleMediumSize = 28,
+        titleSmallSize = 24,
         bodyLargeSize = 24,
         bodyMediumSize = 22,
         labelLargeSize = 20,
@@ -157,6 +168,7 @@ val ExpandedTypography =
         headlineMediumSize = 36,
         titleLargeSize = 64,
         titleMediumSize = 28,
+        titleSmallSize = 24,
         bodyLargeSize = 24,
         bodyMediumSize = 22,
         labelLargeSize = 20,


### PR DESCRIPTION
# Enhancing Profile UI Consistency and Layout Responsiveness

## Description
This PR focuses on enhancing the `ProfileComponents.kt`, `CreateProfile.kt`, and `Type.kt` files. Key updates include refining UI components for consistent styling and typography, improving layout responsiveness, and converting the profile creation screen layout for better performance. This PR closes issue #169, subtask from #82.

## Changes

### Modified Files
- **`ProfileComponents.kt`**:
  - Updated `ProfilePicture` component to use a standardized size dimension.
  - Enhanced `ProfileSection` and input fields (`ProfileInputName`, `ProfileInputDob`, `ProfileInputDescription`) with improved padding, focus handling, and consistent typography.
  - Modified `ProfileSaveButton` to feature rounded corners and an updated text style.
- **`CreateProfile.kt`**:
  - Converted layout from `Column` to `LazyColumn` for improved scrolling performance and flexibility.
- **`Type.kt`**:
  - Added and refined various typography styles (`titleSmall`, `bodyMedium`, etc.) to ensure consistent text rendering across different screens.

### Added Files
- **`Dimens.kt`**:
  - Introduced new dimensions for profile-related components such as picture size and padding.

## Dependencies Added
- N/A

## Testing
- Verified responsiveness and styling consistency across various screen sizes.
- Ensured consistent typography and UI elements for profile creation and editing.

## Screenshots
| Size                 | Before                                                                                       | After                                                                                        |
|----------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| Compact S            | ![Before](https://github.com/user-attachments/assets/419d8789-ee32-4dc5-8160-fdb5ae4a4b99)  | ![After](https://github.com/user-attachments/assets/8e86ffb2-2759-40ea-a3b8-0a72deb82e3e) |
| Compact M            | ![Before](https://github.com/user-attachments/assets/01132ae3-4fbb-4cab-8a54-517d6a0eb21d)   | ![After](https://github.com/user-attachments/assets/897f5064-80fc-4326-80be-277dca9f40e8) |
| Compact L            | ![Before](https://github.com/user-attachments/assets/46574496-42e2-46d2-b507-ac086e39658b)   | ![After](https://github.com/user-attachments/assets/453b5f9a-506e-46d6-b356-1b8bed94f10b) |
| Medium (horizontal) |![Before](https://github.com/user-attachments/assets/50d1e048-6dc2-4ff8-8b0e-41a704d1fd7a) | ![After](https://github.com/user-attachments/assets/fb84de14-4685-4395-9bec-fc8d2c471dd2) |
| Medium | ![Before](https://github.com/user-attachments/assets/168b2e29-d5e4-47c0-8281-160e4fe482ef) | ![After](https://github.com/user-attachments/assets/9d67b228-337a-4808-a9ab-e874a0f0bf78) |
| Extended  | ![Before](https://github.com/user-attachments/assets/4f3e49d4-79dd-4a4b-8e35-3aa4ddb07172) | ![After](https://github.com/user-attachments/assets/cdcbe4d9-634e-44a3-a152-e7bd83a74111) |
