### PR TITLE
feat: adjust layout to all screen sizes

### DIFF
--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -6,12 +6,19 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,10 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.android.periodpals.R
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
@@ -33,7 +37,7 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Your Profile"
 private const val TAG = "ProfileScreen"
@@ -58,7 +62,6 @@ private const val NO_REVIEWS_TEXT = "No reviews yet..."
  * @param navigationActions The navigation actions to navigate between screens.
  * @sample ProfileScreen
  */
-@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   val context = LocalContext.current
@@ -75,13 +78,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(ProfileScreen.SCREEN),
-      bottomBar = {
-        BottomNavigationMenu(
-            onTabSelect = { route -> navigationActions.navigateTo(route) },
-            tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute(),
-        )
-      },
       topBar = {
         TopAppBar(
             title = SCREEN_TITLE,
@@ -89,54 +85,87 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
             onEditButtonClick = { navigationActions.navigateTo(Screen.EDIT_PROFILE) },
         )
       },
-  ) { padding ->
-    Column(
-        modifier = Modifier.padding(padding).padding(40.dp),
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+        )
+      },
+  ) { paddingValues ->
+    LazyColumn(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       // Profile picture
-      ProfilePicture(
-          model = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE.toString(),
-          onClick = null,
-      )
+      item {
+        ProfilePicture(model = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE.toString())
+      }
 
       // Name
-      Text(
-          text = userState.value?.name ?: DEFAULT_NAME,
-          fontSize = 24.sp,
-          fontWeight = FontWeight.Bold,
-          modifier = Modifier.testTag(ProfileScreen.NAME_FIELD),
-      )
+      item {
+        Text(
+            text = userState.value?.name ?: DEFAULT_NAME,
+            textAlign = TextAlign.Center,
+            softWrap = true,
+            style = MaterialTheme.typography.titleSmall,
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
+        )
+      }
 
       // Description
-      Text(
-          text = userState.value?.description ?: DEFAULT_DESCRIPTION,
-          textAlign = TextAlign.Center,
-          fontSize = 20.sp,
-          modifier = Modifier.testTag(ProfileScreen.DESCRIPTION_FIELD),
-      )
+      item {
+        Text(
+            text = userState.value?.description ?: DEFAULT_DESCRIPTION,
+            textAlign = TextAlign.Center,
+            softWrap = true,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(ProfileScreen.DESCRIPTION_FIELD),
+        )
+      }
 
       // Contribution
-      Text(
-          text =
-              if (numberInteractions == 0) NEW_USER_TEXT
-              else NUMBER_INTERACTION_TEXT + numberInteractions,
-          fontSize = 16.sp,
-          modifier = Modifier.align(Alignment.Start).testTag(ProfileScreen.CONTRIBUTION_FIELD),
-      )
+      item {
+        Text(
+            text =
+                if (numberInteractions == 0) NEW_USER_TEXT
+                else NUMBER_INTERACTION_TEXT + numberInteractions,
+            textAlign = TextAlign.Left,
+            softWrap = true,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(ProfileScreen.CONTRIBUTION_FIELD),
+        )
+      }
 
       // Review section text
-      ProfileSection(
-          text = REVIEWS_TITLE,
-          testTag = ProfileScreen.REVIEWS_SECTION,
-      )
+      item {
+        ProfileSection(
+            text = REVIEWS_TITLE,
+            testTag = ProfileScreen.REVIEWS_SECTION,
+        )
+      }
 
       // Reviews or no reviews card
-      if (numberInteractions == 0) {
-        NoReviewCard()
-      } else {
-        /** TODO: Implement the review section */
+      item {
+        if (numberInteractions == 0) {
+          NoReviewCard()
+        } else {
+          /** TODO: Implement the review section */
+        }
       }
     }
   }
@@ -152,20 +181,26 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 @Composable
 private fun NoReviewCard() {
   Card(
-      elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
-      modifier = Modifier.testTag(ProfileScreen.NO_REVIEWS_CARD),
+      modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_CARD),
+      shape = RoundedCornerShape(MaterialTheme.dimens.cardRounded),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
+        modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small3),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(10.dp),
-        modifier = Modifier.padding(7.dp),
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       Icon(
           imageVector = Icons.Outlined.SentimentVeryDissatisfied,
           contentDescription = "NoReviews",
-          modifier = Modifier.testTag(ProfileScreen.NO_REVIEWS_ICON),
+          modifier =
+              Modifier.size(MaterialTheme.dimens.iconSize).testTag(ProfileScreen.NO_REVIEWS_ICON),
       )
-      Text(text = NO_REVIEWS_TEXT, modifier = Modifier.testTag(ProfileScreen.NO_REVIEWS_TEXT))
+      Text(
+          text = NO_REVIEWS_TEXT,
+          style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT))
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -22,6 +22,8 @@ data class Dimens(
     val borderLine: Dp = 1.dp,
     val buttonHeight: Dp = 40.dp,
     val buttonRoundedPercent: Int = 50,
+    val cardElevation: Dp = 4.dp,
+    val cardRounded: Dp = 12.dp,
     val iconSize: Dp = 0.dp,
     val profilePictureSize: Dp = 190.dp,
 )


### PR DESCRIPTION
# Responsive layout for `ProfileScreen`

## Description
This PR introduces a responsive layout (padding, design and typographies) for the `ProfileScreen`. It closes issue #172, subtask from #82.

## Changes
- New `cardElevation` in `Dimens.kt` for `Card`s' elevation.
- (New from #173) `cardRounded`in `Dimens.kt`for `Card`s' rounded edges.
- Adapted padding and typographies to the components.

## Files 

#### Added
None.

#### Modified
- **`ProfileScreen.kt`**:  updated padding and typographies for responsive layout.
- **`Dimens.kt`**: new `cardElevation` `val`.

#### Removed
None.

## Dependencies Added
None.

## Testing

## Screenshots
| Screen               | Before                                                                                           | After                                                                                             |
|----------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| **Compact S**        | ![image](https://github.com/user-attachments/assets/bf4384fe-33c7-418b-a6eb-1b448c261ab7)        | ![image](https://github.com/user-attachments/assets/08653fb2-b3a1-47f2-99b7-5cf1ebaa9eed)        |
| **Compact M**        | ![image](https://github.com/user-attachments/assets/d7453082-32eb-4b4a-93d0-7af9c41960d0)        | ![image](https://github.com/user-attachments/assets/392c8df3-a851-49dd-ba9f-17d9c71ec47e)        |
| **Compact L**        | ![image](https://github.com/user-attachments/assets/7269c898-0f11-4c60-8c04-fe2de74afe77)        | ![image](https://github.com/user-attachments/assets/6ec3e369-2008-4ebe-a943-bfe967185a04)        |
| **Medium (horizontal)** | ![image](https://github.com/user-attachments/assets/1001b885-20f9-4143-aa94-a4437f140396)     | ![image](https://github.com/user-attachments/assets/9044acf4-158b-4d64-827c-98e27a8e7fd4)        |
| **Medium**           | ![image](https://github.com/user-attachments/assets/84b005f3-192d-4b57-b690-920c5025c29d)        | ![image](https://github.com/user-attachments/assets/7ab65a5d-6dd5-4064-afcd-dbf61fbbfd03)        |
| **Extended**         | ![image](https://github.com/user-attachments/assets/e7693f4f-60fa-41e3-b4c4-b42dbdc02678)        | ![image](https://github.com/user-attachments/assets/2c4a6585-a54f-49c5-9f95-8d07db3c8be8)        |
