### PR TITLE
Fix/style/layout responsiveness/edit profile

### DIFF
--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -8,10 +8,10 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Icon
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
@@ -47,15 +46,14 @@ import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Edit Your Profile"
 
-/* Placeholder Screen, waiting for implementation */
-@OptIn(ExperimentalGlideComposeApi::class)
+/** TODO: Placeholder Screen, waiting for implementation */
 @Composable
 fun EditProfileScreen(navigationActions: NavigationActions) {
-  // State variables, to remplace it with the real data
+  // TODO: State variables, to remplace it with the real data
   var name by remember { mutableStateOf("Emilia Jones") }
   var dob by remember { mutableStateOf("20/01/2001") }
   var description by remember {
@@ -88,65 +86,78 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
             onBackButtonClick = { navigationActions.navigateTo(Screen.PROFILE) })
       },
       content = { pd ->
-        Column(
-            modifier = Modifier.padding(pd).padding(24.dp).fillMaxSize(),
+        LazyColumn(
+            modifier =
+                Modifier.fillMaxSize()
+                    .padding(pd)
+                    .padding(
+                        horizontal = MaterialTheme.dimens.medium3,
+                        vertical = MaterialTheme.dimens.small3),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+            verticalArrangement =
+                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
         ) {
           // Profile image and its edit icon
-          Box(modifier = Modifier.size(190.dp)) {
-            ProfilePicture(profileImageUri)
+          item {
+            Box(modifier = Modifier.size(MaterialTheme.dimens.profilePictureSize)) {
+              ProfilePicture(profileImageUri)
 
-            IconButton(
-                onClick = {
-                  val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                  launcher.launch(pickImageIntent)
-                },
-                colors =
-                    IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.tertiary,
-                        contentColor = MaterialTheme.colorScheme.onTertiary,
-                    ),
-                modifier =
-                    Modifier.align(Alignment.TopEnd)
-                        .size(40.dp)
-                        .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
-            ) {
-              Icon(
-                  imageVector = Icons.Outlined.Edit,
-                  contentDescription = "edit icon",
-              )
+              IconButton(
+                  onClick = {
+                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+                    launcher.launch(pickImageIntent)
+                  },
+                  colors =
+                      IconButtonDefaults.iconButtonColors(
+                          containerColor = MaterialTheme.colorScheme.tertiary,
+                          contentColor = MaterialTheme.colorScheme.onTertiary,
+                      ),
+                  modifier =
+                      Modifier.align(Alignment.TopEnd)
+                          .size(MaterialTheme.dimens.iconSizeBig)
+                          .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
+              ) {
+                Icon(
+                    imageVector = Icons.Outlined.Edit,
+                    contentDescription = "edit icon",
+                    modifier = Modifier.fillMaxSize().padding(MaterialTheme.dimens.small2),
+                )
+              }
             }
           }
 
           // Mandatory section title
-          ProfileSection(MANDATORY_TEXT, ProfileScreens.MANDATORY_SECTION)
+          item { ProfileSection(MANDATORY_TEXT, ProfileScreens.MANDATORY_SECTION) }
 
           // Name input field
-          ProfileInputName(name = name, onValueChange = { name = it })
+          item { ProfileInputName(name = name, onValueChange = { name = it }) }
 
           // Date of Birth input field
-          ProfileInputDob(dob = dob, onValueChange = { dob = it })
+          item { ProfileInputDob(dob = dob, onValueChange = { dob = it }) }
 
           // Your profile section title
-          ProfileSection(PROFILE_TEXT, ProfileScreens.YOUR_PROFILE_SECTION)
+          item { ProfileSection(PROFILE_TEXT, ProfileScreens.YOUR_PROFILE_SECTION) }
 
           // Description input field
-          ProfileInputDescription(description = description, onValueChange = { description = it })
+          item {
+            ProfileInputDescription(description = description, onValueChange = { description = it })
+          }
 
           // Save Changes button
-          ProfileSaveButton(
-              onClick = {
-                val errorMessage = validateFields(name, dob, description)
-                if (errorMessage != null) {
-                  Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-                } else {
-                  // TODO: Save the profile (future implementation)
-                  Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-                  navigationActions.navigateTo(Screen.PROFILE)
-                }
-              },
-          )
+          item {
+            ProfileSaveButton(
+                onClick = {
+                  val errorMessage = validateFields(name, dob, description)
+                  if (errorMessage != null) {
+                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                  } else {
+                    // TODO: Save the profile (future implementation)
+                    Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+                    navigationActions.navigateTo(Screen.PROFILE)
+                  }
+                },
+            )
+          }
         }
       })
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -114,13 +114,13 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
                       ),
                   modifier =
                       Modifier.align(Alignment.TopEnd)
-                          .size(MaterialTheme.dimens.iconSizeBig)
+                          .size(MaterialTheme.dimens.iconButtonSize)
                           .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
               ) {
                 Icon(
                     imageVector = Icons.Outlined.Edit,
                     contentDescription = "edit icon",
-                    modifier = Modifier.fillMaxSize().padding(MaterialTheme.dimens.small2),
+                    modifier = Modifier.align(Alignment.Center).size(MaterialTheme.dimens.iconSize),
                 )
               }
             }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -25,7 +25,7 @@ data class Dimens(
     val cardElevation: Dp = 4.dp,
     val cardRounded: Dp = 12.dp,
     val iconSize: Dp = 0.dp,
-    val iconSizeBig: Dp = iconSize * 5 / 3,
+    val iconButtonSize: Dp = iconSize * 5 / 3,
     val profilePictureSize: Dp = 190.dp,
 )
 

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -22,7 +22,10 @@ data class Dimens(
     val borderLine: Dp = 1.dp,
     val buttonHeight: Dp = 40.dp,
     val buttonRoundedPercent: Int = 50,
+    val cardElevation: Dp = 4.dp,
+    val cardRounded: Dp = 12.dp,
     val iconSize: Dp = 0.dp,
+    val iconSizeBig: Dp = iconSize * 5 / 3,
     val profilePictureSize: Dp = 190.dp,
 )
 


### PR DESCRIPTION
# Responsive layout for `EditProfileScreen


## Description
This PR introduces a responsive layout (typography, padding, layout, ...) for `EditProfileScreen`. It closes issue #174, subtask from #82.


## Changes
- Use `LazyColumn` (by default scrollable) instead of a `Column` component in `EditProfileScreen`'s `Scaffold`.
- New val `iconButtonSize` in `Dimens.kt` for the edit profile picture `IconButton`.
- Adapted layout in `EditProfileScreen`.


## Files 

#### Added
- None.

#### Modified
- **`EditProfileScreen.kt`**: adapt layout to be responsive to all screen sizes.
- **`Dimens.kt`**: add new val `iconButtonSize` which is 5/3 of `iconSize`.

#### Removed
- None.


## Dependencies Added
- None.


## Testing
- Verified on multiple emulators to ensure consistent and responsive design across different screen sizes.

## Screenshots
| Screen               | Before                                                                                           | After                                                                                             |
|----------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| **Compact S**        | ![image](https://github.com/user-attachments/assets/de225657-7c72-4aaf-a97e-54ab66902f8b)        | ![image](https://github.com/user-attachments/assets/a2f59d82-8141-4fb7-bfb8-746f27e0f067)        |
| **Compact M**        | ![image](https://github.com/user-attachments/assets/65f7198a-615f-4ed4-ac0c-1af8fb851785)        | ![image](https://github.com/user-attachments/assets/67919353-52de-4924-966a-ab4287fc86ce)        |
| **Compact L**        | ![image](https://github.com/user-attachments/assets/f3b1993e-0b7b-4d9a-83cc-251a1705dc04)        | ![image](https://github.com/user-attachments/assets/ae4c2a14-2e87-4b70-a8b9-1d246998b6ed)        |
| **Medium (horizontal)** | ![image](https://github.com/user-attachments/assets/7136ba9a-a0e9-4b8f-91bf-97d4d319fcf5)     | ![image](https://github.com/user-attachments/assets/fb1026ef-cce2-43ef-a371-b7a415c5b470)        |
| **Medium**           | ![image](https://github.com/user-attachments/assets/a6592d72-2e2f-4fdd-ad95-6eb92cf50b0b)        | ![image](https://github.com/user-attachments/assets/ec7f4847-fbb5-4152-84bf-51658131ba88)        |
| **Extended**         | ![image](https://github.com/user-attachments/assets/34df0327-2ce2-4d9e-86df-f30ee572719e)        | ![image](https://github.com/user-attachments/assets/b40d8414-5853-4414-9f31-8560e4dcf4cc)        |
