### PR TITLE
feat: add "Current Location" as a selectable option.

### DIFF
--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -73,6 +73,8 @@ private const val SUBMISSION_BUTTON_TEXT = "Ask for Help"
 private const val MAX_NAME_LEN = 30
 private const val MAX_LOCATION_SUGGESTIONS = 3
 
+private const val CURRENT_LOCATION_TEXT = "Current Location"
+
 /**
  * Composable function for the CreateAlert screen.
  *
@@ -192,7 +194,7 @@ fun CreateAlertScreen(
               modifier = Modifier.wrapContentSize(),
           ) {
             DropdownMenuItem(
-                text = { Text("Current Location") },
+                text = { Text(CURRENT_LOCATION_TEXT) },
                 onClick = {
                   // Logic for fetching and setting current location will be implemented later
                   showDropdown = false // For now close dropdown on selection

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -10,11 +10,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GpsFixed
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -188,6 +191,16 @@ fun CreateAlertScreen(
               onDismissRequest = { showDropdown = false },
               modifier = Modifier.wrapContentSize(),
           ) {
+            DropdownMenuItem(
+                text = { Text("Current Location") },
+                onClick = {
+                  // Logic for fetching and setting current location will be implemented later
+                  showDropdown = false // For now close dropdown on selection
+                },
+                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                leadingIcon = {
+                  Icon(imageVector = Icons.Filled.GpsFixed, contentDescription = "GPS icon")
+                })
             Log.d("CreateAlertScreen", "Location suggestions: ${locationSuggestions}")
             locationSuggestions.take(MAX_LOCATION_SUGGESTIONS).forEach { location ->
               DropdownMenuItem(

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -196,7 +196,7 @@ fun CreateAlertScreen(
             DropdownMenuItem(
                 text = { Text(CURRENT_LOCATION_TEXT) },
                 onClick = {
-                  // Logic for fetching and setting current location will be implemented later
+                  // TODO : Logic for fetching and setting current location
                   showDropdown = false // For now close dropdown on selection
                 },
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,


### PR DESCRIPTION
# Add "Current Location" as a selectable option.

## Description
This PR introduces the UI for the "Use Current Location" feature on the Create Alert screen. Users can now see an option to set their location automatically using the current location, though the location logic is not yet implemented. This closes issue #181 (and so the issue #151).

## Changes
- Added a "Current Location" DropdownMenuItem to the Create Alert screen, allowing users to trigger the location setting.

## Files 

#### Modified
- `CreateAlertScreen.kt`: Contains the "Current Location" option and a specific icon.

## Testing
- Since we didn't specifically test the dropdown items in any other field, I assumed that all dropdown-related tests would be handled later as part of the broader testing strategy.

## Screenshots 

<img src="https://github.com/user-attachments/assets/91cfe145-faee-4595-8c6d-45979594ceed" width="300" />
