### PR TITLE
Fix/style/layout responsivness/clean up

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.model.alert.Alert
 import com.android.periodpals.model.alert.Product
@@ -18,6 +19,7 @@ import com.android.periodpals.model.alert.Urgency
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
+import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
@@ -112,6 +114,7 @@ class AlertListsScreenTest {
         .assertTextEquals("Alert Lists")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
   }
 
   @Test
@@ -151,11 +154,16 @@ class AlertListsScreenTest {
 
     composeTestRule
         .onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertHasNoClickAction()
-    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_ICON).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AlertListsScreen.NO_ALERTS_ICON)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(AlertListsScreen.NO_ALERTS_TEXT)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals(NO_MY_ALERTS_TEXT)
   }
@@ -166,32 +174,39 @@ class AlertListsScreenTest {
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
     composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
-    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD).assertDoesNotExist()
 
     MY_ALERTS_LIST.forEach { alert ->
       val alertId: String = alert.id.toString()
       composeTestRule
           .onNodeWithTag(MyAlertItem.MY_ALERT + alertId)
+          .performScrollTo()
           .assertIsDisplayed()
           .assertHasNoClickAction()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PROFILE_PICTURE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_TIME_AND_LOCATION + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(
               AlertListsScreen.ALERT_PRODUCT_AND_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PRODUCT_TYPE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(MyAlertItem.MY_EDIT_BUTTON + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
           .assertHasClickAction()
     }
@@ -211,93 +226,135 @@ class AlertListsScreenTest {
 
     composeTestRule
         .onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertHasNoClickAction()
-    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_ICON).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AlertListsScreen.NO_ALERTS_ICON)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(AlertListsScreen.NO_ALERTS_TEXT)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals(NO_PALS_ALERTS_TEXT)
   }
 
   @Test
-  fun palsAlertsListIsCorrect() {
+  fun palsAlertsListNoActionIsCorrect() {
     composeTestRule.setContent {
       AlertListsScreen(navigationActions, emptyList(), PALS_ALERTS_LIST)
     }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).performClick()
-
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsSelected()
+    composeTestRule
+        .onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB)
+        .assertIsNotSelected()
+        .performClick()
+        .assertIsSelected()
+    composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsNotSelected()
+    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD).assertDoesNotExist()
 
     PALS_ALERTS_LIST.forEach { alert ->
       val alertId: String = alert.id.toString()
       composeTestRule
           .onNodeWithTag(PalsAlertItem.PAL_ALERT + alertId)
+          .performScrollTo()
           .assertIsDisplayed()
           .assertHasClickAction()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PROFILE_PICTURE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_TIME_AND_LOCATION + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(PalsAlertItem.PAL_NAME + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(
               AlertListsScreen.ALERT_PRODUCT_AND_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PRODUCT_TYPE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
+
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_MESSAGE + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_DIVIDER + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_BUTTONS + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_ACCEPT_BUTTON + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_DECLINE_BUTTON + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
     }
   }
 
   @Test
-  fun palsAlertsListClickedIsCorrect() {
+  fun palsAlertsListDoubleClickIsCorrect() {
     composeTestRule.setContent {
       AlertListsScreen(navigationActions, emptyList(), PALS_ALERTS_LIST)
     }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).performClick()
-
-    composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsSelected()
+    composeTestRule
+        .onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB)
+        .assertIsNotSelected()
+        .performClick()
+        .assertIsSelected()
+    composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsNotSelected()
+    composeTestRule.onNodeWithTag(AlertListsScreen.NO_ALERTS_CARD).assertDoesNotExist()
 
     PALS_ALERTS_LIST.forEach { alert ->
       val alertId: String = alert.id.toString()
       composeTestRule
           .onNodeWithTag(PalsAlertItem.PAL_ALERT + alertId)
+          .performScrollTo()
           .assertIsDisplayed()
           .assertHasClickAction()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PROFILE_PICTURE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_TIME_AND_LOCATION + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(PalsAlertItem.PAL_NAME + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(
               AlertListsScreen.ALERT_PRODUCT_AND_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_PRODUCT_TYPE + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
       composeTestRule
           .onNodeWithTag(AlertListsScreen.ALERT_URGENCY + alertId, useUnmergedTree = true)
+          .performScrollTo()
           .assertIsDisplayed()
 
+      // First click to display the alert's details
       composeTestRule.onNodeWithTag(PalsAlertItem.PAL_ALERT + alertId).performClick()
       composeTestRule
           .onNodeWithTag(PalsAlertItem.PAL_MESSAGE + alertId, useUnmergedTree = true)
@@ -318,6 +375,24 @@ class AlertListsScreenTest {
             .assertIsDisplayed()
             .assertHasClickAction()
       }
+
+      // Second click to toggle the alert
+      composeTestRule.onNodeWithTag(PalsAlertItem.PAL_ALERT + alertId).performClick()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_MESSAGE + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_DIVIDER + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_BUTTONS + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_ACCEPT_BUTTON + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
+      composeTestRule
+          .onNodeWithTag(PalsAlertItem.PAL_DECLINE_BUTTON + alertId, useUnmergedTree = true)
+          .assertIsNotDisplayed()
     }
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.model.location.Location
@@ -70,13 +71,6 @@ class CreateAlertScreenTest {
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
     composeTestRule.onNodeWithTag(CreateAlertScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.INSTRUCTION_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.GPS_ICON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
@@ -84,8 +78,31 @@ class CreateAlertScreenTest {
         .assertTextEquals("Create Alert")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.INSTRUCTION_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.URGENCY_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals(SUBMIT_BUTTON_TEXT)
   }
@@ -99,23 +116,31 @@ class CreateAlertScreenTest {
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performClick()
-    composeTestRule.onNodeWithText(PRODUCT).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(PRODUCT).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performClick()
-    composeTestRule.onNodeWithText(URGENCY).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(URGENCY).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION1.name)
+        .performScrollTo()
         .performClick()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
         .assertTextContains(LOCATION_SUGGESTION1.name)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).performTextInput(MESSAGE)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD)
+        .performScrollTo()
+        .performTextInput(MESSAGE)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performScrollTo().performClick()
     verify(navigationActions).navigateTo(Screen.ALERT_LIST)
   }
 
@@ -128,19 +153,27 @@ class CreateAlertScreenTest {
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performClick()
-    composeTestRule.onNodeWithText(URGENCY).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(URGENCY).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION1.name)
+        .performScrollTo()
         .performClick()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
         .assertTextContains(LOCATION_SUGGESTION1.name)
-    composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).performTextInput(MESSAGE)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD)
+        .performScrollTo()
+        .performTextInput(MESSAGE)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performScrollTo().performClick()
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -154,19 +187,27 @@ class CreateAlertScreenTest {
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performClick()
-    composeTestRule.onNodeWithText(PRODUCT).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(PRODUCT).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION1.name)
+        .performScrollTo()
         .performClick()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
         .assertTextContains(LOCATION_SUGGESTION1.name)
-    composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).performTextInput(MESSAGE)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD)
+        .performScrollTo()
+        .performTextInput(MESSAGE)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performScrollTo().performClick()
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -180,15 +221,18 @@ class CreateAlertScreenTest {
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performClick()
-    composeTestRule.onNodeWithText(PRODUCT).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(PRODUCT).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performClick()
-    composeTestRule.onNodeWithText(URGENCY).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(URGENCY).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).performTextInput(MESSAGE)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD)
+        .performScrollTo()
+        .performTextInput(MESSAGE)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performScrollTo().performClick()
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -202,21 +246,26 @@ class CreateAlertScreenTest {
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performClick()
-    composeTestRule.onNodeWithText(PRODUCT).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(PRODUCT).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performClick()
-    composeTestRule.onNodeWithText(URGENCY).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(URGENCY).performScrollTo().performClick()
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION1.name)
+        .performScrollTo()
         .performClick()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
         .assertTextContains(LOCATION_SUGGESTION1.name)
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON).performScrollTo().performClick()
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -232,6 +281,7 @@ class CreateAlertScreenTest {
 
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.SUBMIT_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
         .performClick()
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
@@ -245,7 +295,10 @@ class CreateAlertScreenTest {
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
     Log.d("LocationViewModelTest", locationViewModel.locationSuggestions.value.toString())
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onAllNodesWithContentDescription(CreateAlertScreen.DROPDOWN_ITEM)
         .assertCountEquals(0)
@@ -260,18 +313,24 @@ class CreateAlertScreenTest {
                 listOf(LOCATION_SUGGESTION1, LOCATION_SUGGESTION2, LOCATION_SUGGESTION3)))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onAllNodesWithContentDescription(CreateAlertScreen.DROPDOWN_ITEM)
         .assertCountEquals(3)
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION1.name)
+        .performScrollTo()
         .assertExists()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION2.name)
+        .performScrollTo()
         .assertExists()
     composeTestRule
         .onNodeWithTag(CreateAlertScreen.DROPDOWN_ITEM + LOCATION_SUGGESTION3.name)
+        .performScrollTo()
         .assertExists()
   }
 
@@ -290,7 +349,10 @@ class CreateAlertScreenTest {
                 )))
     composeTestRule.setContent { CreateAlertScreen(navigationActions, locationViewModel) }
 
-    composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).performTextInput(LOCATION)
+    composeTestRule
+        .onNodeWithTag(CreateAlertScreen.LOCATION_FIELD)
+        .performScrollTo()
+        .performTextInput(LOCATION)
     composeTestRule
         .onAllNodesWithContentDescription(CreateAlertScreen.DROPDOWN_ITEM)
         .assertCountEquals(3)

--- a/app/src/androidTest/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
@@ -74,6 +74,7 @@ class CreateAlertScreenTest {
     composeTestRule.onNodeWithTag(CreateAlertScreen.PRODUCT_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateAlertScreen.URGENCY_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateAlertScreen.LOCATION_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(CreateAlertScreen.GPS_ICON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(CreateAlertScreen.MESSAGE_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -6,11 +6,14 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
+import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
+import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
@@ -30,8 +33,8 @@ class SignInScreenTest {
   private lateinit var authViewModel: AuthenticationViewModel
 
   companion object {
-    private const val email = "test@example.com"
-    private const val password = "password"
+    private const val EMAIL = "test@example.com"
+    private const val PASSWORD = "password"
   }
 
   @Before
@@ -49,78 +52,140 @@ class SignInScreenTest {
   fun allComponentsAreDisplayed() {
 
     composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
     composeTestRule.onNodeWithTag(AuthenticationScreens.BACKGROUND).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.WELCOME_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignInScreen.INSTRUCTION_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.WELCOME_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignInScreen.INSTRUCTION_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_VISIBILITY_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignInScreen.CONTINUE_WITH_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignInScreen.GOOGLE_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignInScreen.CONTINUE_WITH_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignInScreen.GOOGLE_BUTTON).performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON)
+        .performScrollTo()
+        .assertIsDisplayed()
   }
 
   @Test
   fun emptyEmailShowsCorrectError() {
 
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
         .assertTextEquals("Email cannot be empty")
   }
 
   @Test
   fun emptyEmailDoesNotCallVM() {
 
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
+
     verify(authViewModel, never()).logInWithEmail(any(), any())
   }
 
   @Test
   fun emptyPasswordShowsCorrectError() {
 
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
+        .performScrollTo()
         .assertTextEquals("Password cannot be empty")
   }
 
   @Test
   fun emptyPasswordDoesNotCallVM() {
 
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
+
     verify(authViewModel, never()).logInWithEmail(any(), any())
   }
 
   @Test
   fun validSignInAttemptNavigatesToProfileScreen() {
 
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 
   @Test
   fun validSignInAttemptCallsVMLogInWithEmail() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    verify(authViewModel).logInWithEmail(eq(email), eq(password))
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performScrollTo().performClick()
+
+    verify(authViewModel).logInWithEmail(eq(EMAIL), eq(PASSWORD))
   }
 
   @Test
   fun signUpHereNavigatesToSignUpScreen() {
-    composeTestRule.onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON)
+        .performScrollTo()
+        .performClick()
+
     verify(navigationActions).navigateTo(Screen.SIGN_UP)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -6,11 +6,14 @@ import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignUpScreen
+import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
+import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
@@ -30,16 +33,16 @@ class SignUpScreenTest {
   private lateinit var authViewModel: AuthenticationViewModel
 
   companion object {
-    private const val email = "test@example.com"
-    private const val invalidEmail = "invalidEmail"
-    private const val password = "Passw0rd*"
-    private const val tooShort = "short"
-    private const val noCapital = "password"
-    private const val noMinuscule = "PASSWORD"
-    private const val noNumber = "Password"
-    private const val noSpecial = "Passw0rd"
-    private const val doNotMatch1 = "Password1*"
-    private const val doNotMatch2 = "Password2*"
+    private const val EMAIL = "test@example.com"
+    private const val INVALID_EMAIL = "invalidEmail"
+    private const val PASSWORD = "Passw0rd*"
+    private const val PSW_TOO_SHORT = "short"
+    private const val PSW_NO_CAPITAL = "password"
+    private const val PSW_NO_MINUSCULE = "PASSWORD"
+    private const val PSW_NO_NUMBER = "Password"
+    private const val PSW_NO_SPECIAL = "Passw0rd"
+    private const val PSW_DO_NOT_MATCH_1 = "Password1*"
+    private const val PSW_DO_NOT_MATCH_2 = "Password2*"
   }
 
   @Before
@@ -56,85 +59,168 @@ class SignUpScreenTest {
   @Test
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(SignUpScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
     composeTestRule.onNodeWithTag(AuthenticationScreens.BACKGROUND).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.WELCOME_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignUpScreen.INSTRUCTION_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).assertIsDisplayed()
+
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.WELCOME_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.INSTRUCTION_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_VISIBILITY_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().assertIsDisplayed()
   }
 
   @Test
   fun emptyEmailShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
         .assertTextEquals("Email cannot be empty")
   }
 
   @Test
   fun emptyEmailDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
+
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun invalidEmailShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(invalidEmail)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(INVALID_EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_ERROR_TEXT)
+        .performScrollTo()
         .assertTextEquals("Email must contain @")
   }
 
   @Test
   fun invalidEmailDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(invalidEmail)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(INVALID_EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
+
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun emptyPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
+        .performScrollTo()
         .assertTextEquals("Password cannot be empty")
   }
 
   @Test
   fun emptyPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
+
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun emptyConfirmedPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT)
         .assertTextEquals("Passwords do not match")
@@ -142,19 +228,29 @@ class SignUpScreenTest {
 
   @Test
   fun emptyConfirmedPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun emptyPasswordOnlyShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .performScrollTo()
+        .performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performScrollTo()
+        .performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT)
         .assertTextEquals("Password cannot be empty")
@@ -162,17 +258,21 @@ class SignUpScreenTest {
 
   @Test
   fun emptyPasswordOnlyDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun tooShortPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(tooShort)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(tooShort)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_TOO_SHORT)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_TOO_SHORT)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -182,18 +282,26 @@ class SignUpScreenTest {
 
   @Test
   fun tooShortPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(tooShort)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(tooShort)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_TOO_SHORT)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_TOO_SHORT)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun noCapitalPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noCapital)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noCapital)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_CAPITAL)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_CAPITAL)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -203,20 +311,26 @@ class SignUpScreenTest {
 
   @Test
   fun noCapitalPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noCapital)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noCapital)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_CAPITAL)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_CAPITAL)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun noMinusculePasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
-        .performTextInput(noMinuscule)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noMinuscule)
+        .performTextInput(PSW_NO_MINUSCULE)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_MINUSCULE)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -226,20 +340,26 @@ class SignUpScreenTest {
 
   @Test
   fun noMinusculePasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
-        .performTextInput(noMinuscule)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noMinuscule)
+        .performTextInput(PSW_NO_MINUSCULE)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_MINUSCULE)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun noNumberPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noNumber)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noNumber)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_NUMBER)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_NUMBER)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -249,18 +369,26 @@ class SignUpScreenTest {
 
   @Test
   fun noNumberPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noNumber)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noNumber)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_NUMBER)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_NUMBER)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun noSpecialPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noSpecial)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_SPECIAL)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_SPECIAL)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -270,20 +398,26 @@ class SignUpScreenTest {
 
   @Test
   fun noSpecialPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noSpecial)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noSpecial)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .performTextInput(PSW_NO_SPECIAL)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_NO_SPECIAL)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun doNotMatchPasswordShowsCorrectError() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
-        .performTextInput(doNotMatch1)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(doNotMatch2)
+        .performTextInput(PSW_DO_NOT_MATCH_1)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_DO_NOT_MATCH_2)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT).assertIsDisplayed()
     composeTestRule
@@ -293,30 +427,32 @@ class SignUpScreenTest {
 
   @Test
   fun doNotMatchPasswordDoesNotCallVM() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule
         .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
-        .performTextInput(doNotMatch1)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(doNotMatch2)
+        .performTextInput(PSW_DO_NOT_MATCH_1)
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD)
+        .performTextInput(PSW_DO_NOT_MATCH_2)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(authViewModel, never()).signUpWithEmail(any(), any())
   }
 
   @Test
   fun validSignUpAttemptNavigatesToCreateProfileScreen() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
     verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
   }
 
   @Test
   fun validSignUpAttemptCallsVMLogInWithEmail() {
-    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
-    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
-    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
+    composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(PASSWORD)
+    composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel).signUpWithEmail(eq(email), eq(password))
+    verify(authViewModel).signUpWithEmail(eq(EMAIL), eq(PASSWORD))
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/map/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/map/MapScreenTest.kt
@@ -78,6 +78,9 @@ class MapScreenTest {
     composeTestRule.onNodeWithTag(TopAppBar.TITLE_TEXT).assertIsDisplayed().assertTextEquals("Map")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+
+    // TODO: Change logic here with C.kt file test tags
+    composeTestRule.onNodeWithTag("MapView").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -3,11 +3,11 @@ package com.android.periodpals.ui.profile
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.periodpals.model.user.User
@@ -61,15 +61,33 @@ class CreateProfileTest {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.MANDATORY_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.MANDATORY_SECTION)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(ProfileScreens.SAVE_BUTTON)
-        .assertIsDisplayed()
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals("Save")
         .assertHasClickAction()
@@ -78,11 +96,9 @@ class CreateProfileTest {
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
         .assertTextEquals("Create Your Account")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
-    composeTestRule
-        .onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU)
-        .assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
   }
 
   @Test
@@ -90,7 +106,10 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/2000")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("01/01/2000")
     assertTrue(validateDate("01/01/2000"))
     assertTrue(validateDate("31/12/1999"))
   }
@@ -100,7 +119,10 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("invalid_date")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("invalid_date")
     assertFalse(validateDate("32/01/2000")) // Invalid day
     assertFalse(validateDate("01/13/2000")) // Invalid month
     assertFalse(validateDate("01/01/abcd")) // Invalid year
@@ -109,35 +131,41 @@ class CreateProfileTest {
   }
 
   @Test
-  fun createInvalidProfileNoDob() {
+  fun createInvalidProfileNoName() {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(dob)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
     verify(userViewModel, never()).saveUser(any())
-
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
-  fun createInvalidProfileNoName() {
+  fun createInvalidProfileNoDob() {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
     verify(userViewModel, never()).saveUser(any())
-
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -147,12 +175,17 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
     verify(userViewModel, never()).saveUser(any())
-
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -162,15 +195,21 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(mutableStateOf(null))
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
     verify(userViewModel).saveUser(any())
-
     verify(navigationActions, never()).navigateTo(Screen.PROFILE)
   }
 
@@ -179,15 +218,21 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput(description)
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
     verify(userViewModel).saveUser(any())
-
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -3,6 +3,7 @@ package com.android.periodpals.ui.profile
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -61,6 +62,15 @@ class CreateProfileTest {
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(CreateProfileScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(TopAppBar.TITLE_TEXT)
+        .assertIsDisplayed()
+        .assertTextEquals("Create Your Account")
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
         .performScrollTo()
@@ -91,14 +101,6 @@ class CreateProfileTest {
         .assertIsDisplayed()
         .assertTextEquals("Save")
         .assertHasClickAction()
-    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(TopAppBar.TITLE_TEXT)
-        .assertIsDisplayed()
-        .assertTextEquals("Create Your Account")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
-    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -1,5 +1,6 @@
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -42,6 +43,15 @@ class EditProfileTest {
   @Test
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(TopAppBar.TITLE_TEXT)
+        .assertIsDisplayed()
+        .assertTextEquals("Edit Your Profile")
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
         .performScrollTo()
@@ -76,14 +86,6 @@ class EditProfileTest {
         .assertIsDisplayed()
         .assertTextEquals("Save")
         .assertHasClickAction()
-    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(TopAppBar.TITLE_TEXT)
-        .assertIsDisplayed()
-        .assertTextEquals("Edit Your Profile")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
-    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -48,7 +48,7 @@ class EditProfileTest {
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
         .assertTextEquals("Edit Your Profile")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
 

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -1,10 +1,10 @@
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -42,15 +42,37 @@ class EditProfileTest {
   @Test
   fun allComponentsAreDisplayed() {
     composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(EditProfileScreen.EDIT_PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.MANDATORY_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(EditProfileScreen.EDIT_PROFILE_PICTURE)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.MANDATORY_SECTION)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.YOUR_PROFILE_SECTION)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(ProfileScreens.SAVE_BUTTON)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals("Save")
         .assertHasClickAction()
@@ -59,68 +81,139 @@ class EditProfileTest {
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
         .assertTextEquals("Edit Your Profile")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
     composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertDoesNotExist()
   }
 
   @Test
   fun editValidProfile() {
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("John Doe")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("01/01/1990")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
 
   @Test
   fun editInvalidProfileNoName() {
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("01/01/1990")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileNoDOB() {
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("John Doe")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
         .performTextInput("A short bio")
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileNoDescription() {
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("John Doe")
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 
   @Test
   fun editInvalidProfileAllEmptyFields() {
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextClearance()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions, never()).navigateTo(any<String>())
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -2,6 +2,7 @@ package com.android.periodpals.ui.profile
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -52,6 +53,15 @@ class ProfileScreenTest {
     composeTestRule.setContent { ProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(TopAppBar.TITLE_TEXT)
+        .assertIsDisplayed()
+        .assertTextEquals("Your Profile")
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
         .performScrollTo()
@@ -82,14 +92,6 @@ class ProfileScreenTest {
         .onNodeWithTag(ProfileScreen.NO_REVIEWS_CARD)
         .performScrollTo()
         .assertIsDisplayed()
-    composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
-    composeTestRule
-        .onNodeWithTag(TopAppBar.TITLE_TEXT)
-        .assertIsDisplayed()
-        .assertTextEquals("Your Profile")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
   }
 
   @Test
@@ -97,7 +99,7 @@ class ProfileScreenTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { ProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).performScrollTo().performClick()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).performClick()
 
     verify(navigationActions).navigateTo(Screen.EDIT_PROFILE)
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -2,11 +2,11 @@ package com.android.periodpals.ui.profile
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
@@ -52,25 +52,44 @@ class ProfileScreenTest {
     composeTestRule.setContent { ProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreens.PROFILE_PICTURE).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.CONTRIBUTION_FIELD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.PROFILE_PICTURE)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.CONTRIBUTION_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(ProfileScreen.REVIEWS_SECTION)
+        .performScrollTo()
         .assertIsDisplayed()
         .assertTextEquals("Reviews")
-    composeTestRule.onNodeWithTag(ProfileScreen.NO_REVIEWS_ICON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.NO_REVIEWS_TEXT).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ProfileScreen.NO_REVIEWS_CARD).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.NO_REVIEWS_ICON)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.NO_REVIEWS_TEXT)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.NO_REVIEWS_CARD)
+        .performScrollTo()
+        .assertIsDisplayed()
     composeTestRule.onNodeWithTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
         .assertTextEquals("Your Profile")
-    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertDoesNotExist()
   }
 
   @Test
@@ -78,7 +97,8 @@ class ProfileScreenTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { ProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).performScrollTo().performClick()
+
     verify(navigationActions).navigateTo(Screen.EDIT_PROFILE)
   }
 
@@ -87,8 +107,11 @@ class ProfileScreenTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { ProfileScreen(userViewModel, navigationActions) }
 
-    composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertTextEquals(name)
-    composeTestRule.onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD).assertTextEquals(description)
+    composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).performScrollTo().assertTextEquals(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)
+        .performScrollTo()
+        .assertTextEquals(description)
   }
 
   @Test
@@ -98,9 +121,11 @@ class ProfileScreenTest {
 
     composeTestRule
         .onNodeWithTag(ProfileScreen.NAME_FIELD)
+        .performScrollTo()
         .assertTextEquals("Error loading name, try again later.")
     composeTestRule
         .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)
+        .performScrollTo()
         .assertTextEquals("Error loading description, try again later.")
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/timer/TimerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/timer/TimerScreenTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import com.android.periodpals.resources.C.Tag.TimerScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -39,6 +40,6 @@ class TimerScreenTest {
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
 
-    composeTestRule.onNodeWithTag(TimerScreen.TIMER_TEXT).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TimerScreen.TIMER_TEXT).performScrollTo().assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/android/periodpals/ui/timer/TimerScreenTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/timer/TimerScreenTest.kt
@@ -38,5 +38,7 @@ class TimerScreenTest {
         .assertTextEquals("Tampon Timer")
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsNotDisplayed()
+
+    composeTestRule.onNodeWithTag(TimerScreen.TIMER_TEXT).assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -17,7 +17,6 @@ object C {
       const val URGENCY_FIELD = "urgencyField"
       const val DROPDOWN_ITEM = "dropdownItem"
       const val LOCATION_FIELD = "locationField"
-      const val GPS_ICON = "gpsIcon"
       const val MESSAGE_FIELD = "messageField"
       const val SUBMIT_BUTTON = "submitButton"
     }

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -17,6 +17,7 @@ object C {
       const val URGENCY_FIELD = "urgencyField"
       const val DROPDOWN_ITEM = "dropdownItem"
       const val LOCATION_FIELD = "locationField"
+      const val GPS_ICON = "gpsIcon"
       const val MESSAGE_FIELD = "messageField"
       const val SUBMIT_BUTTON = "submitButton"
     }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -99,14 +100,18 @@ fun AlertListsScreen(
         Column(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
           TopAppBar(title = SCREEN_TITLE)
           TabRow(
-              selectedTabIndex = selectedTab.ordinal,
               modifier =
                   Modifier.fillMaxWidth().wrapContentHeight().testTag(AlertListsScreen.TAB_ROW),
+              selectedTabIndex = selectedTab.ordinal,
           ) {
             Tab(
                 modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.MY_ALERTS_TAB),
                 text = {
-                  Text(text = MY_ALERTS_TAB_TITLE, style = MaterialTheme.typography.headlineSmall)
+                  Text(
+                      modifier = Modifier.wrapContentSize(),
+                      text = MY_ALERTS_TAB_TITLE,
+                      style = MaterialTheme.typography.headlineSmall,
+                  )
                 },
                 selected = selectedTab == AlertListsTab.MY_ALERTS,
                 onClick = { selectedTab = AlertListsTab.MY_ALERTS },
@@ -114,7 +119,11 @@ fun AlertListsScreen(
             Tab(
                 modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.PALS_ALERTS_TAB),
                 text = {
-                  Text(text = PALS_ALERTS_TAB_TITLE, style = MaterialTheme.typography.headlineSmall)
+                  Text(
+                      modifier = Modifier.wrapContentSize(),
+                      text = PALS_ALERTS_TAB_TITLE,
+                      style = MaterialTheme.typography.headlineSmall,
+                  )
                 },
                 selected = selectedTab == AlertListsTab.PALS_ALERTS,
                 onClick = { selectedTab = AlertListsTab.PALS_ALERTS },
@@ -363,15 +372,15 @@ private fun AlertProfilePicture(idTestTag: String) {
 private fun AlertTimeAndLocation(alert: Alert, idTestTag: String) {
   val formattedTime = LocalDateTime.parse(alert.createdAt).format(DATE_FORMATTER)
   Text(
-      text = "${formattedTime}, ${alert.location}",
-      textAlign = TextAlign.Left,
-      style = MaterialTheme.typography.labelMedium,
-      fontWeight = FontWeight.SemiBold,
-      softWrap = true,
       modifier =
           Modifier.fillMaxWidth()
               .wrapContentHeight()
               .testTag(AlertListsScreen.ALERT_TIME_AND_LOCATION + idTestTag),
+      text = "${formattedTime}, ${alert.location}",
+      fontWeight = FontWeight.SemiBold,
+      textAlign = TextAlign.Left,
+      softWrap = true,
+      style = MaterialTheme.typography.labelMedium,
   )
 }
 
@@ -418,73 +427,81 @@ private fun AlertProductAndUrgency(idTestTag: String) {
 private fun AlertAcceptButtons(idTestTag: String) {
   val context = LocalContext.current // TODO: Delete when implement accept / reject alert action
   Row(
-      modifier = Modifier.wrapContentSize().testTag(PalsAlertItem.PAL_BUTTONS + idTestTag),
+      modifier =
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(PalsAlertItem.PAL_BUTTONS + idTestTag),
       horizontalArrangement =
           Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
       verticalAlignment = Alignment.CenterVertically,
   ) {
     // Accept alert button
-    Button(
+    AlertActionButton(
+        text = PAL_ALERT_ACCEPT_TEXT,
+        icon = Icons.Outlined.Check,
         onClick = {
           // TODO: Implement accept alert action
           Toast.makeText(context, "To implement accept alert action", Toast.LENGTH_SHORT).show()
         },
-        enabled = true,
-        border =
-            BorderStroke(
-                width = MaterialTheme.dimens.borderLine,
-                color = MaterialTheme.colorScheme.onSecondaryContainer),
-        modifier = Modifier.wrapContentSize().testTag(PalsAlertItem.PAL_ACCEPT_BUTTON + idTestTag),
-    ) {
-      Row(
-          modifier = Modifier.wrapContentSize(),
-          horizontalArrangement =
-              Arrangement.spacedBy(MaterialTheme.dimens.small1, Alignment.CenterHorizontally),
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Icon(
-            imageVector = Icons.Outlined.Check,
-            contentDescription = "Accept Alert",
-            modifier = Modifier.size(MaterialTheme.dimens.iconSizeSmall),
-        )
-        Text(
-            text = PAL_ALERT_ACCEPT_TEXT,
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.wrapContentSize(),
-        )
-      }
-    }
+        contentDescription = "Accept Alert",
+        testTag = PalsAlertItem.PAL_ACCEPT_BUTTON + idTestTag,
+    )
 
     // Decline alert button
-    Button(
+    AlertActionButton(
+        text = PAL_ALERT_DECLINE_TEXT,
+        icon = Icons.Outlined.Close,
         onClick = {
           // TODO: Implement decline alert action
           Toast.makeText(context, "To implement decline alert action", Toast.LENGTH_SHORT).show()
         },
-        enabled = true,
-        border =
-            BorderStroke(
-                width = MaterialTheme.dimens.borderLine,
-                color = MaterialTheme.colorScheme.onSecondaryContainer),
-        modifier = Modifier.wrapContentSize().testTag(PalsAlertItem.PAL_DECLINE_BUTTON + idTestTag),
+        contentDescription = "Decline Alert",
+        testTag = PalsAlertItem.PAL_DECLINE_BUTTON + idTestTag,
+    )
+  }
+}
+
+/**
+ * Composable function that displays an alert action button with an icon and text.
+ *
+ * @param text The text to be displayed on the button.
+ * @param icon The icon to be displayed on the button.
+ * @param onClick The action to be executed when the button is clicked.
+ * @param testTag The test tag for the button.
+ */
+@Composable
+private fun AlertActionButton(
+    text: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    contentDescription: String,
+    testTag: String
+) {
+  Button(
+      onClick = onClick,
+      enabled = true,
+      border =
+          BorderStroke(
+              width = MaterialTheme.dimens.borderLine,
+              color = MaterialTheme.colorScheme.onSecondaryContainer),
+      modifier = Modifier.wrapContentSize().testTag(testTag),
+  ) {
+    Row(
+        modifier = Modifier.wrapContentSize(),
+        horizontalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small1, Alignment.CenterHorizontally),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-      Row(
+      Icon(
+          imageVector = icon,
+          contentDescription = contentDescription,
+          modifier = Modifier.size(MaterialTheme.dimens.iconSizeSmall),
+      )
+      Text(
+          text = text,
+          style = MaterialTheme.typography.labelMedium,
           modifier = Modifier.wrapContentSize(),
-          horizontalArrangement =
-              Arrangement.spacedBy(MaterialTheme.dimens.small1, Alignment.CenterHorizontally),
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Icon(
-            imageVector = Icons.Outlined.Close,
-            contentDescription = "Decline Alert",
-            modifier = Modifier.size(MaterialTheme.dimens.iconSizeSmall),
-        )
-        Text(
-            text = PAL_ALERT_DECLINE_TEXT,
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.wrapContentSize(),
-        )
-      }
+      )
     }
   }
 }
@@ -508,15 +525,15 @@ private fun NoAlertDialog(text: String) {
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       Icon(
-          imageVector = Icons.Outlined.SentimentVerySatisfied,
-          contentDescription = "No Alert Emoji",
           modifier =
               Modifier.size(MaterialTheme.dimens.iconSize).testTag(AlertListsScreen.NO_ALERTS_ICON),
+          imageVector = Icons.Outlined.SentimentVerySatisfied,
+          contentDescription = "No Alert Emoji",
       )
       Text(
+          modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.NO_ALERTS_TEXT),
           text = text,
           style = MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.NO_ALERTS_TEXT),
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -178,8 +177,7 @@ private fun MyAlertItem(alert: Alert) {
   Card(
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(MyAlertItem.MY_ALERT + idTestTag),
-      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRounded),
-      colors = CardDefaults.elevatedCardColors(),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Row(
@@ -262,8 +260,7 @@ fun PalsAlertItem(alert: Alert) {
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(PalsAlertItem.PAL_ALERT + idTestTag),
       onClick = { isClicked = !isClicked },
-      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRounded),
-      colors = CardDefaults.elevatedCardColors(),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
@@ -496,10 +493,8 @@ private fun AlertAcceptButtons(idTestTag: String) {
 @Composable
 private fun NoAlertDialog(text: String) {
   Card(
-      modifier =
-          Modifier.wrapContentSize()
-              .clip(RoundedCornerShape(size = MaterialTheme.dimens.small2))
-              .testTag(AlertListsScreen.NO_ALERTS_CARD),
+      modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.NO_ALERTS_CARD),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -430,6 +430,10 @@ private fun AlertAcceptButtons(idTestTag: String) {
           Toast.makeText(context, "To implement accept alert action", Toast.LENGTH_SHORT).show()
         },
         enabled = true,
+        border =
+            BorderStroke(
+                width = MaterialTheme.dimens.borderLine,
+                color = MaterialTheme.colorScheme.onSecondaryContainer),
         modifier = Modifier.wrapContentSize().testTag(PalsAlertItem.PAL_ACCEPT_BUTTON + idTestTag),
     ) {
       Row(

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -180,7 +180,7 @@ private fun MyAlertItem(alert: Alert) {
           Modifier.fillMaxWidth().wrapContentHeight().testTag(MyAlertItem.MY_ALERT + idTestTag),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRounded),
       colors = CardDefaults.elevatedCardColors(),
-      elevation = CardDefaults.cardElevation(MaterialTheme.dimens.small1),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Row(
         modifier =
@@ -188,7 +188,8 @@ private fun MyAlertItem(alert: Alert) {
                 .wrapContentHeight()
                 .padding(
                     horizontal = MaterialTheme.dimens.small3,
-                    vertical = MaterialTheme.dimens.small1),
+                    vertical = MaterialTheme.dimens.small1,
+                ),
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimens.small3, Alignment.Start),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -263,7 +264,7 @@ fun PalsAlertItem(alert: Alert) {
       onClick = { isClicked = !isClicked },
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRounded),
       colors = CardDefaults.elevatedCardColors(),
-      elevation = CardDefaults.cardElevation(MaterialTheme.dimens.small1),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
         modifier =
@@ -271,7 +272,8 @@ fun PalsAlertItem(alert: Alert) {
                 .wrapContentHeight()
                 .padding(
                     horizontal = MaterialTheme.dimens.small3,
-                    vertical = MaterialTheme.dimens.small1),
+                    vertical = MaterialTheme.dimens.small1,
+                ),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small1, Alignment.CenterVertically),
@@ -498,7 +500,7 @@ private fun NoAlertDialog(text: String) {
           Modifier.wrapContentSize()
               .clip(RoundedCornerShape(size = MaterialTheme.dimens.small2))
               .testTag(AlertListsScreen.NO_ALERTS_CARD),
-      elevation = CardDefaults.cardElevation(MaterialTheme.dimens.small1),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
         modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small3),

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -137,7 +137,8 @@ fun AlertListsScreen(
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3),
+                    vertical = MaterialTheme.dimens.small3,
+                ),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.Top),
     ) {

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -498,7 +498,7 @@ private fun NoAlertDialog(text: String) {
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
-        modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small3),
+        modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small2),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -195,7 +195,12 @@ fun CreateAlertScreen(
               },
               contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
               leadingIcon = {
-                Icon(imageVector = Icons.Filled.GpsFixed, contentDescription = "GPS icon")
+                Icon(
+                    imageVector = Icons.Filled.GpsFixed,
+                    contentDescription = "GPS icon",
+                    modifier =
+                        Modifier.size(MaterialTheme.dimens.iconSize)
+                            .testTag(CreateAlertScreen.GPS_ICON))
               })
           Log.d("CreateAlertScreen", "Location suggestions: $locationSuggestions")
           locationSuggestions.take(MAX_LOCATION_SUGGESTIONS).forEach { location ->
@@ -226,7 +231,7 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */},
+                onClick = { /* TODO show more results */ },
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -120,7 +120,8 @@ fun CreateAlertScreen(
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3)
+                    vertical = MaterialTheme.dimens.small3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
@@ -196,7 +197,7 @@ fun CreateAlertScreen(
               leadingIcon = {
                 Icon(imageVector = Icons.Filled.GpsFixed, contentDescription = "GPS icon")
               })
-          Log.d("CreateAlertScreen", "Location suggestions: ${locationSuggestions}")
+          Log.d("CreateAlertScreen", "Location suggestions: $locationSuggestions")
           locationSuggestions.take(MAX_LOCATION_SUGGESTIONS).forEach { location ->
             DropdownMenuItem(
                 text = {

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -231,7 +231,7 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */ },
+                onClick = { /* TODO show more results */},
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -229,7 +229,7 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */ },
+                onClick = { /* TODO show more results */},
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -198,9 +198,7 @@ fun CreateAlertScreen(
                 Icon(
                     imageVector = Icons.Filled.GpsFixed,
                     contentDescription = "GPS icon",
-                    modifier =
-                        Modifier.size(MaterialTheme.dimens.iconSize)
-                            .testTag(CreateAlertScreen.GPS_ICON))
+                    modifier = Modifier.size(MaterialTheme.dimens.iconSize))
               })
           Log.d("CreateAlertScreen", "Location suggestions: $locationSuggestions")
           locationSuggestions.take(MAX_LOCATION_SUGGESTIONS).forEach { location ->
@@ -231,7 +229,7 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */},
+                onClick = { /* TODO show more results */ },
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -18,8 +18,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
@@ -96,110 +97,106 @@ fun SignInScreen(
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
 
-  Scaffold(modifier = Modifier.fillMaxSize().testTag(SignInScreen.SCREEN)) { padding ->
+  Scaffold(modifier = Modifier.fillMaxSize().testTag(SignInScreen.SCREEN)) { paddingValues ->
     GradedBackground()
 
-    LazyColumn(
+    Column(
         modifier =
             Modifier.fillMaxSize()
-                .padding(padding)
+                .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3,
-                ),
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
-      item { AuthenticationWelcomeText() }
+      AuthenticationWelcomeText()
 
-      item {
-        Box(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
-                    .background(Color.White)
-                    .padding(
-                        horizontal = MaterialTheme.dimens.medium1,
-                        vertical = MaterialTheme.dimens.small3,
-                    )) {
-              Column(
-                  modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement =
-                      Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-              ) {
-                Text(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .wrapContentHeight()
-                            .testTag(SignInScreen.INSTRUCTION_TEXT),
-                    text = SIGN_IN_INSTRUCTION,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                AuthenticationEmailInput(
-                    email = email,
-                    onEmailChange = { email = it },
-                    emailErrorMessage = emailErrorMessage,
-                )
-                AuthenticationPasswordInput(
-                    password = password,
-                    onPasswordChange = { password = it },
-                    passwordVisible = passwordVisible,
-                    onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                    passwordErrorMessage = passwordErrorMessage,
-                )
-                AuthenticationSubmitButton(
-                    text = SIGN_IN_BUTTON_TEXT,
-                    onClick = {
-                      attemptSignIn(
-                          email = email,
-                          setEmailErrorMessage = setEmailErrorMessage,
-                          password = password,
-                          setPasswordErrorMessage = setPasswordErrorMessage,
-                          authenticationViewModel = authenticationViewModel,
-                          userState = userState,
-                          context = context,
-                          navigationActions = navigationActions,
-                      )
-                    },
-                    testTag = SignInScreen.SIGN_IN_BUTTON,
-                )
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .wrapContentHeight()
+                  .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
+                  .background(Color.White)
+                  .padding(
+                      horizontal = MaterialTheme.dimens.medium1,
+                      vertical = MaterialTheme.dimens.small3,
+                  )) {
+            Column(
+                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement =
+                    Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+            ) {
+              Text(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentHeight()
+                          .testTag(SignInScreen.INSTRUCTION_TEXT),
+                  text = SIGN_IN_INSTRUCTION,
+                  textAlign = TextAlign.Center,
+                  style = MaterialTheme.typography.bodyLarge,
+              )
+              AuthenticationEmailInput(
+                  email = email,
+                  onEmailChange = { email = it },
+                  emailErrorMessage = emailErrorMessage,
+              )
+              AuthenticationPasswordInput(
+                  password = password,
+                  onPasswordChange = { password = it },
+                  passwordVisible = passwordVisible,
+                  onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+                  passwordErrorMessage = passwordErrorMessage,
+              )
+              AuthenticationSubmitButton(
+                  text = SIGN_IN_BUTTON_TEXT,
+                  onClick = {
+                    attemptSignIn(
+                        email = email,
+                        setEmailErrorMessage = setEmailErrorMessage,
+                        password = password,
+                        setPasswordErrorMessage = setPasswordErrorMessage,
+                        authenticationViewModel = authenticationViewModel,
+                        userState = userState,
+                        context = context,
+                        navigationActions = navigationActions,
+                    )
+                  },
+                  testTag = SignInScreen.SIGN_IN_BUTTON,
+              )
 
-                Text(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .wrapContentHeight()
-                            .testTag(SignInScreen.CONTINUE_WITH_TEXT),
-                    text = CONTINUE_WITH_TEXT,
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+              Text(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentHeight()
+                          .testTag(SignInScreen.CONTINUE_WITH_TEXT),
+                  text = CONTINUE_WITH_TEXT,
+                  textAlign = TextAlign.Center,
+                  style = MaterialTheme.typography.bodyLarge,
+              )
 
-                AuthenticationGoogleButton(context)
-              }
+              AuthenticationGoogleButton(context)
             }
-      }
+          }
 
-      item {
-        Row(
-            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-          Text(text = NO_ACCOUNT_TEXT, style = MaterialTheme.typography.bodyMedium)
+      Row(
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(text = NO_ACCOUNT_TEXT, style = MaterialTheme.typography.bodyMedium)
 
-          Text(
-              text = SIGN_UP_TEXT,
-              modifier =
-                  Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                      .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-              color = Color.Blue,
-              style = MaterialTheme.typography.bodyMedium,
-          )
-        }
+        Text(
+            text = SIGN_UP_TEXT,
+            modifier =
+                Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+            color = Color.Blue,
+            style = MaterialTheme.typography.bodyMedium,
+        )
       }
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -60,6 +60,7 @@ private const val DEFAULT_PASSWORD_VISIBILITY = false
 private const val SIGN_IN_INSTRUCTION = "Sign in to your account"
 private const val SIGN_IN_BUTTON_TEXT = "Sign in"
 private const val CONTINUE_WITH_TEXT = "Or continue with"
+private const val SIGN_UP_WITH_GOOGLE = "Sign in with Google"
 private const val NO_ACCOUNT_TEXT = "Not registered yet? "
 private const val SIGN_UP_TEXT = "Sign up here!"
 
@@ -188,13 +189,17 @@ fun SignInScreen(
           horizontalArrangement = Arrangement.Center,
           verticalAlignment = Alignment.CenterVertically,
       ) {
-        Text(text = NO_ACCOUNT_TEXT, style = MaterialTheme.typography.bodyMedium)
+        Text(
+            modifier = Modifier.wrapContentSize(),
+            text = NO_ACCOUNT_TEXT,
+            style = MaterialTheme.typography.bodyMedium)
 
         Text(
-            text = SIGN_UP_TEXT,
             modifier =
-                Modifier.clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                Modifier.wrapContentSize()
+                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
                     .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+            text = SIGN_UP_TEXT,
             color = Color.Blue,
             style = MaterialTheme.typography.bodyMedium,
         )
@@ -223,6 +228,7 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
       border = BorderStroke(MaterialTheme.dimens.borderLine, Color.LightGray),
   ) {
     Row(
+        modifier = Modifier.wrapContentSize(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
@@ -233,9 +239,11 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
           modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
       Text(
-          text = "Sign in with Google",
+          modifier = Modifier.wrapContentSize(),
+          text = SIGN_UP_WITH_GOOGLE,
           color = Color.Black,
           fontWeight = FontWeight.Medium,
+          softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
       )
     }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -15,12 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -42,6 +39,7 @@ import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
+import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
 import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
@@ -113,97 +111,79 @@ fun SignInScreen(
     ) {
       AuthenticationWelcomeText()
 
-      Card(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-          colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
-          elevation =
-              CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
-      ) {
-        Column(
+      AuthenticationCard {
+        Text(
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
+            text = SIGN_IN_INSTRUCTION,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+
+        AuthenticationEmailInput(
+            email = email,
+            onEmailChange = { email = it },
+            emailErrorMessage = emailErrorMessage,
+        )
+
+        AuthenticationPasswordInput(
+            password = password,
+            onPasswordChange = { password = it },
+            passwordVisible = passwordVisible,
+            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordErrorMessage = passwordErrorMessage,
+        )
+
+        AuthenticationSubmitButton(
+            text = SIGN_IN_BUTTON_TEXT,
+            onClick = {
+              attemptSignIn(
+                  email = email,
+                  setEmailErrorMessage = setEmailErrorMessage,
+                  password = password,
+                  setPasswordErrorMessage = setPasswordErrorMessage,
+                  authenticationViewModel = authenticationViewModel,
+                  userState = userState,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignInScreen.SIGN_IN_BUTTON,
+        )
+
+        Text(
             modifier =
                 Modifier.fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(
-                        horizontal = MaterialTheme.dimens.medium1,
-                        vertical = MaterialTheme.dimens.small3,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement =
-                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-        ) {
-          Text(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .wrapContentHeight()
-                      .testTag(SignInScreen.INSTRUCTION_TEXT),
-              text = SIGN_IN_INSTRUCTION,
-              textAlign = TextAlign.Center,
-              style = MaterialTheme.typography.bodyLarge,
-          )
-          AuthenticationEmailInput(
-              email = email,
-              onEmailChange = { email = it },
-              emailErrorMessage = emailErrorMessage,
-          )
-          AuthenticationPasswordInput(
-              password = password,
-              onPasswordChange = { password = it },
-              passwordVisible = passwordVisible,
-              onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-              passwordErrorMessage = passwordErrorMessage,
-          )
-          AuthenticationSubmitButton(
-              text = SIGN_IN_BUTTON_TEXT,
-              onClick = {
-                attemptSignIn(
-                    email = email,
-                    setEmailErrorMessage = setEmailErrorMessage,
-                    password = password,
-                    setPasswordErrorMessage = setPasswordErrorMessage,
-                    authenticationViewModel = authenticationViewModel,
-                    userState = userState,
-                    context = context,
-                    navigationActions = navigationActions,
-                )
-              },
-              testTag = SignInScreen.SIGN_IN_BUTTON,
-          )
-
-          Text(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .wrapContentHeight()
-                      .testTag(SignInScreen.CONTINUE_WITH_TEXT),
-              text = CONTINUE_WITH_TEXT,
-              textAlign = TextAlign.Center,
-              style = MaterialTheme.typography.bodyLarge,
-          )
-
-          AuthenticationGoogleButton(context)
-        }
-      }
-
-      Row(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          horizontalArrangement = Arrangement.Center,
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Text(
-            modifier = Modifier.wrapContentSize(),
-            text = NO_ACCOUNT_TEXT,
-            style = MaterialTheme.typography.bodyMedium)
-
-        Text(
-            modifier =
-                Modifier.wrapContentSize()
-                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-            text = SIGN_UP_TEXT,
-            color = Color.Blue,
-            style = MaterialTheme.typography.bodyMedium,
+                    .testTag(SignInScreen.CONTINUE_WITH_TEXT),
+            text = CONTINUE_WITH_TEXT,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
+
+        AuthenticationGoogleButton(context)
       }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text(
+          modifier = Modifier.wrapContentSize(),
+          text = NO_ACCOUNT_TEXT,
+          style = MaterialTheme.typography.bodyMedium)
+
+      Text(
+          modifier =
+              Modifier.wrapContentSize()
+                  .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                  .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+          text = SIGN_UP_TEXT,
+          color = Color.Blue,
+          style = MaterialTheme.typography.bodyMedium,
+      )
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -123,64 +123,66 @@ fun SignInScreen(
                   .padding(
                       horizontal = MaterialTheme.dimens.medium1,
                       vertical = MaterialTheme.dimens.small3,
-                  )) {
-            Column(
-                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement =
-                    Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-            ) {
-              Text(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .wrapContentHeight()
-                          .testTag(SignInScreen.INSTRUCTION_TEXT),
-                  text = SIGN_IN_INSTRUCTION,
-                  textAlign = TextAlign.Center,
-                  style = MaterialTheme.typography.bodyLarge,
-              )
-              AuthenticationEmailInput(
-                  email = email,
-                  onEmailChange = { email = it },
-                  emailErrorMessage = emailErrorMessage,
-              )
-              AuthenticationPasswordInput(
-                  password = password,
-                  onPasswordChange = { password = it },
-                  passwordVisible = passwordVisible,
-                  onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                  passwordErrorMessage = passwordErrorMessage,
-              )
-              AuthenticationSubmitButton(
-                  text = SIGN_IN_BUTTON_TEXT,
-                  onClick = {
-                    attemptSignIn(
-                        email = email,
-                        setEmailErrorMessage = setEmailErrorMessage,
-                        password = password,
-                        setPasswordErrorMessage = setPasswordErrorMessage,
-                        authenticationViewModel = authenticationViewModel,
-                        userState = userState,
-                        context = context,
-                        navigationActions = navigationActions,
-                    )
-                  },
-                  testTag = SignInScreen.SIGN_IN_BUTTON,
-              )
+                  ),
+          contentAlignment = Alignment.Center,
+      ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement =
+                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+        ) {
+          Text(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .wrapContentHeight()
+                      .testTag(SignInScreen.INSTRUCTION_TEXT),
+              text = SIGN_IN_INSTRUCTION,
+              textAlign = TextAlign.Center,
+              style = MaterialTheme.typography.bodyLarge,
+          )
+          AuthenticationEmailInput(
+              email = email,
+              onEmailChange = { email = it },
+              emailErrorMessage = emailErrorMessage,
+          )
+          AuthenticationPasswordInput(
+              password = password,
+              onPasswordChange = { password = it },
+              passwordVisible = passwordVisible,
+              onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+              passwordErrorMessage = passwordErrorMessage,
+          )
+          AuthenticationSubmitButton(
+              text = SIGN_IN_BUTTON_TEXT,
+              onClick = {
+                attemptSignIn(
+                    email = email,
+                    setEmailErrorMessage = setEmailErrorMessage,
+                    password = password,
+                    setPasswordErrorMessage = setPasswordErrorMessage,
+                    authenticationViewModel = authenticationViewModel,
+                    userState = userState,
+                    context = context,
+                    navigationActions = navigationActions,
+                )
+              },
+              testTag = SignInScreen.SIGN_IN_BUTTON,
+          )
 
-              Text(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .wrapContentHeight()
-                          .testTag(SignInScreen.CONTINUE_WITH_TEXT),
-                  text = CONTINUE_WITH_TEXT,
-                  textAlign = TextAlign.Center,
-                  style = MaterialTheme.typography.bodyLarge,
-              )
+          Text(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .wrapContentHeight()
+                      .testTag(SignInScreen.CONTINUE_WITH_TEXT),
+              text = CONTINUE_WITH_TEXT,
+              textAlign = TextAlign.Center,
+              style = MaterialTheme.typography.bodyLarge,
+          )
 
-              AuthenticationGoogleButton(context)
-            }
-          }
+          AuthenticationGoogleButton(context)
+        }
+      }
 
       Row(
           modifier = Modifier.fillMaxWidth().wrapContentHeight(),
@@ -217,8 +219,8 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
         Toast.makeText(context, "Use other login method for now, thanks!", Toast.LENGTH_SHORT)
             .show()
       },
-      colors = ButtonDefaults.buttonColors(containerColor = Color.White),
       shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
+      colors = ButtonDefaults.buttonColors(containerColor = Color.White),
       border = BorderStroke(MaterialTheme.dimens.borderLine, Color.LightGray),
   ) {
     Row(

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -163,27 +163,27 @@ fun SignInScreen(
 
         AuthenticationGoogleButton(context)
       }
-    }
 
-    Row(
-        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-      Text(
-          modifier = Modifier.wrapContentSize(),
-          text = NO_ACCOUNT_TEXT,
-          style = MaterialTheme.typography.bodyMedium)
+      Row(
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+            modifier = Modifier.wrapContentSize(),
+            text = NO_ACCOUNT_TEXT,
+            style = MaterialTheme.typography.bodyMedium)
 
-      Text(
-          modifier =
-              Modifier.wrapContentSize()
-                  .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                  .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-          text = SIGN_UP_TEXT,
-          color = Color.Blue,
-          style = MaterialTheme.typography.bodyMedium,
-      )
+        Text(
+            modifier =
+                Modifier.wrapContentSize()
+                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+            text = SIGN_UP_TEXT,
+            color = Color.Blue,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -219,7 +218,7 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
         Toast.makeText(context, "Use other login method for now, thanks!", Toast.LENGTH_SHORT)
             .show()
       },
-      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
+      enabled = true,
       colors = ButtonDefaults.buttonColors(containerColor = Color.White),
       border = BorderStroke(MaterialTheme.dimens.borderLine, Color.LightGray),
   ) {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -4,11 +4,8 @@ import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,9 +15,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -33,7 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -113,20 +112,21 @@ fun SignInScreen(
     ) {
       AuthenticationWelcomeText()
 
-      Box(
-          modifier =
-              Modifier.fillMaxWidth()
-                  .wrapContentHeight()
-                  .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
-                  .background(Color.White)
-                  .padding(
-                      horizontal = MaterialTheme.dimens.medium1,
-                      vertical = MaterialTheme.dimens.small3,
-                  ),
-          contentAlignment = Alignment.Center,
+      Card(
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+          colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
+          elevation =
+              CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
       ) {
         Column(
-            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(
+                        horizontal = MaterialTheme.dimens.medium1,
+                        vertical = MaterialTheme.dimens.small3,
+                    ),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement =
                 Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -106,7 +106,8 @@ fun SignInScreen(
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3)
+                    vertical = MaterialTheme.dimens.medium3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -224,14 +223,14 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
   ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
     ) {
       Image(
           painter = painterResource(id = R.drawable.google_logo),
           contentDescription = "Google Logo",
           modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
-      Spacer(modifier = Modifier.size(MaterialTheme.dimens.small2))
       Text(
           text = "Sign in with Google",
           color = Color.Black,

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -11,7 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -99,112 +100,106 @@ fun SignUpScreen(
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
 
-  Scaffold(
-      modifier = Modifier.fillMaxSize().testTag(SignUpScreen.SCREEN),
-      content = { padding ->
-        GradedBackground()
+  Scaffold(modifier = Modifier.fillMaxSize().testTag(SignUpScreen.SCREEN)) { paddingValues ->
+    GradedBackground()
 
-        LazyColumn(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(padding)
-                    .padding(
-                        horizontal = MaterialTheme.dimens.large,
-                        vertical = MaterialTheme.dimens.medium3,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement =
-                Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
-        ) {
-          item { AuthenticationWelcomeText() }
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.large,
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+    ) {
+      AuthenticationWelcomeText()
 
-          item {
-            Box(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .wrapContentHeight()
-                        .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
-                        .background(Color.White)
-                        .padding(
-                            horizontal = MaterialTheme.dimens.medium1,
-                            vertical = MaterialTheme.dimens.small3,
-                        )) {
-                  Column(
-                      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                      horizontalAlignment = Alignment.CenterHorizontally,
-                      verticalArrangement =
-                          Arrangement.spacedBy(
-                              MaterialTheme.dimens.small2, Alignment.CenterVertically),
-                  ) {
-                    Text(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .wrapContentHeight()
-                                .testTag(SignUpScreen.INSTRUCTION_TEXT),
-                        text = SIGN_UP_INSTRUCTION,
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .wrapContentHeight()
+                  .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
+                  .background(Color.White)
+                  .padding(
+                      horizontal = MaterialTheme.dimens.medium1,
+                      vertical = MaterialTheme.dimens.small3,
+                  )) {
+            Column(
+                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement =
+                    Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+            ) {
+              Text(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentHeight()
+                          .testTag(SignUpScreen.INSTRUCTION_TEXT),
+                  text = SIGN_UP_INSTRUCTION,
+                  textAlign = TextAlign.Center,
+                  style = MaterialTheme.typography.bodyLarge,
+              )
 
-                    AuthenticationEmailInput(
+              AuthenticationEmailInput(
+                  email = email,
+                  onEmailChange = { email = it },
+                  emailErrorMessage = emailErrorMessage,
+              )
+
+              AuthenticationPasswordInput(
+                  password = password,
+                  onPasswordChange = { password = it },
+                  passwordVisible = passwordVisible,
+                  onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+                  passwordErrorMessage,
+              )
+              Text(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .wrapContentHeight()
+                          .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+                  text = CONFIRM_PASSWORD_INSTRUCTION,
+                  textAlign = TextAlign.Center,
+                  style = MaterialTheme.typography.bodyLarge,
+              )
+              AuthenticationPasswordInput(
+                  password = confirmedPassword,
+                  onPasswordChange = { confirmedPassword = it },
+                  passwordVisible = confirmedPasswordVisible,
+                  onPasswordVisibilityChange = {
+                    confirmedPasswordVisible = !confirmedPasswordVisible
+                  },
+                  passwordErrorMessage = confirmedPasswordErrorMessage,
+                  passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+                  testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+                  visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+              )
+
+              AuthenticationSubmitButton(
+                  text = SIGN_UP_BUTTON_TEXT,
+                  onClick = {
+                    attemptSignUp(
                         email = email,
-                        onEmailChange = { email = it },
-                        emailErrorMessage = emailErrorMessage,
-                    )
-
-                    AuthenticationPasswordInput(
                         password = password,
-                        onPasswordChange = { password = it },
-                        passwordVisible = passwordVisible,
-                        onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                        passwordErrorMessage,
+                        confirmedPassword = confirmedPassword,
+                        setEmailErrorMessage = setEmailErrorMessage,
+                        setPasswordErrorMessage = setPasswordErrorMessage,
+                        setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
+                        authenticationViewModel = authenticationViewModel,
+                        userState = userState,
+                        context = context,
+                        navigationActions = navigationActions,
                     )
-                    Text(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .wrapContentHeight()
-                                .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-                        text = CONFIRM_PASSWORD_INSTRUCTION,
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                    AuthenticationPasswordInput(
-                        password = confirmedPassword,
-                        onPasswordChange = { confirmedPassword = it },
-                        passwordVisible = confirmedPasswordVisible,
-                        onPasswordVisibilityChange = {
-                          confirmedPasswordVisible = !confirmedPasswordVisible
-                        },
-                        passwordErrorMessage = confirmedPasswordErrorMessage,
-                        passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-                        testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-                        visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
-                    )
-
-                    AuthenticationSubmitButton(
-                        text = SIGN_UP_BUTTON_TEXT,
-                        onClick = {
-                          attemptSignUp(
-                              email = email,
-                              password = password,
-                              confirmedPassword = confirmedPassword,
-                              setEmailErrorMessage = setEmailErrorMessage,
-                              setPasswordErrorMessage = setPasswordErrorMessage,
-                              setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
-                              authenticationViewModel = authenticationViewModel,
-                              userState = userState,
-                              context = context,
-                              navigationActions = navigationActions,
-                          )
-                        },
-                        testTag = SignUpScreen.SIGN_UP_BUTTON,
-                    )
-                  }
-                }
+                  },
+                  testTag = SignUpScreen.SIGN_UP_BUTTON,
+              )
+            }
           }
-        }
-      },
-  )
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -109,7 +109,8 @@ fun SignUpScreen(
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3)
+                    vertical = MaterialTheme.dimens.medium3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -156,7 +156,7 @@ fun SignUpScreen(
               onPasswordChange = { password = it },
               passwordVisible = passwordVisible,
               onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-              passwordErrorMessage,
+              passwordErrorMessage = passwordErrorMessage,
           )
           Text(
               modifier =

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -2,17 +2,17 @@ package com.android.periodpals.ui.authentication
 
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -24,8 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -118,20 +116,21 @@ fun SignUpScreen(
     ) {
       AuthenticationWelcomeText()
 
-      Box(
-          modifier =
-              Modifier.fillMaxWidth()
-                  .wrapContentHeight()
-                  .border(MaterialTheme.dimens.borderLine, Color.Gray, RectangleShape)
-                  .background(Color.White)
-                  .padding(
-                      horizontal = MaterialTheme.dimens.medium1,
-                      vertical = MaterialTheme.dimens.small3,
-                  ),
-          contentAlignment = Alignment.Center,
+      Card(
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+          colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
+          elevation =
+              CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
       ) {
         Column(
-            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(
+                        horizontal = MaterialTheme.dimens.medium1,
+                        vertical = MaterialTheme.dimens.small3,
+                    ),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement =
                 Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -127,78 +127,78 @@ fun SignUpScreen(
                   .padding(
                       horizontal = MaterialTheme.dimens.medium1,
                       vertical = MaterialTheme.dimens.small3,
-                  )) {
-            Column(
-                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement =
-                    Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-            ) {
-              Text(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .wrapContentHeight()
-                          .testTag(SignUpScreen.INSTRUCTION_TEXT),
-                  text = SIGN_UP_INSTRUCTION,
-                  textAlign = TextAlign.Center,
-                  style = MaterialTheme.typography.bodyLarge,
-              )
+                  ),
+          contentAlignment = Alignment.Center,
+      ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement =
+                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+        ) {
+          Text(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .wrapContentHeight()
+                      .testTag(SignUpScreen.INSTRUCTION_TEXT),
+              text = SIGN_UP_INSTRUCTION,
+              textAlign = TextAlign.Center,
+              style = MaterialTheme.typography.bodyLarge,
+          )
 
-              AuthenticationEmailInput(
-                  email = email,
-                  onEmailChange = { email = it },
-                  emailErrorMessage = emailErrorMessage,
-              )
+          AuthenticationEmailInput(
+              email = email,
+              onEmailChange = { email = it },
+              emailErrorMessage = emailErrorMessage,
+          )
 
-              AuthenticationPasswordInput(
-                  password = password,
-                  onPasswordChange = { password = it },
-                  passwordVisible = passwordVisible,
-                  onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-                  passwordErrorMessage,
-              )
-              Text(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .wrapContentHeight()
-                          .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-                  text = CONFIRM_PASSWORD_INSTRUCTION,
-                  textAlign = TextAlign.Center,
-                  style = MaterialTheme.typography.bodyLarge,
-              )
-              AuthenticationPasswordInput(
-                  password = confirmedPassword,
-                  onPasswordChange = { confirmedPassword = it },
-                  passwordVisible = confirmedPasswordVisible,
-                  onPasswordVisibilityChange = {
-                    confirmedPasswordVisible = !confirmedPasswordVisible
-                  },
-                  passwordErrorMessage = confirmedPasswordErrorMessage,
-                  passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-                  testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-                  visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
-              )
+          AuthenticationPasswordInput(
+              password = password,
+              onPasswordChange = { password = it },
+              passwordVisible = passwordVisible,
+              onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+              passwordErrorMessage,
+          )
+          Text(
+              modifier =
+                  Modifier.fillMaxWidth()
+                      .wrapContentHeight()
+                      .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+              text = CONFIRM_PASSWORD_INSTRUCTION,
+              textAlign = TextAlign.Center,
+              style = MaterialTheme.typography.bodyLarge,
+          )
+          AuthenticationPasswordInput(
+              password = confirmedPassword,
+              onPasswordChange = { confirmedPassword = it },
+              passwordVisible = confirmedPasswordVisible,
+              onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
+              passwordErrorMessage = confirmedPasswordErrorMessage,
+              passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+              testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+              visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+          )
 
-              AuthenticationSubmitButton(
-                  text = SIGN_UP_BUTTON_TEXT,
-                  onClick = {
-                    attemptSignUp(
-                        email = email,
-                        password = password,
-                        confirmedPassword = confirmedPassword,
-                        setEmailErrorMessage = setEmailErrorMessage,
-                        setPasswordErrorMessage = setPasswordErrorMessage,
-                        setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
-                        authenticationViewModel = authenticationViewModel,
-                        userState = userState,
-                        context = context,
-                        navigationActions = navigationActions,
-                    )
-                  },
-                  testTag = SignUpScreen.SIGN_UP_BUTTON,
-              )
-            }
-          }
+          AuthenticationSubmitButton(
+              text = SIGN_UP_BUTTON_TEXT,
+              onClick = {
+                attemptSignUp(
+                    email = email,
+                    password = password,
+                    confirmedPassword = confirmedPassword,
+                    setEmailErrorMessage = setEmailErrorMessage,
+                    setPasswordErrorMessage = setPasswordErrorMessage,
+                    setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
+                    authenticationViewModel = authenticationViewModel,
+                    userState = userState,
+                    context = context,
+                    navigationActions = navigationActions,
+                )
+              },
+              testTag = SignUpScreen.SIGN_UP_BUTTON,
+          )
+        }
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -9,10 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -30,6 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignUpScreen
+import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
 import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
@@ -116,87 +114,68 @@ fun SignUpScreen(
     ) {
       AuthenticationWelcomeText()
 
-      Card(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-          colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
-          elevation =
-              CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
-      ) {
-        Column(
+      AuthenticationCard {
+        Text(
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
+            text = SIGN_UP_INSTRUCTION,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+
+        AuthenticationEmailInput(
+            email = email,
+            onEmailChange = { email = it },
+            emailErrorMessage = emailErrorMessage,
+        )
+
+        AuthenticationPasswordInput(
+            password = password,
+            onPasswordChange = { password = it },
+            passwordVisible = passwordVisible,
+            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordErrorMessage = passwordErrorMessage,
+        )
+
+        Text(
             modifier =
                 Modifier.fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(
-                        horizontal = MaterialTheme.dimens.medium1,
-                        vertical = MaterialTheme.dimens.small3,
-                    ),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement =
-                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-        ) {
-          Text(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .wrapContentHeight()
-                      .testTag(SignUpScreen.INSTRUCTION_TEXT),
-              text = SIGN_UP_INSTRUCTION,
-              textAlign = TextAlign.Center,
-              style = MaterialTheme.typography.bodyLarge,
-          )
+                    .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+            text = CONFIRM_PASSWORD_INSTRUCTION,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
+        )
 
-          AuthenticationEmailInput(
-              email = email,
-              onEmailChange = { email = it },
-              emailErrorMessage = emailErrorMessage,
-          )
+        AuthenticationPasswordInput(
+            password = confirmedPassword,
+            onPasswordChange = { confirmedPassword = it },
+            passwordVisible = confirmedPasswordVisible,
+            onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
+            passwordErrorMessage = confirmedPasswordErrorMessage,
+            passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+            testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+            visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+        )
 
-          AuthenticationPasswordInput(
-              password = password,
-              onPasswordChange = { password = it },
-              passwordVisible = passwordVisible,
-              onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-              passwordErrorMessage = passwordErrorMessage,
-          )
-          Text(
-              modifier =
-                  Modifier.fillMaxWidth()
-                      .wrapContentHeight()
-                      .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-              text = CONFIRM_PASSWORD_INSTRUCTION,
-              textAlign = TextAlign.Center,
-              style = MaterialTheme.typography.bodyLarge,
-          )
-          AuthenticationPasswordInput(
-              password = confirmedPassword,
-              onPasswordChange = { confirmedPassword = it },
-              passwordVisible = confirmedPasswordVisible,
-              onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
-              passwordErrorMessage = confirmedPasswordErrorMessage,
-              passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-              testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-              visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
-          )
-
-          AuthenticationSubmitButton(
-              text = SIGN_UP_BUTTON_TEXT,
-              onClick = {
-                attemptSignUp(
-                    email = email,
-                    password = password,
-                    confirmedPassword = confirmedPassword,
-                    setEmailErrorMessage = setEmailErrorMessage,
-                    setPasswordErrorMessage = setPasswordErrorMessage,
-                    setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
-                    authenticationViewModel = authenticationViewModel,
-                    userState = userState,
-                    context = context,
-                    navigationActions = navigationActions,
-                )
-              },
-              testTag = SignUpScreen.SIGN_UP_BUTTON,
-          )
-        }
+        AuthenticationSubmitButton(
+            text = SIGN_UP_BUTTON_TEXT,
+            onClick = {
+              attemptSignUp(
+                  email = email,
+                  password = password,
+                  confirmedPassword = confirmedPassword,
+                  setEmailErrorMessage = setEmailErrorMessage,
+                  setPasswordErrorMessage = setPasswordErrorMessage,
+                  setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
+                  authenticationViewModel = authenticationViewModel,
+                  userState = userState,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignUpScreen.SIGN_UP_BUTTON,
+        )
       }
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -2,16 +2,22 @@ package com.android.periodpals.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -22,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.geometry.Offset
@@ -37,6 +44,40 @@ import com.android.periodpals.ui.theme.Pink40
 import com.android.periodpals.ui.theme.Purple80
 import com.android.periodpals.ui.theme.PurpleGrey80
 import com.android.periodpals.ui.theme.dimens
+
+/**
+ * A composable function that displays a card with authentication content.
+ *
+ * The card is a rounded rectangle with a shadow. The content is displayed inside the card.
+ *
+ * @param content The content to display inside the card.
+ */
+@Composable
+fun AuthenticationCard(
+    content: @Composable () -> Unit,
+) {
+  Card(
+      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
+  ) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium1,
+                    vertical = MaterialTheme.dimens.small3,
+                ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+    ) {
+      content()
+    }
+  }
+}
 
 /**
  * A composable function that displays a graded background with a gradient.

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -8,12 +8,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -36,7 +34,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
 import com.android.periodpals.ui.theme.Pink40
-import com.android.periodpals.ui.theme.Purple40
 import com.android.periodpals.ui.theme.Purple80
 import com.android.periodpals.ui.theme.PurpleGrey80
 import com.android.periodpals.ui.theme.dimens
@@ -209,8 +206,7 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
   Button(
       modifier = Modifier.wrapContentSize().testTag(testTag),
       onClick = onClick,
-      colors = ButtonDefaults.buttonColors(containerColor = Purple40),
-      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
+      enabled = true,
   ) {
     Text(text = text, color = Color.White, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -208,6 +208,11 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
       onClick = onClick,
       enabled = true,
   ) {
-    Text(text = text, color = Color.White, style = MaterialTheme.typography.bodyMedium)
+    Text(
+        text = text,
+        modifier = Modifier.wrapContentSize(),
+        color = Color.White,
+        style = MaterialTheme.typography.bodyMedium,
+    )
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -189,7 +188,6 @@ fun ProfileSaveButton(onClick: () -> Unit) {
       modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
       onClick = onClick,
       enabled = true,
-      shape = RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent),
   ) {
     Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -60,7 +60,8 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
           Modifier.size(MaterialTheme.dimens.profilePictureSize)
               .clip(shape = CircleShape)
               .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-              .testTag(ProfileScreens.PROFILE_PICTURE))
+              .testTag(ProfileScreens.PROFILE_PICTURE),
+  )
 }
 
 /**
@@ -106,9 +107,11 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
             text = NAME_LABEL,
             style =
                 if (isFocused || name.isNotEmpty()) MaterialTheme.typography.labelMedium
-                else MaterialTheme.typography.labelLarge)
+                else MaterialTheme.typography.labelLarge,
+        )
       },
-      placeholder = { Text(text = NAME_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) })
+      placeholder = { Text(text = NAME_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
+  )
 }
 
 /**
@@ -134,7 +137,8 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
             text = DOB_LABEL,
             style =
                 if (isFocused || dob.isNotEmpty()) MaterialTheme.typography.labelMedium
-                else MaterialTheme.typography.labelLarge)
+                else MaterialTheme.typography.labelLarge,
+        )
       },
       placeholder = { Text(text = DOB_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
   )
@@ -163,7 +167,8 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
             text = DESCRIPTION_LABEL,
             style =
                 if (isFocused || description.isNotEmpty()) MaterialTheme.typography.labelMedium
-                else MaterialTheme.typography.labelLarge)
+                else MaterialTheme.typography.labelLarge,
+        )
       },
       placeholder = {
         Text(text = DESCRIPTION_PLACEHOLDER, style = MaterialTheme.typography.labelLarge)

--- a/app/src/main/java/com/android/periodpals/ui/map/Map.kt
+++ b/app/src/main/java/com/android/periodpals/ui/map/Map.kt
@@ -63,21 +63,23 @@ fun MapScreen(locationService: GPSServiceImpl, navigationActions: NavigationActi
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(MapScreen.SCREEN),
+      topBar = { TopAppBar(title = SCREEN_TITLE) },
       bottomBar = {
         BottomNavigationMenu(
             onTabSelect = { route -> navigationActions.navigateTo(route) },
             tabList = LIST_TOP_LEVEL_DESTINATION,
-            selectedItem = navigationActions.currentRoute())
+            selectedItem = navigationActions.currentRoute(),
+        )
       },
-      topBar = { TopAppBar(title = SCREEN_TITLE) },
-      content = { paddingValues ->
-        initializeMap()
-        MapViewContainer(
-            modifier = Modifier.padding(paddingValues),
-            mapView = mapView,
-            locationPermissionGranted = locationPermissionGranted,
-            fusedLocationClient = fusedLocationClient)
-      })
+  ) { paddingValues ->
+    initializeMap()
+    MapViewContainer(
+        modifier = Modifier.fillMaxSize().padding(paddingValues),
+        mapView = mapView,
+        locationPermissionGranted = locationPermissionGranted,
+        fusedLocationClient = fusedLocationClient,
+    )
+  }
 }
 
 @Composable
@@ -85,7 +87,7 @@ fun MapViewContainer(
     modifier: Modifier,
     mapView: MapView,
     locationPermissionGranted: Boolean,
-    fusedLocationClient: FusedLocationProviderClient
+    fusedLocationClient: FusedLocationProviderClient,
 ) {
   val context = LocalContext.current
   LaunchedEffect(locationPermissionGranted) {

--- a/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
@@ -35,7 +35,7 @@ fun BottomNavigationMenu(
           NavigationBarItem(
               modifier =
                   Modifier.wrapContentSize()
-                      .clip(RoundedCornerShape(MaterialTheme.dimens.buttonRoundedPercent))
+                      .clip(RoundedCornerShape(percent = MaterialTheme.dimens.roundedPercent))
                       .align(Alignment.CenterVertically)
                       .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU_ITEM + tab.textId),
               icon = {

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -3,6 +3,7 @@ package com.android.periodpals.ui.navigation
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Edit
@@ -72,21 +73,22 @@ fun TopAppBar(
       modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(TopAppBar.TOP_BAR),
       title = {
         Text(
+            modifier = Modifier.wrapContentSize().testTag(TopAppBar.TITLE_TEXT),
             text = title,
-            modifier = Modifier.testTag(TopAppBar.TITLE_TEXT),
             style = MaterialTheme.typography.titleMedium,
+            softWrap = true,
         )
       },
       navigationIcon = {
         if (backButton) {
           IconButton(
+              modifier = Modifier.wrapContentSize().testTag(TopAppBar.GO_BACK_BUTTON),
               onClick = onBackButtonClick!!,
-              modifier = Modifier.testTag(TopAppBar.GO_BACK_BUTTON),
           ) {
             Icon(
+                modifier = Modifier.size(MaterialTheme.dimens.iconSize),
                 imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                 contentDescription = "Back",
-                modifier = Modifier.size(MaterialTheme.dimens.iconSize),
             )
           }
         }
@@ -94,13 +96,13 @@ fun TopAppBar(
       actions = {
         if (editButton) {
           IconButton(
+              modifier = Modifier.wrapContentSize().testTag(TopAppBar.EDIT_BUTTON),
               onClick = onEditButtonClick!!,
-              modifier = Modifier.testTag(TopAppBar.EDIT_BUTTON),
           ) {
             Icon(
+                modifier = Modifier.size(MaterialTheme.dimens.iconSize),
                 imageVector = Icons.Outlined.Edit,
                 contentDescription = "Edit",
-                modifier = Modifier.size(MaterialTheme.dimens.iconSize),
             )
           }
         }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -53,7 +53,6 @@ import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 
 private const val SCREEN_TITLE = "Create Your Account"
 
@@ -62,7 +61,6 @@ private const val SCREEN_TITLE = "Create Your Account"
  *
  * @param navigationActions Actions to handle navigation events.
  */
-@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   var name by remember { mutableStateOf("") }
@@ -93,7 +91,8 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3)
+                    vertical = MaterialTheme.dimens.small3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -10,9 +10,11 @@ import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -84,73 +86,57 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
-  ) { padding ->
-    LazyColumn(
+  ) { paddingValues ->
+    Column(
         modifier =
             Modifier.fillMaxSize()
-                .padding(padding)
+                .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3),
+                    vertical = MaterialTheme.dimens.small3)
+                .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       // Profile picture
-      item {
-        ProfilePicture(
-            model = profileImageUri,
-            onClick = {
-              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-              launcher.launch(pickImageIntent)
-            },
-        )
-      }
+      ProfilePicture(
+          model = profileImageUri,
+          onClick = {
+            val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+            launcher.launch(pickImageIntent)
+          },
+      )
 
       // Mandatory section title
-      item {
-        ProfileSection(
-            text = MANDATORY_TEXT,
-            testTag = ProfileScreens.MANDATORY_SECTION,
-        )
-      }
+      ProfileSection(text = MANDATORY_TEXT, testTag = ProfileScreens.MANDATORY_SECTION)
 
-      // Name field
-      item { ProfileInputName(name = name, onValueChange = { name = it }) }
+      // Name input field
+      ProfileInputName(name = name, onValueChange = { name = it })
 
-      // Date of birth field
-      item { ProfileInputDob(dob = age, onValueChange = { age = it }) }
+      // Date of birth input field
+      ProfileInputDob(dob = age, onValueChange = { age = it })
 
       // Your profile section title
-      item {
-        ProfileSection(
-            text = PROFILE_TEXT,
-            testTag = ProfileScreens.YOUR_PROFILE_SECTION,
-        )
-      }
+      ProfileSection(text = PROFILE_TEXT, testTag = ProfileScreens.YOUR_PROFILE_SECTION)
 
-      // Description field
-      item {
-        ProfileInputDescription(description = description, onValueChange = { description = it })
-      }
+      // Description input field
+      ProfileInputDescription(description = description, onValueChange = { description = it })
 
       // Save button
-      item {
-        ProfileSaveButton(
-            onClick = {
-              attemptSaveUserData(
-                  name = name,
-                  age = age,
-                  description = description,
-                  profileImageUri = profileImageUri,
-                  context = context,
-                  userViewModel = userViewModel,
-                  userState = userState,
-                  navigationActions = navigationActions,
-              )
-            },
-        )
-      }
+      ProfileSaveButton(
+          onClick = {
+            attemptSaveUserData(
+                name = name,
+                age = age,
+                description = description,
+                profileImageUri = profileImageUri,
+                context = context,
+                userViewModel = userViewModel,
+                userState = userState,
+                navigationActions = navigationActions,
+            )
+          })
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -105,7 +105,7 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3
+                    vertical = MaterialTheme.dimens.small3,
                 )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -8,10 +8,12 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Icon
@@ -93,83 +95,80 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
         TopAppBar(
             title = SCREEN_TITLE,
             true,
-            onBackButtonClick = { navigationActions.navigateTo(Screen.PROFILE) })
+            onBackButtonClick = { navigationActions.navigateTo(Screen.PROFILE) },
+        )
       },
-      content = { pd ->
-        LazyColumn(
-            modifier =
-                Modifier.fillMaxSize()
-                    .padding(pd)
-                    .padding(
-                        horizontal = MaterialTheme.dimens.medium3,
-                        vertical = MaterialTheme.dimens.small3),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement =
-                Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-        ) {
-          // Profile image and its edit icon
-          item {
-            Box(modifier = Modifier.size(MaterialTheme.dimens.profilePictureSize)) {
-              ProfilePicture(profileImageUri)
-
-              IconButton(
-                  onClick = {
-                    val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
-                    launcher.launch(pickImageIntent)
-                  },
-                  colors =
-                      IconButtonDefaults.iconButtonColors(
-                          containerColor = MaterialTheme.colorScheme.tertiary,
-                          contentColor = MaterialTheme.colorScheme.onTertiary,
-                      ),
-                  modifier =
-                      Modifier.align(Alignment.TopEnd)
-                          .size(MaterialTheme.dimens.iconButtonSize)
-                          .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
-              ) {
-                Icon(
-                    imageVector = Icons.Outlined.Edit,
-                    contentDescription = "edit icon",
-                    modifier = Modifier.align(Alignment.Center).size(MaterialTheme.dimens.iconSize),
+  ) { paddingValues ->
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3
                 )
-              }
-            }
-          }
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+    ) {
+      // Profile image and its edit icon
+      Box(modifier = Modifier.size(MaterialTheme.dimens.profilePictureSize)) {
+        ProfilePicture(profileImageUri)
 
-          // Mandatory section title
-          item { ProfileSection(MANDATORY_TEXT, ProfileScreens.MANDATORY_SECTION) }
-
-          // Name input field
-          item { ProfileInputName(name = name, onValueChange = { name = it }) }
-
-          // Date of Birth input field
-          item { ProfileInputDob(dob = dob, onValueChange = { dob = it }) }
-
-          // Your profile section title
-          item { ProfileSection(PROFILE_TEXT, ProfileScreens.YOUR_PROFILE_SECTION) }
-
-          // Description input field
-          item {
-            ProfileInputDescription(description = description, onValueChange = { description = it })
-          }
-
-          // Save Changes button
-          item {
-            ProfileSaveButton(
-                onClick = {
-                  val errorMessage = validateFields(name, dob, description)
-                  if (errorMessage != null) {
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-                  } else {
-                    // TODO: Save the profile (future implementation)
-                    Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-                    navigationActions.navigateTo(Screen.PROFILE)
-                  }
-                },
-            )
-          }
+        // Edit profile picture icon button
+        IconButton(
+            onClick = {
+              val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
+              launcher.launch(pickImageIntent)
+            },
+            colors =
+                IconButtonDefaults.iconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.tertiary,
+                    contentColor = MaterialTheme.colorScheme.onTertiary,
+                ),
+            modifier =
+                Modifier.align(Alignment.TopEnd)
+                    .size(MaterialTheme.dimens.iconButtonSize)
+                    .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
+        ) {
+          Icon(
+              imageVector = Icons.Outlined.Edit,
+              contentDescription = "edit icon",
+              modifier = Modifier.align(Alignment.Center).size(MaterialTheme.dimens.iconSize),
+          )
         }
-      })
+      }
+
+      // Mandatory section title
+      ProfileSection(MANDATORY_TEXT, ProfileScreens.MANDATORY_SECTION)
+
+      // Name input field
+      ProfileInputName(name = name, onValueChange = { name = it })
+
+      // Date of Birth input field
+      ProfileInputDob(dob = dob, onValueChange = { dob = it })
+
+      // Your profile section title
+      ProfileSection(PROFILE_TEXT, ProfileScreens.YOUR_PROFILE_SECTION)
+
+      // Description input field
+      ProfileInputDescription(description = description, onValueChange = { description = it })
+
+      // Save Changes button
+      ProfileSaveButton(
+          onClick = {
+            val errorMessage = validateFields(name, dob, description)
+            if (errorMessage != null) {
+              Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+            } else {
+              // TODO: Save the profile (future implementation)
+              Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+              navigationActions.navigateTo(Screen.PROFILE)
+            }
+          })
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -112,33 +112,33 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 
       // Name
       Text(
+          modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
           text = userState.value?.name ?: DEFAULT_NAME,
           textAlign = TextAlign.Center,
           softWrap = true,
           style = MaterialTheme.typography.titleSmall,
-          modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
       )
 
       // Description
       Text(
+          modifier =
+              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.DESCRIPTION_FIELD),
           text = userState.value?.description ?: DEFAULT_DESCRIPTION,
           textAlign = TextAlign.Center,
           softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
-          modifier =
-              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.DESCRIPTION_FIELD),
       )
 
       // Contribution
       Text(
+          modifier =
+              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.CONTRIBUTION_FIELD),
           text =
               if (numberInteractions == 0) NEW_USER_TEXT
               else NUMBER_INTERACTION_TEXT + numberInteractions,
           textAlign = TextAlign.Left,
           softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
-          modifier =
-              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.CONTRIBUTION_FIELD),
       )
 
       // Review section text
@@ -181,9 +181,9 @@ private fun NoReviewCard() {
               Modifier.size(MaterialTheme.dimens.iconSize).testTag(ProfileScreen.NO_REVIEWS_ICON),
       )
       Text(
+          modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT),
           text = NO_REVIEWS_TEXT,
           style = MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT),
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -100,7 +100,8 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3)
+                    vertical = MaterialTheme.dimens.small3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -11,8 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.SentimentVeryDissatisfied
 import androidx.compose.material3.Card
@@ -93,79 +94,60 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
         )
       },
   ) { paddingValues ->
-    LazyColumn(
+    Column(
         modifier =
             Modifier.fillMaxSize()
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3),
+                    vertical = MaterialTheme.dimens.small3)
+                .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
     ) {
       // Profile picture
-      item {
-        ProfilePicture(model = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE.toString())
-      }
+      ProfilePicture(model = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE.toString())
 
       // Name
-      item {
-        Text(
-            text = userState.value?.name ?: DEFAULT_NAME,
-            textAlign = TextAlign.Center,
-            softWrap = true,
-            style = MaterialTheme.typography.titleSmall,
-            modifier =
-                Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
-        )
-      }
+      Text(
+          text = userState.value?.name ?: DEFAULT_NAME,
+          textAlign = TextAlign.Center,
+          softWrap = true,
+          style = MaterialTheme.typography.titleSmall,
+          modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
+      )
 
       // Description
-      item {
-        Text(
-            text = userState.value?.description ?: DEFAULT_DESCRIPTION,
-            textAlign = TextAlign.Center,
-            softWrap = true,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(ProfileScreen.DESCRIPTION_FIELD),
-        )
-      }
+      Text(
+          text = userState.value?.description ?: DEFAULT_DESCRIPTION,
+          textAlign = TextAlign.Center,
+          softWrap = true,
+          style = MaterialTheme.typography.bodyMedium,
+          modifier =
+              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.DESCRIPTION_FIELD),
+      )
 
       // Contribution
-      item {
-        Text(
-            text =
-                if (numberInteractions == 0) NEW_USER_TEXT
-                else NUMBER_INTERACTION_TEXT + numberInteractions,
-            textAlign = TextAlign.Left,
-            softWrap = true,
-            style = MaterialTheme.typography.bodyMedium,
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(ProfileScreen.CONTRIBUTION_FIELD),
-        )
-      }
+      Text(
+          text =
+              if (numberInteractions == 0) NEW_USER_TEXT
+              else NUMBER_INTERACTION_TEXT + numberInteractions,
+          textAlign = TextAlign.Left,
+          softWrap = true,
+          style = MaterialTheme.typography.bodyMedium,
+          modifier =
+              Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.CONTRIBUTION_FIELD),
+      )
 
       // Review section text
-      item {
-        ProfileSection(
-            text = REVIEWS_TITLE,
-            testTag = ProfileScreen.REVIEWS_SECTION,
-        )
-      }
+      ProfileSection(text = REVIEWS_TITLE, testTag = ProfileScreen.REVIEWS_SECTION)
 
       // Reviews or no reviews card
-      item {
-        if (numberInteractions == 0) {
-          NoReviewCard()
-        } else {
-          /** TODO: Implement the review section */
-        }
+      if (numberInteractions == 0) {
+        NoReviewCard()
+      } else {
+        /** TODO: Implement the review section */
       }
     }
   }
@@ -200,7 +182,8 @@ private fun NoReviewCard() {
       Text(
           text = NO_REVIEWS_TEXT,
           style = MaterialTheme.typography.bodyMedium,
-          modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT))
+          modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT),
+      )
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -165,7 +165,7 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 private fun NoReviewCard() {
   Card(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_CARD),
-      shape = RoundedCornerShape(MaterialTheme.dimens.cardRounded),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -169,7 +169,7 @@ private fun NoReviewCard() {
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
-        modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small3),
+        modifier = Modifier.wrapContentSize().padding(MaterialTheme.dimens.small2),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -14,12 +14,12 @@ import androidx.compose.ui.unit.dp
  * [wiki page](https://github.com/PeriodPals/periodpals/wiki/App-Style-Guide#padding-and-typograhy).
  */
 data class Dimens(
-    val extraSmall: Dp = 0.dp,
+    val extraSmall: Dp = 0.dp, // not yet used
     val small1: Dp = 0.dp,
     val small2: Dp = 0.dp,
     val small3: Dp = 0.dp,
     val medium1: Dp = 0.dp,
-    val medium2: Dp = 0.dp,
+    val medium2: Dp = 0.dp, // not yet used
     val medium3: Dp = 0.dp,
     val large: Dp = 0.dp,
     val borderLine: Dp = 1.dp,

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -16,37 +16,28 @@ import androidx.compose.ui.unit.dp
 data class Dimens(
     val extraSmall: Dp = 0.dp, // not yet used
     val small1: Dp = 0.dp,
-    val small2: Dp = 0.dp,
-    val small3: Dp = 0.dp,
-    val medium1: Dp = 0.dp,
-    val medium2: Dp = 0.dp, // not yet used
-    val medium3: Dp = 0.dp,
-    val large: Dp = 0.dp,
+    val small2: Dp = small1 * 2,
+    val small3: Dp = small1 * 4,
+    val medium1: Dp = small1 * 6,
+    val medium2: Dp = small1 * 8, // not yet used
+    val medium3: Dp = small1 * 10,
+    val large: Dp = small1 * 15,
     val borderLine: Dp = 1.dp,
     val buttonHeight: Dp = 40.dp,
     val buttonRoundedPercent: Int = 50,
     val cardElevation: Dp = 4.dp,
-    val cardRoundedSize: Dp = 12.dp,
+    val cardRoundedSize: Dp = small1 * 3,
     val iconSize: Dp = 0.dp,
     val iconSizeSmall: Dp = iconSize * 2 / 3,
     val iconButtonSize: Dp = iconSize * 5 / 3,
-    val profilePictureSize: Dp = 190.dp,
+    val profilePictureSize: Dp = small1 * 50,
 )
 
 // Width <= 360dp
-val CompactSmallDimens =
-    Dimens(
-        small1 = 3.dp,
-        small2 = 6.dp,
-        small3 = 12.dp,
-        medium1 = 18.dp,
-        medium2 = 24.dp,
-        medium3 = 30.dp,
-        large = 45.dp,
-        cardRoundedSize = 9.dp,
-        iconSize = 20.dp)
+val CompactSmallDimens = Dimens(small1 = 3.dp, iconSize = 20.dp)
 
 // 360dp < Width <= 500dp
+/** Reference padding and spacing values for a medium screen size. */
 val CompactMediumDimens =
     Dimens(
         small1 = 4.dp,
@@ -56,42 +47,19 @@ val CompactMediumDimens =
         medium2 = 32.dp,
         medium3 = 40.dp,
         large = 60.dp,
+        borderLine = 1.dp,
+        buttonHeight = 40.dp,
+        buttonRoundedPercent = 50,
+        cardElevation = 4.dp,
         cardRoundedSize = 12.dp,
-        iconSize = 24.dp)
+        iconSize = 24.dp,
+        iconSizeSmall = 16.dp,
+        iconButtonSize = 40.dp,
+        profilePictureSize = 50.dp)
 
 // 500dp < Width
-val CompactLargeDimens =
-    Dimens(
-        small1 = 5.dp,
-        small2 = 10.dp,
-        small3 = 20.dp,
-        medium1 = 30.dp,
-        medium2 = 40.dp,
-        medium3 = 50.dp,
-        large = 65.dp,
-        cardRoundedSize = 15.dp,
-        iconSize = 26.dp)
+val CompactLargeDimens = Dimens(small1 = 5.dp, iconSize = 30.dp)
 
-val MediumDimens =
-    Dimens(
-        small1 = 8.dp,
-        small2 = 16.dp,
-        small3 = 32.dp,
-        medium1 = 48.dp,
-        medium2 = 64.dp,
-        medium3 = 80.dp,
-        large = 120.dp,
-        cardRoundedSize = 24.dp,
-        iconSize = 30.dp)
+val MediumDimens = Dimens(small1 = 8.dp, iconSize = 30.dp)
 
-val ExpandedDimens =
-    Dimens(
-        small1 = 9.dp,
-        small2 = 18.dp,
-        small3 = 36.dp,
-        medium1 = 54.dp,
-        medium2 = 72.dp,
-        medium3 = 90.dp,
-        large = 135.dp,
-        cardRoundedSize = 27.dp,
-        iconSize = 30.dp)
+val ExpandedDimens = Dimens(small1 = 9.dp, iconSize = 30.dp)

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -23,14 +23,14 @@ data class Dimens(
     val medium3: Dp = small1 * 10,
     val large: Dp = small1 * 15,
     val borderLine: Dp = 1.dp,
-    val buttonHeight: Dp = 40.dp,
-    val buttonRoundedPercent: Int = 50,
+    val buttonHeight: Dp = 40.dp, // not yet used
     val cardElevation: Dp = 4.dp,
     val cardRoundedSize: Dp = small1 * 3,
     val iconSize: Dp = 0.dp,
     val iconSizeSmall: Dp = iconSize * 2 / 3,
-    val iconButtonSize: Dp = iconSize * 5 / 3,
+    val iconButtonSize: Dp = iconSize * 2,
     val profilePictureSize: Dp = small1 * 50,
+    val roundedPercent: Int = 50,
 )
 
 // Width <= 360dp
@@ -49,13 +49,14 @@ val CompactMediumDimens =
         large = 60.dp,
         borderLine = 1.dp,
         buttonHeight = 40.dp,
-        buttonRoundedPercent = 50,
         cardElevation = 4.dp,
         cardRoundedSize = 12.dp,
         iconSize = 24.dp,
         iconSizeSmall = 16.dp,
         iconButtonSize = 40.dp,
-        profilePictureSize = 50.dp)
+        profilePictureSize = 50.dp,
+        roundedPercent = 50,
+    )
 
 // 500dp < Width
 val CompactLargeDimens = Dimens(small1 = 5.dp, iconSize = 30.dp)

--- a/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Dimens.kt
@@ -26,7 +26,7 @@ data class Dimens(
     val buttonHeight: Dp = 40.dp,
     val buttonRoundedPercent: Int = 50,
     val cardElevation: Dp = 4.dp,
-    val cardRounded: Dp = 12.dp,
+    val cardRoundedSize: Dp = 12.dp,
     val iconSize: Dp = 0.dp,
     val iconSizeSmall: Dp = iconSize * 2 / 3,
     val iconButtonSize: Dp = iconSize * 5 / 3,
@@ -43,7 +43,7 @@ val CompactSmallDimens =
         medium2 = 24.dp,
         medium3 = 30.dp,
         large = 45.dp,
-        cardRounded = 9.dp,
+        cardRoundedSize = 9.dp,
         iconSize = 20.dp)
 
 // 360dp < Width <= 500dp
@@ -56,7 +56,7 @@ val CompactMediumDimens =
         medium2 = 32.dp,
         medium3 = 40.dp,
         large = 60.dp,
-        cardRounded = 12.dp,
+        cardRoundedSize = 12.dp,
         iconSize = 24.dp)
 
 // 500dp < Width
@@ -69,7 +69,7 @@ val CompactLargeDimens =
         medium2 = 40.dp,
         medium3 = 50.dp,
         large = 65.dp,
-        cardRounded = 15.dp,
+        cardRoundedSize = 15.dp,
         iconSize = 26.dp)
 
 val MediumDimens =
@@ -81,7 +81,7 @@ val MediumDimens =
         medium2 = 64.dp,
         medium3 = 80.dp,
         large = 120.dp,
-        cardRounded = 24.dp,
+        cardRoundedSize = 24.dp,
         iconSize = 30.dp)
 
 val ExpandedDimens =
@@ -93,5 +93,5 @@ val ExpandedDimens =
         medium2 = 72.dp,
         medium3 = 90.dp,
         large = 135.dp,
-        cardRounded = 27.dp,
+        cardRoundedSize = 27.dp,
         iconSize = 30.dp)

--- a/app/src/main/java/com/android/periodpals/ui/timer/Timer.kt
+++ b/app/src/main/java/com/android/periodpals/ui/timer/Timer.kt
@@ -1,10 +1,16 @@
 package com.android.periodpals.ui.timer
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.resources.C.Tag.TimerScreen
@@ -12,20 +18,37 @@ import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Tampon Timer"
 
-/* Placeholder Screen, waiting for implementation */
+/** TODO: Placeholder Screen, waiting for implementation */
 @Composable
 fun TimerScreen(navigationActions: NavigationActions) {
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(TimerScreen.SCREEN),
-      bottomBar = ({
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute())
-          }),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
-      content = { pd -> Text("Timer Screen", modifier = Modifier.fillMaxSize().padding(pd)) })
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute())
+      },
+  ) { paddingValues ->
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+    ) {
+      // TODO: delete when implementing the screen
+      Text("Timer Screen", modifier = Modifier.fillMaxSize().testTag(TimerScreen.TIMER_TEXT))
+    }
+  }
 }

--- a/app/src/main/java/com/android/periodpals/ui/timer/Timer.kt
+++ b/app/src/main/java/com/android/periodpals/ui/timer/Timer.kt
@@ -41,7 +41,8 @@ fun TimerScreen(navigationActions: NavigationActions) {
                 .padding(paddingValues)
                 .padding(
                     horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3)
+                    vertical = MaterialTheme.dimens.small3,
+                )
                 .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =


### PR DESCRIPTION
# Clean up of layout responsiveness code

## Description
This PR standardizes the use of dimensions from `Dimens.kt` and typographies from `Type.kt`, addressing issue #184 (a subtask of #82, which is also closed).  

As I opened this PR, I came across a problem with the CI which is due to refactoring `LazyColumn`s into `Column`s with `Modifier.verticalScroll(rememberScrollState())`. That's when I noticed I had to add `.performScrollTo()` to all the UI tests which lead to having +1000 more lines of code changed. I had to do it in this PR as else I would have had to roll back all the changes on the columns and modifiers which are probably about 200-300 other lines. All of this lead to this HUGE PR. It wouldn't have happened if I had seen earlier [this](https://github.com/PeriodPals/periodpals/pull/93#discussion_r1822423405) comment left by @charliemangano on a cancelled PR.  
**Note**: if I had divided this into smaller PRs, i.e. per screens or profile screens, auth screens, ..., this would have been another 3-5 PRs for which both me and other devs don't have time and energy. We've already given so much for #82.

Beside the above point, this PR is about cleaning up the layout responsiveness' implementations for consistency and code maintainability, i.e. padding, dimensions, elevations, rounded corners, typographies, ...


## Changes
- Replaced `Box` with `Card` on Auth screens.
- Replaced `LazyColumn` with `Column` in `Scaffold`s, except for `AlertListsScreen` which led up to...
- ... have to add `.performScrollTo()` to all relevant components in all UI tests.
  *(These two changes by themselves are already more than 1000 changed lines if I had extracted it into a separate PR.)*
- Refactored `buttonRoundedPercent` to `roundedPercent`.
- Refined code in various components for readability and maintainability.
- General clean-up of layout responsiveness.

## Files

#### Added
- None.

#### Modified
- `TimerScreenTest.kt`: Added assertions for timer text visibility (to be reimplemented later).
- `AlertLists.kt`: Refactored functions and added helper for alert accept/decline.
- `AuthenticationComponents.kt`:
  - New shared `Card` component for both sign-in and sign-up screens. It reduces code duplication, and enforces code consistency and maintainability.
- `SignIn.kt`, `SignUp.kt`: Replaced `Box` with `AuthenticationCard` component mentioned in the previous point.
- `Dimens.kt`:
  - Simplified implementation, retaining padding for compact M screens as a reference.
  - Refactored `buttonRoundedPercent` to `roundedPercent` which is only used in the `BottomNavigationBar`. Buttons are by default with perfect rounded edges.
- Tests: Added `performScrollTo()` for components in `Scaffold`.
- Other components: Biggest change is to refactor `LazyColumn` to `Column` with a `Modifier.verticalScroll(rememberScrollState())`.

#### Removed
- None.

## Dependencies Added
- None.

## Testing
- Updated UI tests with `performScrollTo()` for scrolling behavior.
- Standardized test assertions for consistency.
- Verified timer text visibility on the Timer screen.

