### PR TITLE
Fix/authentication/sync-problems : Fix sync problem with auth screens

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -39,6 +39,13 @@ class SignInScreenTest {
     navigationActions = mock(NavigationActions::class.java)
     authViewModel = mock(AuthenticationViewModel::class.java)
 
+    `when`(
+            authViewModel.logInWithEmail(
+                userEmail = any(), userPassword = any(), onSuccess = any(), onFailure = any()))
+        .thenAnswer {
+          val onSuccess = it.arguments[2] as () -> Unit
+          onSuccess()
+        }
     `when`(navigationActions.currentRoute()).thenReturn(Screen.SIGN_IN)
     `when`(authViewModel.userAuthenticationState)
         .thenReturn(mutableStateOf(UserAuthenticationState.Success("User is logged in")))
@@ -79,7 +86,7 @@ class SignInScreenTest {
 
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    verify(authViewModel, never()).logInWithEmail(any(), any())
+    verify(authViewModel, never()).logInWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -98,7 +105,7 @@ class SignInScreenTest {
 
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    verify(authViewModel, never()).logInWithEmail(any(), any())
+    verify(authViewModel, never()).logInWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -115,7 +122,7 @@ class SignInScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).performClick()
-    verify(authViewModel).logInWithEmail(eq(email), eq(password))
+    verify(authViewModel).logInWithEmail(eq(email), eq(password), any(), any())
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -47,6 +47,13 @@ class SignUpScreenTest {
     navigationActions = mock(NavigationActions::class.java)
     authViewModel = mock(AuthenticationViewModel::class.java)
 
+    `when`(
+            authViewModel.signUpWithEmail(
+                userEmail = any(), userPassword = any(), onSuccess = any(), onFailure = any()))
+        .thenAnswer {
+          val onSuccess = it.arguments[2] as () -> Unit
+          onSuccess()
+        }
     `when`(navigationActions.currentRoute()).thenReturn(Screen.SIGN_UP)
     `when`(authViewModel.userAuthenticationState)
         .thenReturn(mutableStateOf(UserAuthenticationState.Success("User is signed up")))
@@ -88,7 +95,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -109,7 +116,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -126,7 +133,7 @@ class SignUpScreenTest {
   fun emptyPasswordDoesNotCallVM() {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -145,7 +152,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -165,7 +172,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(email)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -186,7 +193,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(tooShort)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(tooShort)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -207,7 +214,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noCapital)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noCapital)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -232,7 +239,7 @@ class SignUpScreenTest {
         .performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noMinuscule)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -253,7 +260,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noNumber)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noNumber)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -274,7 +281,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(noSpecial)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(noSpecial)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -299,7 +306,7 @@ class SignUpScreenTest {
         .performTextInput(doNotMatch1)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(doNotMatch2)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel, never()).signUpWithEmail(any(), any())
+    verify(authViewModel, never()).signUpWithEmail(any(), any(), any(), any())
   }
 
   @Test
@@ -317,6 +324,6 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(password)
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
-    verify(authViewModel).signUpWithEmail(eq(email), eq(password))
+    verify(authViewModel).signUpWithEmail(eq(email), eq(password), any(), any())
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -92,8 +92,16 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
     }
   }
 
-  /** Logs out the current user. */
-  fun logOut() {
+  /**
+   * Logs out the current user.
+   *
+   * @param onSuccess Callback to be invoked when the logout is successful.
+   * @param onFailure Callback to be invoked when the logout fails.
+   */
+  fun logOut(
+      onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") }
+  ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.logout(
@@ -101,43 +109,64 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
             Log.d(TAG, "logOut: logged out successfully")
             _userAuthenticationState.value =
                 UserAuthenticationState.Success("Logged out successfully")
+            onSuccess()
           },
           onFailure = { e: Exception ->
             Log.d(TAG, "logOut: failed to log out: $e")
             _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
           },
       )
     }
   }
 
-  /** Checks if a user is logged in. */
-  fun isUserLoggedIn() {
+  /**
+   * Checks if a user is logged in.
+   *
+   * @param onSuccess Callback to be invoked when the user is confirmed to be logged in.
+   * @param onFailure Callback to be invoked when the user is not logged in.
+   */
+  fun isUserLoggedIn(
+      onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "isUserLoggedIn failure callback: $e")
+      }
+  ) {
     Thread.sleep(1500)
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
           onSuccess = {
             Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
             _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
+            onSuccess()
           },
-          onFailure = {
+          onFailure = { e: Exception ->
             Log.d(TAG, "isUserLoggedIn: user is not logged in")
             _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
+            onFailure(e)
           },
       )
     }
   }
 
   /** Loads AuthenticationUserData to local state */
-  fun loadAuthenticationUserData() {
+  fun loadAuthenticationUserData(
+      onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
+      }
+  ) {
     viewModelScope.launch {
       authenticationModel.currentAuthenticationUser(
           onSuccess = {
             Log.d(TAG, "loadAuthUserData: user data successfully loaded")
             _authUserData.value = it.asAuthenticationUserData()
+            onSuccess()
           },
-          onFailure = {
+          onFailure = { e: Exception ->
             Log.d(TAG, "loadAuthUserData: failed to load user data")
             _authUserData.value = null
+            onFailure(e)
           },
       )
     }

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -66,7 +66,12 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param userEmail The email of the user.
    * @param userPassword The password of the user.
    */
-  fun logInWithEmail(userEmail: String, userPassword: String) {
+  fun logInWithEmail(
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") }
+  ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.login(
@@ -76,10 +81,12 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
             Log.d(TAG, "logInWithEmail: logged in successfully")
             _userAuthenticationState.value =
                 UserAuthenticationState.Success("Logged in successfully")
+            onSuccess()
           },
           onFailure = { e: Exception ->
             Log.d(TAG, "logInWithEmail: failed to log in: $e")
             _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
           },
       )
     }

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -31,14 +31,14 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    *
    * @param userEmail The email of the user.
    * @param userPassword The password of the user.
+   * @param onSuccess Callback to be invoked when the registration is successful.
+   * @param onFailure Callback to be invoked when the registration fails.
    */
   fun signUpWithEmail(
       userEmail: String,
       userPassword: String,
-      onSuccess: () -> Unit = { Log.d(TAG, "signUpWithEmail: registered user successfully") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "signUpWithEmail: failed to register user: $e")
-      }
+      onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") }
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
@@ -65,6 +65,8 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    *
    * @param userEmail The email of the user.
    * @param userPassword The password of the user.
+   * @param onSuccess Callback to be invoked when the login is successful.
+   * @param onFailure Callback to be invoked when the login fails.
    */
   fun logInWithEmail(
       userEmail: String,
@@ -149,7 +151,12 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
     }
   }
 
-  /** Loads AuthenticationUserData to local state */
+  /**
+   * Loads AuthenticationUserData to local state.
+   *
+   * @param onSuccess Callback to be invoked when the user data is successfully loaded.
+   * @param onFailure Callback to be invoked when the user data fails to load.
+   */
   fun loadAuthenticationUserData(
       onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
       onFailure: (Exception) -> Unit = { e: Exception ->

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -134,7 +134,6 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
         Log.d(TAG, "isUserLoggedIn failure callback: $e")
       }
   ) {
-    Thread.sleep(1500)
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
           onSuccess = {

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -32,7 +32,14 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param userEmail The email of the user.
    * @param userPassword The password of the user.
    */
-  fun signUpWithEmail(userEmail: String, userPassword: String) {
+  fun signUpWithEmail(
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signUpWithEmail: registered user successfully") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "signUpWithEmail: failed to register user: $e")
+      }
+  ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.register(
@@ -42,10 +49,12 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
             Log.d(TAG, "signUpWithEmail: registered user successfully")
             _userAuthenticationState.value =
                 UserAuthenticationState.Success("Registered user successfully")
+            onSuccess()
           },
           onFailure = { e: Exception ->
             Log.d(TAG, "signUpWithEmail: failed to register user: $e")
             _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
           },
       )
     }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -1,6 +1,8 @@
 package com.android.periodpals.ui.authentication
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
@@ -265,10 +267,16 @@ private fun attemptSignIn(
       userEmail = email,
       userPassword = password,
       onSuccess = {
-        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
         navigationActions.navigateTo(Screen.PROFILE)
       },
-      onFailure = { Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show() })
+      onFailure = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
+      })
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -275,18 +275,14 @@ private fun attemptSignIn(
     return
   }
 
-  authenticationViewModel.logInWithEmail(email, password)
-  authenticationViewModel.isUserLoggedIn()
-
-  val loginSuccess = userState is UserAuthenticationState.Success
-  if (!loginSuccess) {
-    Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-  navigationActions.navigateTo(Screen.PROFILE)
-  return
+  authenticationViewModel.logInWithEmail(
+      userEmail = email,
+      userPassword = password,
+      onSuccess = {
+        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        navigationActions.navigateTo(Screen.PROFILE)
+      },
+      onFailure = { Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show() })
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -244,18 +244,16 @@ private fun attemptSignUp(
     return
   }
 
-  authenticationViewModel.signUpWithEmail(email, password)
-  authenticationViewModel.isUserLoggedIn()
-
-  val loginSuccess = userState is UserAuthenticationState.Success
-  if (!loginSuccess) {
-    Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-  navigationActions.navigateTo(Screen.CREATE_PROFILE)
-  return
+  authenticationViewModel.signUpWithEmail(
+      userEmail = email,
+      userPassword = password,
+      onSuccess = {
+        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        navigationActions.navigateTo(Screen.CREATE_PROFILE)
+      },
+      onFailure = { e: Exception ->
+        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+      })
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -1,6 +1,8 @@
 package com.android.periodpals.ui.authentication
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -222,11 +224,15 @@ private fun attemptSignUp(
       userEmail = email,
       userPassword = password,
       onSuccess = {
-        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
         navigationActions.navigateTo(Screen.CREATE_PROFILE)
       },
       onFailure = { e: Exception ->
-        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
       })
 }
 


### PR DESCRIPTION
# Fix sync problem with auth screens

## Description
This PR introduces a fix for issue #187: it solves the syncing problem that made a user have to click two times on the "SignUp"/"SignIn" button on the authentication screens.

The problem came from how we handle our side effects, as the callbacks of the view model execute, at least partly, only after we've checked in the authentication screens if the loging in/signing up was successful, for example:

```kotlin
// in `SignIn`
authenticationViewModel.logInWithEmail(email, password)            // this does not finish executing

val loginSuccess = userState is UserAuthenticationState.Success    // before this happens
```
So our authentication screens thought that the operation failed, when it had just not finished executing.

## Changes
Changed the signature of the functions in `AuthenticationViewModel` to have `onSuccess` and `onFailure` callbacks. I moved the code that was previously in the button's `onClick` into the callbacks of the calls to `logInWithEmail` and `signUpWithEmail`. This ensures that this bit of code is executed **after** the rest of the `logInWithEmail` or `signUpWithEmail` code, which solves the problem.
This change of signature was applied to every function preventively, and all have simple `Log`s as default values. Docs were updated as well.
Updated the tests for the SignIn and SignUp screens to implement the new callbacks properly.

## Files 
#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt`: add callbacks to function signatures
- `app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt`, `app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt`: updated the calls to the view model functions to implement the callbacks properly
- `app/src/androidTest/java/com/android/periodpals/ui/authentication/SignInTest.kt`, `app/src/androidTest/java/com/android/periodpals/ui/authentication/SignUpTest.kt`: updated the tests to implement the callbacks properly

#### Removed
None

## Dependencies Added
None

## Testing
Existing tests were updated but still check for the same things. Tests all pass. None more written. This should help for the end-to-end tests.