### PR TITLE
Fix/profile/sync-problems : Fix sync problem with CreateProfile screen

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -119,7 +119,7 @@ class CreateProfileTest {
         .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
-    verify(userViewModel, never()).saveUser(any())
+    verify(userViewModel, never()).saveUser(any(), any(), any())
 
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
@@ -136,7 +136,7 @@ class CreateProfileTest {
         .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
-    verify(userViewModel, never()).saveUser(any())
+    verify(userViewModel, never()).saveUser(any(), any(), any())
 
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
@@ -151,7 +151,7 @@ class CreateProfileTest {
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
-    verify(userViewModel, never()).saveUser(any())
+    verify(userViewModel, never()).saveUser(any(), any(), any())
 
     verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
     verify(navigationActions, never()).navigateTo(any<String>())
@@ -160,6 +160,10 @@ class CreateProfileTest {
   @Test
   fun createValidProfileVMFailure() {
     `when`(userViewModel.user).thenReturn(mutableStateOf(null))
+    `when`(userViewModel.saveUser(any(), any(), any())).thenAnswer {
+      val onFailure = it.arguments[2] as (Exception) -> Unit
+      onFailure(Exception("Error saving user"))
+    }
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
@@ -169,7 +173,7 @@ class CreateProfileTest {
         .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
-    verify(userViewModel).saveUser(any())
+    verify(userViewModel).saveUser(any(), any(), any())
 
     verify(navigationActions, never()).navigateTo(Screen.PROFILE)
   }
@@ -177,6 +181,10 @@ class CreateProfileTest {
   @Test
   fun createValidProfileVMSuccess() {
     `when`(userViewModel.user).thenReturn(userState)
+    `when`(userViewModel.saveUser(any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as () -> Unit
+      onSuccess()
+    }
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
@@ -186,7 +194,7 @@ class CreateProfileTest {
         .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
 
-    verify(userViewModel).saveUser(any())
+    verify(userViewModel).saveUser(any(), any(), any())
 
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -110,6 +110,10 @@ class EditProfileTest {
   @Test
   fun editValidProfileVMFailure() {
     `when`(userViewModel.user).thenReturn(mutableStateOf(null))
+    `when`(userViewModel.saveUser(any(), any(), any())).thenAnswer {
+      val onFailure = it.arguments[2] as (Exception) -> Unit
+      onFailure(Exception("Error saving user"))
+    }
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
@@ -126,13 +130,17 @@ class EditProfileTest {
         .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
-    org.mockito.kotlin.verify(userViewModel).saveUser(any())
+    org.mockito.kotlin.verify(userViewModel).saveUser(any(), any(), any())
     org.mockito.kotlin.verify(navigationActions, Mockito.never()).navigateTo(Screen.PROFILE)
   }
 
   @Test
   fun editValidProfileVMSuccess() {
     `when`(userViewModel.user).thenReturn(userState)
+    `when`(userViewModel.saveUser(any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as () -> Unit
+      onSuccess()
+    }
     composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule

--- a/app/src/main/java/com/android/periodpals/model/user/UserModelSupabase.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserModelSupabase.kt
@@ -22,7 +22,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
   ) {
     try {
       val result =
-          withContext(Dispatchers.IO) {
+          withContext(Dispatchers.Main) {
             supabase.postgrest[USERS]
                 .select {}
                 .decodeSingle<UserDto>() // RLS rules only allows user to check their own line
@@ -41,7 +41,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
       onFailure: (Exception) -> Unit
   ) {
     try {
-      withContext(Dispatchers.IO) {
+      withContext(Dispatchers.Main) {
         val userDto =
             UserDto(
                 name = user.name,
@@ -64,7 +64,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
       onFailure: (Exception) -> Unit
   ) {
     try {
-      withContext(Dispatchers.IO) {
+      withContext(Dispatchers.Main) {
         val result = supabase.postgrest[USERS].upsert(userDto) { select() }.decodeSingle<UserDto>()
         Log.d(TAG, "upsertUserProfile: Success")
         onSuccess(result)

--- a/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
@@ -19,17 +19,30 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
   private val _user = mutableStateOf<User?>(null)
   val user: State<User?> = _user
 
-  /** Loads the user profile and updates the user state. */
-  fun loadUser() {
+  /**
+   * Loads the user profile and updates the user state.
+   *
+   * @param onSuccess Callback function to be called when the user profile is successfully loaded.
+   * @param onFailure Callback function to be called when there is an error loading the user
+   *   profile.
+   */
+  fun loadUser(
+      onSuccess: () -> Unit = { Log.d(TAG, "loadUser success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loadUser failure callback: $e")
+      }
+  ) {
     viewModelScope.launch {
       userRepository.loadUserProfile(
           onSuccess = { userDto ->
-            Log.d(TAG, "loadUserProfile: Succesful")
+            Log.d(TAG, "loadUserProfile: Successful")
             _user.value = userDto.asUser()
+            onSuccess()
           },
-          onFailure = {
-            Log.d(TAG, "loadUserProfile: fail to load user profile: ${it.message}")
+          onFailure = { e: Exception ->
+            Log.d(TAG, "loadUserProfile: fail to load user profile: ${e.message}")
             _user.value = null
+            onFailure(e)
           },
       )
     }
@@ -39,18 +52,28 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
    * Saves the user profile.
    *
    * @param user The user profile to be saved.
+   * @param onSuccess Callback function to be called when the user profile is successfully saved.
+   * @param onFailure Callback function to be called when there is an error saving the user profile.
    */
-  fun saveUser(user: User) {
+  fun saveUser(
+      user: User,
+      onSuccess: () -> Unit = { Log.d(TAG, "saveUser success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "saveUser failure callback: $e")
+      }
+  ) {
     viewModelScope.launch {
       userRepository.upsertUserProfile(
           user.asUserDto(),
           onSuccess = {
             Log.d(TAG, "saveUser: Success")
             _user.value = it.asUser()
+            onSuccess()
           },
-          onFailure = {
-            Log.d(TAG, "saveUser: fail to save user: ${it.message}")
+          onFailure = { e: Exception ->
+            Log.d(TAG, "saveUser: fail to save user: ${e.message}")
             _user.value = null
+            onFailure(e)
           })
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -2,6 +2,8 @@ package com.android.periodpals.ui.components
 
 import android.content.Context
 import android.icu.util.GregorianCalendar
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.clickable
@@ -16,7 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -205,7 +206,6 @@ fun ProfileSaveButton(
     profileImageUri: String,
     context: Context,
     userViewModel: UserViewModel,
-    userState: State<User?>,
     navigationActions: NavigationActions
 ) {
 
@@ -221,17 +221,26 @@ fun ProfileSaveButton(
 
         Log.d(LOG_TAG, LOG_SAVING_PROFILE)
         val newUser =
-            User(name = name, dob = dob, description = description, imageUrl = profileImageUri)
-        userViewModel.saveUser(newUser)
-        if (userState.value == null) {
-          Log.d(LOG_TAG, LOG_FAILURE)
-          Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
-          return@Button
-        }
-
-        Log.d(LOG_TAG, LOG_SUCCESS)
-        Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-        navigationActions.navigateTo(Screen.PROFILE)
+            User(
+                name = name,
+                dob = dob,
+                description = description,
+                imageUrl = profileImageUri.toString())
+        userViewModel.saveUser(
+            user = newUser,
+            onSuccess = {
+              Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread
+                Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+              }
+              Log.d(LOG_TAG, LOG_SUCCESS)
+              navigationActions.navigateTo(Screen.PROFILE)
+            },
+            onFailure = {
+              Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread
+                Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+              }
+              Log.d(LOG_TAG, LOG_FAILURE)
+            })
       },
       enabled = true,
   ) {

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -195,7 +195,6 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
  * @param context The context used to show Toast messages.
  * @param profileImageUri The URI of the profile image selected by the user.
  * @param userViewModel The ViewModel that handles user data.
- * @param userState The current state of the user.
  * @param navigationActions The navigation actions to navigate between screens.
  */
 @Composable
@@ -221,11 +220,7 @@ fun ProfileSaveButton(
 
         Log.d(LOG_TAG, LOG_SAVING_PROFILE)
         val newUser =
-            User(
-                name = name,
-                dob = dob,
-                description = description,
-                imageUrl = profileImageUri.toString())
+            User(name = name, dob = dob, description = description, imageUrl = profileImageUri)
         userViewModel.saveUser(
             user = newUser,
             onSuccess = {

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -172,11 +172,11 @@ private fun attemptSaveUserData(
   userViewModel.saveUser(
       user = newUser,
       onSuccess = {
-        Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread
+        Handler(Looper.getMainLooper()).post {
           Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-          navigationActions.navigateTo(Screen.PROFILE)
         }
         Log.d(LOG_TAG, LOG_SUCCESS)
+        navigationActions.navigateTo(Screen.PROFILE)
       },
       onFailure = {
         Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -178,16 +178,16 @@ private fun attemptSaveUserData(
       user = newUser,
       onSuccess = {
         Handler(Looper.getMainLooper()).post {
-          Log.d(LOG_TAG, LOG_SUCCESS)
           Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-          navigationActions.navigateTo(Screen.PROFILE)
         }
+        Log.d(LOG_TAG, LOG_SUCCESS)
+        navigationActions.navigateTo(Screen.PROFILE)
       },
       onFailure = {
         Handler(Looper.getMainLooper()).post {
-          Log.d(LOG_TAG, LOG_FAILURE)
           Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
         }
+        Log.d(LOG_TAG, LOG_FAILURE)
       })
 }
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -52,7 +52,6 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var profileImageUri by remember {
     mutableStateOf("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
   }
-  val userState = userViewModel.user
   val context = LocalContext.current
 
   val launcher =
@@ -106,14 +105,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
 
       // Save button
       ProfileSaveButton(
-          name,
-          age,
-          description,
-          profileImageUri,
-          context,
-          userViewModel,
-          userState,
-          navigationActions)
+          name, age, description, profileImageUri, context, userViewModel, navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -187,16 +187,17 @@ private fun attemptSaveUserData(
   Log.d(LOG_TAG, LOG_SAVING_PROFILE)
   val newUser =
       User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
-  userViewModel.saveUser(newUser)
-  if (userState.value == null) {
-    Log.d(LOG_TAG, LOG_FAILURE)
-    Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Log.d(LOG_TAG, LOG_SUCCESS)
-  Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-  navigationActions.navigateTo(Screen.PROFILE)
+  userViewModel.saveUser(
+      user = newUser,
+      onSuccess = {
+        Log.d(LOG_TAG, LOG_SUCCESS)
+        Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+        navigationActions.navigateTo(Screen.PROFILE)
+      },
+      onFailure = {
+        Log.d(LOG_TAG, LOG_FAILURE)
+        Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+      })
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -180,7 +180,7 @@ private fun attemptSaveUserData(
         navigationActions.navigateTo(Screen.PROFILE)
       },
       onFailure = {
-        Handler(Looper.getMainLooper()).post {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread
           Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
         }
         Log.d(LOG_TAG, LOG_FAILURE)

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -172,11 +172,11 @@ private fun attemptSaveUserData(
   userViewModel.saveUser(
       user = newUser,
       onSuccess = {
-        Handler(Looper.getMainLooper()).post {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread
           Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+          navigationActions.navigateTo(Screen.PROFILE)
         }
         Log.d(LOG_TAG, LOG_SUCCESS)
-        navigationActions.navigateTo(Screen.PROFILE)
       },
       onFailure = {
         Handler(Looper.getMainLooper()).post { // used to show the Toast on the main thread

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -148,7 +148,6 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
  * @param context The context used to show Toast messages.
  * @param profileImageUri The URI of the profile image selected by the user.
  * @param userViewModel The ViewModel that handles user data.
- * @param userState The current state of the user.
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSaveUserData(

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -72,7 +71,6 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
     mutableStateOf<Uri?>(
         Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
   }
-  val userState = userViewModel.user
   val context = LocalContext.current
 
   val launcher =
@@ -134,7 +132,6 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
                 profileImageUri = profileImageUri,
                 context = context,
                 userViewModel = userViewModel,
-                userState = userState,
                 navigationActions = navigationActions,
             )
           })
@@ -161,7 +158,6 @@ private fun attemptSaveUserData(
     profileImageUri: Uri?,
     context: Context,
     userViewModel: UserViewModel,
-    userState: State<User?>,
     navigationActions: NavigationActions,
 ) {
   val errorMessage = validateFields(name, age, description)

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.icu.util.GregorianCalendar
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -175,13 +177,17 @@ private fun attemptSaveUserData(
   userViewModel.saveUser(
       user = newUser,
       onSuccess = {
-        Log.d(LOG_TAG, LOG_SUCCESS)
-        Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-        navigationActions.navigateTo(Screen.PROFILE)
+        Handler(Looper.getMainLooper()).post {
+          Log.d(LOG_TAG, LOG_SUCCESS)
+          Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+          navigationActions.navigateTo(Screen.PROFILE)
+        }
       },
       onFailure = {
-        Log.d(LOG_TAG, LOG_FAILURE)
-        Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+        Handler(Looper.getMainLooper()).post {
+          Log.d(LOG_TAG, LOG_FAILURE)
+          Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+        }
       })
 }
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -2,6 +2,8 @@ package com.android.periodpals.ui.profile
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -68,9 +70,11 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
   val context = LocalContext.current
   userViewModel.loadUser(
       onFailure = {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
+          Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+              .show()
+        }
         Log.d(TAG, "User data is null")
-        Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
-            .show()
       },
   )
   val userState = userViewModel.user

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -66,12 +66,14 @@ private val DEFAULT_PROFILE_PICTURE =
 fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
 
   val context = LocalContext.current
-  userViewModel.loadUser()
+  userViewModel.loadUser(
+      onFailure = {
+        Log.d(TAG, "User data is null")
+        Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+            .show()
+      },
+  )
   val userState = userViewModel.user
-  if (userState.value == null) {
-    Log.d(TAG, "User data is null")
-    Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT).show()
-  }
 
   var name by remember { mutableStateOf(userState.value?.name ?: "") }
   var dob by remember { mutableStateOf(userState.value?.dob ?: "") }
@@ -156,14 +158,7 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
 
       // Save Changes button
       ProfileSaveButton(
-          name,
-          dob,
-          description,
-          profileImageUri,
-          context,
-          userViewModel,
-          userState,
-          navigationActions)
+          name, dob, description, profileImageUri, context, userViewModel, navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -73,7 +73,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
 
   Log.d(TAG, "Loading user data")
   userViewModel.loadUser(
-      onSuccess = {},
       onFailure = { e ->
         Log.d(TAG, "User data is null")
         Handler(Looper.getMainLooper()).post {

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -69,12 +69,14 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
       0 // TODO: placeholder to be replaced when we integrate it to the User data class
 
   Log.d(TAG, "Loading user data")
-  userViewModel.loadUser()
+  userViewModel.loadUser(
+      onSuccess = {},
+      onFailure = { e ->
+        Log.d(TAG, "User data is null")
+        Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+            .show()
+      })
   val userState = userViewModel.user
-  if (userState.value == null) {
-    Log.d(TAG, "User data is null")
-    Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT).show()
-  }
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(ProfileScreen.SCREEN),

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -75,7 +75,7 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
   userViewModel.loadUser(
       onFailure = { e ->
         Log.d(TAG, "User data is null")
-        Handler(Looper.getMainLooper()).post {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
           Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
               .show()
         }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -1,6 +1,8 @@
 package com.android.periodpals.ui.profile
 
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
@@ -73,9 +75,11 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
   userViewModel.loadUser(
       onSuccess = {},
       onFailure = { e ->
-        Log.d(TAG, "User data is null")
-        Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
-            .show()
+        Handler(Looper.getMainLooper()).post {
+          Log.d(TAG, "User data is null")
+          Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+              .show()
+        }
       })
   val userState = userViewModel.user
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -75,8 +75,8 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
   userViewModel.loadUser(
       onSuccess = {},
       onFailure = { e ->
+        Log.d(TAG, "User data is null")
         Handler(Looper.getMainLooper()).post {
-          Log.d(TAG, "User data is null")
           Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
               .show()
         }


### PR DESCRIPTION
# Fix sync problem with CreateProfile screen

## Description
This PR introduces a fix for issue #190: it solves the syncing problem that made a user have to click two times on the "Save" button on the CreateProfile screen.

The problem came from how we handle our side effects, as the callbacks of the view model execute, at least partly, only after we've checked in the CreateProfile screen that the saving had succeeded, for example:

```kotlin
// in `CreateProfile`
userViewModel.saveUser()              // this does not finish executing

if (userState.value == null) {...}    // before this happens
```
So our CreateProfile screen thought that the operation failed, when it had just not finished executing.

## Changes
Changed the signature of the functions in `UserViewModel` to have `onSuccess` and `onFailure` callbacks. I moved the code that was previously in the button's `onClick` into the callbacks of the calls to `saveUser` and `loadUser`. This ensures that this bit of code is executed **after** the rest of the `saveUser` or `loadUser` code, which solves the problem.
These callback all have simple `Log`s as default values. Docs were updated as well.
Updated the tests for the CreateProfile screen to implement the new callbacks properly.

## Files 
#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt`: add callbacks to function signatures
- `app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt`, `app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt`: update the calls to the view model functions to implement the callbacks properly
- `app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt`: update the tests to implement the callbacks properly

#### Removed
None

## Dependencies Added
None

## Testing
Existing tests were updated but still check for the same things. Tests all pass. None more written. This should help for the end-to-end tests.


# Edit: 14/11 8:22PM
Following a merge ([24910ae](https://github.com/PeriodPals/periodpals/pull/191/commits/24910aec9a2f79c66aab975926a23fc0de3e2483)), the function I was modifying (`onClick` of the "Save" `Button` of `CreateProfile`) got refactored into a different file (`ProfileComponents.kt`) that was now shared with `EditProfile`. This means that any modification I made to fix `CreateProfile`'s `onClick`, I now had to do in the `EditProfile` screen as well, and the associated tests. This PR therefore got extended after it had been approved. Having now modified everything I needed to, I'm requesting a re-review.

Updated list of modifications:
Everything from above, plus implementing changes asked in reviews, plus:
- `app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt`: removed unused variable
- `app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt`: update call to `loadUser` to implement callbacks properly
- `app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt`: updated now-refactored `ProfileSaveButton` with work done in previous, now overwritten commits (implement callbacks properly in call to `saveUser`)
- `app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt`: updated to implement new callbacks properly 
- `app/src/test/java/com/android/periodpals/model/user/UserModelSupabaseTest.kt`: updated tests to run on main thread to comply with updated `UserModelSupabase`(fix to unit tests not passing after [dc06a22](https://github.com/PeriodPals/periodpals/pull/191/commits/dc06a22537de25d6a06718e119add4c49ce3866e))