### PR TITLE
Feat/profile/integrate vm editprofile

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -17,6 +17,7 @@ import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.CreateProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
+import com.android.periodpals.ui.components.validateDate
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopLevelDestination

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -1,3 +1,4 @@
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -8,6 +9,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.android.periodpals.model.user.User
+import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
@@ -30,13 +33,27 @@ import org.mockito.kotlin.never
 class EditProfileTest {
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var userViewModel: UserViewModel
   @get:Rule val composeTestRule = createComposeRule()
+
+  companion object {
+    private val name = "John Doe"
+    private val imageUrl = "https://example.com"
+    private val description = "A short description"
+    private val dob = "01/01/2000"
+    private val userState =
+        mutableStateOf(User(name = name, imageUrl = imageUrl, description = description, dob = dob))
+  }
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    userViewModel = mock(UserViewModel::class.java)
+
     `when`(navigationActions.currentRoute()).thenReturn(Route.PROFILE)
-    composeTestRule.setContent { EditProfileScreen(navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
   }
 
   @Test
@@ -69,11 +86,11 @@ class EditProfileTest {
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions).navigateTo(Screen.PROFILE)
   }
@@ -83,10 +100,10 @@ class EditProfileTest {
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -96,10 +113,10 @@ class EditProfileTest {
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-        .performTextInput("A short bio")
+        .performTextInput(description)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }
@@ -109,8 +126,8 @@ class EditProfileTest {
     composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextClearance()
     composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).performTextClearance()
-    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput("John Doe")
-    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput("01/01/1990")
+    composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).performTextInput(name)
+    composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).performTextInput(dob)
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performClick()
     verify(navigationActions, never()).navigateTo(any<String>())
   }

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -58,8 +58,8 @@ class EditProfileTest {
 
   @Test
   fun allComponentsAreDisplayed() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
@@ -107,33 +107,33 @@ class EditProfileTest {
         .assertHasClickAction()
   }
 
-    @Test
-    fun editValidProfileVMFailure() {
-        `when`(userViewModel.user).thenReturn(mutableStateOf(null))
-        composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+  @Test
+  fun editValidProfileVMFailure() {
+    `when`(userViewModel.user).thenReturn(mutableStateOf(null))
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-        composeTestRule
-            .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
-            .performScrollTo()
-            .performTextInput(dob)
-        composeTestRule
-            .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
-            .performScrollTo()
-            .performTextInput(name)
-        composeTestRule
-            .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-            .performScrollTo()
-            .performTextInput(description)
-        composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(description)
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
 
-        org.mockito.kotlin.verify(userViewModel).saveUser(any())
-        org.mockito.kotlin.verify(navigationActions, Mockito.never()).navigateTo(Screen.PROFILE)
-    }
+    org.mockito.kotlin.verify(userViewModel).saveUser(any())
+    org.mockito.kotlin.verify(navigationActions, Mockito.never()).navigateTo(Screen.PROFILE)
+  }
 
   @Test
   fun editValidProfileVMSuccess() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
@@ -166,8 +166,8 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoName() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
@@ -196,8 +196,8 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoDOB() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
@@ -226,8 +226,8 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoDescription() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
@@ -256,8 +256,8 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileAllEmptyFields() {
-      `when`(userViewModel.user).thenReturn(userState)
-      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -19,11 +19,13 @@ import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.profile.CreateProfileScreen
 import com.android.periodpals.ui.profile.EditProfileScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -52,13 +54,13 @@ class EditProfileTest {
     userViewModel = mock(UserViewModel::class.java)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.PROFILE)
-    `when`(userViewModel.user).thenReturn(userState)
-
-    composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
   }
 
   @Test
   fun allComponentsAreDisplayed() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
     composeTestRule
@@ -105,8 +107,34 @@ class EditProfileTest {
         .assertHasClickAction()
   }
 
+    @Test
+    fun editValidProfileVMFailure() {
+        `when`(userViewModel.user).thenReturn(mutableStateOf(null))
+        composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
+        composeTestRule
+            .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+            .performScrollTo()
+            .performTextInput(dob)
+        composeTestRule
+            .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+            .performScrollTo()
+            .performTextInput(name)
+        composeTestRule
+            .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+            .performScrollTo()
+            .performTextInput(description)
+        composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
+        org.mockito.kotlin.verify(userViewModel).saveUser(any())
+        org.mockito.kotlin.verify(navigationActions, Mockito.never()).navigateTo(Screen.PROFILE)
+    }
+
   @Test
-  fun editValidProfile() {
+  fun editValidProfileVMSuccess() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .performScrollTo()
@@ -138,6 +166,9 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoName() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .performScrollTo()
@@ -165,6 +196,9 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoDOB() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .performScrollTo()
@@ -192,6 +226,9 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileNoDescription() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .performScrollTo()
@@ -219,6 +256,9 @@ class EditProfileTest {
 
   @Test
   fun editInvalidProfileAllEmptyFields() {
+      `when`(userViewModel.user).thenReturn(userState)
+      composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
+
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .performScrollTo()

--- a/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/androidTest/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -1,3 +1,5 @@
+package com.android.periodpals.ui.profile
+
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -19,8 +21,6 @@ import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
-import com.android.periodpals.ui.profile.CreateProfileScreen
-import com.android.periodpals.ui.profile.EditProfileScreen
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -67,7 +67,8 @@ class MainActivity : ComponentActivity() {
       PeriodPalsAppTheme {
         // A surface container using the 'background' color from the theme
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-          PeriodPalsApp(locationService, authenticationViewModel, userViewModel)
+          EditProfileScreen(userViewModel, NavigationActions(rememberNavController()))
+          // PeriodPalsApp(locationService, authenticationViewModel, userViewModel)
         }
       }
     }
@@ -116,7 +117,7 @@ fun PeriodPalsApp(
     // Profile
     navigation(startDestination = Screen.PROFILE, route = Route.PROFILE) {
       composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigationActions) }
-      composable(Screen.EDIT_PROFILE) { EditProfileScreen(navigationActions) }
+      composable(Screen.EDIT_PROFILE) { EditProfileScreen(userViewModel, navigationActions) }
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -67,8 +67,7 @@ class MainActivity : ComponentActivity() {
       PeriodPalsAppTheme {
         // A surface container using the 'background' color from the theme
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-          EditProfileScreen(userViewModel, NavigationActions(rememberNavController()))
-          // PeriodPalsApp(locationService, authenticationViewModel, userViewModel)
+          PeriodPalsApp(locationService, authenticationViewModel, userViewModel)
         }
       }
     }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -65,11 +65,10 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
       contentDescription = "profile picture",
       contentScale = ContentScale.Crop,
       modifier =
-      Modifier
-          .size(MaterialTheme.dimens.profilePictureSize)
-          .clip(shape = CircleShape)
-          .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
-          .testTag(ProfileScreens.PROFILE_PICTURE),
+          Modifier.size(MaterialTheme.dimens.profilePictureSize)
+              .clip(shape = CircleShape)
+              .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier)
+              .testTag(ProfileScreens.PROFILE_PICTURE),
   )
 }
 
@@ -83,11 +82,10 @@ fun ProfilePicture(model: Any?, onClick: (() -> Unit)? = null) {
 fun ProfileSection(text: String, testTag: String) {
   Text(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .padding(top = MaterialTheme.dimens.small2)
-          .wrapContentHeight()
-          .testTag(testTag),
+          Modifier.fillMaxWidth()
+              .padding(top = MaterialTheme.dimens.small2)
+              .wrapContentHeight()
+              .testTag(testTag),
       text = text,
       textAlign = TextAlign.Start,
       style = MaterialTheme.typography.titleSmall,
@@ -105,11 +103,10 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
   var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .wrapContentHeight()
-          .testTag(ProfileScreens.NAME_INPUT_FIELD)
-          .onFocusEvent { focusState -> isFocused = focusState.isFocused },
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.NAME_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = name,
       onValueChange = onValueChange,
       textStyle = MaterialTheme.typography.labelLarge,
@@ -136,11 +133,10 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
   var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .wrapContentHeight()
-          .testTag(ProfileScreens.DOB_INPUT_FIELD)
-          .onFocusEvent { focusState -> isFocused = focusState.isFocused },
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.DOB_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = dob,
       onValueChange = onValueChange,
       textStyle = MaterialTheme.typography.labelLarge,
@@ -167,11 +163,10 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
   var isFocused by remember { mutableStateOf(false) }
   OutlinedTextField(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .wrapContentHeight()
-          .testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
-          .onFocusEvent { focusState -> isFocused = focusState.isFocused },
+          Modifier.fillMaxWidth()
+              .wrapContentHeight()
+              .testTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+              .onFocusEvent { focusState -> isFocused = focusState.isFocused },
       value = description,
       onValueChange = onValueChange,
       textStyle = MaterialTheme.typography.labelLarge,
@@ -214,35 +209,28 @@ fun ProfileSaveButton(
     navigationActions: NavigationActions
 ) {
 
-    Button(
-      modifier = Modifier
-          .wrapContentSize()
-          .testTag(ProfileScreens.SAVE_BUTTON),
-        onClick = {
-            val errorMessage = validateFields(name, dob, description)
-            if (errorMessage != null) {
-                Log.d(LOG_TAG, "$LOG_FAILURE: $errorMessage")
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-            }
+  Button(
+      modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
+      onClick = {
+        val errorMessage = validateFields(name, dob, description)
+        if (errorMessage != null) {
+          Log.d(LOG_TAG, "$LOG_FAILURE: $errorMessage")
+          Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+        }
 
-            Log.d(LOG_TAG, LOG_SAVING_PROFILE)
-            val newUser =
-                User(
-                    name = name,
-                    dob = dob,
-                    description = description,
-                    imageUrl = profileImageUri
-                )
-            userViewModel.saveUser(newUser)
-            if (userState.value == null) {
-                Log.d(LOG_TAG, LOG_FAILURE)
-                Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
-            }
+        Log.d(LOG_TAG, LOG_SAVING_PROFILE)
+        val newUser =
+            User(name = name, dob = dob, description = description, imageUrl = profileImageUri)
+        userViewModel.saveUser(newUser)
+        if (userState.value == null) {
+          Log.d(LOG_TAG, LOG_FAILURE)
+          Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+        }
 
-            Log.d(LOG_TAG, LOG_SUCCESS)
-            Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-            navigationActions.navigateTo(Screen.PROFILE)
-        },
+        Log.d(LOG_TAG, LOG_SUCCESS)
+        Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
+        navigationActions.navigateTo(Screen.PROFILE)
+      },
       enabled = true,
   ) {
     Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
@@ -258,12 +246,12 @@ fun ProfileSaveButton(
  * @return An error message if validation fails, otherwise null.
  */
 fun validateFields(name: String, dob: String, description: String): String? {
-    return when {
-        !validateDate(dob) -> ERROR_INVALID_DATE
-        name.isEmpty() -> ERROR_INVALID_NAME
-        description.isEmpty() -> ERROR_INVALID_DESCRIPTION
-        else -> null
-    }
+  return when {
+    !validateDate(dob) -> ERROR_INVALID_DATE
+    name.isEmpty() -> ERROR_INVALID_NAME
+    description.isEmpty() -> ERROR_INVALID_DESCRIPTION
+    else -> null
+  }
 }
 
 /**
@@ -273,17 +261,17 @@ fun validateFields(name: String, dob: String, description: String): String? {
  * @return True if the date is valid, otherwise false.
  */
 fun validateDate(date: String): Boolean {
-    val parts = date.split("/")
-    val calendar = GregorianCalendar.getInstance()
-    calendar.isLenient = false
-    if (parts.size == 3) {
-        return try {
-            calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
-            calendar.time
-            true
-        } catch (e: Exception) {
-            false
-        }
+  val parts = date.split("/")
+  val calendar = GregorianCalendar.getInstance()
+  calendar.isLenient = false
+  if (parts.size == 3) {
+    return try {
+      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
+      calendar.time
+      true
+    } catch (e: Exception) {
+      false
     }
-    return false
+  }
+  return false
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -216,6 +216,7 @@ fun ProfileSaveButton(
         if (errorMessage != null) {
           Log.d(LOG_TAG, "$LOG_FAILURE: $errorMessage")
           Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+          return@Button
         }
 
         Log.d(LOG_TAG, LOG_SAVING_PROFILE)
@@ -225,6 +226,7 @@ fun ProfileSaveButton(
         if (userState.value == null) {
           Log.d(LOG_TAG, LOG_FAILURE)
           Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
+          return@Button
         }
 
         Log.d(LOG_TAG, LOG_SUCCESS)

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -1,12 +1,7 @@
 package com.android.periodpals.ui.profile
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
-import android.icu.util.GregorianCalendar
-import android.net.Uri
-import android.util.Log
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -18,7 +13,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,17 +22,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.R
-import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.CreateProfileScreen
-import com.android.periodpals.ui.components.ERROR_INVALID_DATE
-import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
-import com.android.periodpals.ui.components.ERROR_INVALID_NAME
-import com.android.periodpals.ui.components.LOG_FAILURE
-import com.android.periodpals.ui.components.LOG_SAVING_PROFILE
-import com.android.periodpals.ui.components.LOG_SUCCESS
-import com.android.periodpals.ui.components.LOG_TAG
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
 import com.android.periodpals.ui.components.ProfileInputDescription
@@ -47,10 +33,7 @@ import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSaveButton
 import com.android.periodpals.ui.components.ProfileSection
-import com.android.periodpals.ui.components.TOAST_FAILURE
-import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 
@@ -67,8 +50,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var age by remember { mutableStateOf("") }
   var description by remember { mutableStateOf("") }
   var profileImageUri by remember {
-    mutableStateOf<Uri?>(
-        Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
+      mutableStateOf("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
   }
   val userState = userViewModel.user
   val context = LocalContext.current
@@ -77,23 +59,26 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-              profileImageUri = result.data?.data
+                profileImageUri = result.data?.data.toString()
             }
           }
 
   Scaffold(
-      modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
+      modifier = Modifier
+          .fillMaxSize()
+          .testTag(CreateProfileScreen.SCREEN),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { paddingValues ->
     Column(
         modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3,
-                )
-                .verticalScroll(rememberScrollState()),
+        Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .padding(
+                horizontal = MaterialTheme.dimens.medium3,
+                vertical = MaterialTheme.dimens.small3,
+            )
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
@@ -124,101 +109,15 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
 
       // Save button
       ProfileSaveButton(
-          onClick = {
-            attemptSaveUserData(
-                name = name,
-                age = age,
-                description = description,
-                profileImageUri = profileImageUri,
-                context = context,
-                userViewModel = userViewModel,
-                userState = userState,
-                navigationActions = navigationActions,
-            )
-          })
+          name,
+          age,
+          description,
+          profileImageUri,
+          context,
+          userViewModel,
+          userState,
+          navigationActions
+      )
     }
   }
-}
-
-/**
- * Attempts to save the user data entered in the Create Profile screen.
- *
- * @param name The name entered by the user.
- * @param age The date of birth entered by the user.
- * @param description The description entered by the user.
- * @param context The context used to show Toast messages.
- * @param profileImageUri The URI of the profile image selected by the user.
- * @param userViewModel The ViewModel that handles user data.
- * @param userState The current state of the user.
- * @param navigationActions The navigation actions to navigate between screens.
- */
-private fun attemptSaveUserData(
-    name: String,
-    age: String,
-    description: String,
-    profileImageUri: Uri?,
-    context: Context,
-    userViewModel: UserViewModel,
-    userState: State<User?>,
-    navigationActions: NavigationActions,
-) {
-  val errorMessage = validateFields(name, age, description)
-  if (errorMessage != null) {
-    Log.d(LOG_TAG, "$LOG_FAILURE: $errorMessage")
-    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Log.d(LOG_TAG, LOG_SAVING_PROFILE)
-  val newUser =
-      User(name = name, dob = age, description = description, imageUrl = profileImageUri.toString())
-  userViewModel.saveUser(newUser)
-  if (userState.value == null) {
-    Log.d(LOG_TAG, LOG_FAILURE)
-    Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Log.d(LOG_TAG, LOG_SUCCESS)
-  Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-  navigationActions.navigateTo(Screen.PROFILE)
-}
-
-/**
- * Validates the fields of the profile screen.
- *
- * @param name The name entered by the user.
- * @param dob The date of birth entered by the user.
- * @param description The description entered by the user.
- * @return An error message if validation fails, otherwise null.
- */
-private fun validateFields(name: String, dob: String, description: String): String? {
-  return when {
-    !validateDate(dob) -> ERROR_INVALID_DATE
-    name.isEmpty() -> ERROR_INVALID_NAME
-    description.isEmpty() -> ERROR_INVALID_DESCRIPTION
-    else -> null
-  }
-}
-
-/**
- * Validates the date is in the format DD/MM/YYYY and is a valid date.
- *
- * @param date The date string to validate.
- * @return True if the date is valid, otherwise false.
- */
-fun validateDate(date: String): Boolean {
-  val parts = date.split("/")
-  val calendar = GregorianCalendar.getInstance()
-  calendar.isLenient = false
-  if (parts.size == 3) {
-    return try {
-      calendar.set(parts[2].toInt(), parts[1].toInt() - 1, parts[0].toInt())
-      calendar.time
-      true
-    } catch (e: Exception) {
-      false
-    }
-  }
-  return false
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -50,7 +50,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   var age by remember { mutableStateOf("") }
   var description by remember { mutableStateOf("") }
   var profileImageUri by remember {
-      mutableStateOf("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
+    mutableStateOf("android.resource://com.android.periodpals/" + R.drawable.generic_avatar)
   }
   val userState = userViewModel.user
   val context = LocalContext.current
@@ -59,26 +59,23 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       rememberLauncherForActivityResult(
           contract = ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-                profileImageUri = result.data?.data.toString()
+              profileImageUri = result.data?.data.toString()
             }
           }
 
   Scaffold(
-      modifier = Modifier
-          .fillMaxSize()
-          .testTag(CreateProfileScreen.SCREEN),
+      modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
   ) { paddingValues ->
     Column(
         modifier =
-        Modifier
-            .fillMaxSize()
-            .padding(paddingValues)
-            .padding(
-                horizontal = MaterialTheme.dimens.medium3,
-                vertical = MaterialTheme.dimens.small3,
-            )
-            .verticalScroll(rememberScrollState()),
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3,
+                )
+                .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
@@ -116,8 +113,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
           context,
           userViewModel,
           userState,
-          navigationActions
-      )
+          navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -21,6 +21,10 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -77,11 +81,14 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
     Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT).show()
   }
 
-  var name = userState.value?.name ?: DEFAULT_NAME
-  var dob = userState.value?.dob ?: DEFAULT_DOB
-  var description = userState.value?.description ?: DEFAULT_DESCRIPTION
-
-  var profileImageUri = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE
+  var name by remember { mutableStateOf(userState.value?.name ?: DEFAULT_NAME) }
+  var dob by remember { mutableStateOf(userState.value?.dob ?: DEFAULT_DOB) }
+  var description by remember {
+    mutableStateOf(userState.value?.description ?: DEFAULT_DESCRIPTION)
+  }
+  var profileImageUri by remember {
+    mutableStateOf(userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE)
+  }
 
   val launcher =
       rememberLauncherForActivityResult(

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -1,7 +1,6 @@
 package com.android.periodpals.ui.profile
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.widget.Toast
@@ -23,7 +22,6 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,17 +31,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.R
-import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
-import com.android.periodpals.ui.components.ERROR_INVALID_DATE
-import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
-import com.android.periodpals.ui.components.ERROR_INVALID_NAME
-import com.android.periodpals.ui.components.LOG_FAILURE
-import com.android.periodpals.ui.components.LOG_SAVING_PROFILE
-import com.android.periodpals.ui.components.LOG_SUCCESS
-import com.android.periodpals.ui.components.LOG_TAG
 import com.android.periodpals.ui.components.MANDATORY_TEXT
 import com.android.periodpals.ui.components.PROFILE_TEXT
 import com.android.periodpals.ui.components.ProfileInputDescription
@@ -52,8 +42,6 @@ import com.android.periodpals.ui.components.ProfileInputName
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSaveButton
 import com.android.periodpals.ui.components.ProfileSection
-import com.android.periodpals.ui.components.TOAST_FAILURE
-import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
@@ -101,7 +89,9 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
           }
 
   Scaffold(
-      modifier = Modifier.fillMaxSize().testTag(EditProfileScreen.SCREEN),
+      modifier = Modifier
+          .fillMaxSize()
+          .testTag(EditProfileScreen.SCREEN),
       topBar = {
         TopAppBar(
             title = SCREEN_TITLE,
@@ -112,13 +102,14 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
   ) { paddingValues ->
     Column(
         modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.medium3,
-                    vertical = MaterialTheme.dimens.small3,
-                )
-                .verticalScroll(rememberScrollState()),
+        Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .padding(
+                horizontal = MaterialTheme.dimens.medium3,
+                vertical = MaterialTheme.dimens.small3,
+            )
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
@@ -139,14 +130,17 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
                     contentColor = MaterialTheme.colorScheme.onTertiary,
                 ),
             modifier =
-                Modifier.align(Alignment.TopEnd)
-                    .size(MaterialTheme.dimens.iconButtonSize)
-                    .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
+            Modifier
+                .align(Alignment.TopEnd)
+                .size(MaterialTheme.dimens.iconButtonSize)
+                .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
         ) {
           Icon(
               imageVector = Icons.Outlined.Edit,
               contentDescription = "edit icon",
-              modifier = Modifier.align(Alignment.Center).size(MaterialTheme.dimens.iconSize),
+              modifier = Modifier
+                  .align(Alignment.Center)
+                  .size(MaterialTheme.dimens.iconSize),
           )
         }
       }
@@ -168,78 +162,15 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
 
       // Save Changes button
       ProfileSaveButton(
-          onClick = {
-            attemptSaveUserData(
-                name = name,
-                age = dob,
-                description = description,
-                profileImageUri = profileImageUri,
-                context = context,
-                userViewModel = userViewModel,
-                userState = userState,
-                navigationActions = navigationActions,
-            )
-          },
+          name,
+          dob,
+          description,
+          profileImageUri,
+          context,
+          userViewModel,
+          userState,
+          navigationActions
       )
     }
-  }
-}
-
-/**
- * Attempts to save the user data entered in the Create Profile screen.
- *
- * @param name The name entered by the user.
- * @param age The date of birth entered by the user.
- * @param description The description entered by the user.
- * @param context The context used to show Toast messages.
- * @param profileImageUri The URI of the profile image selected by the user.
- * @param userViewModel The ViewModel that handles user data.
- * @param userState The current state of the user.
- * @param navigationActions The navigation actions to navigate between screens.
- */
-private fun attemptSaveUserData(
-    name: String,
-    age: String,
-    description: String,
-    profileImageUri: String,
-    context: Context,
-    userViewModel: UserViewModel,
-    userState: State<User?>,
-    navigationActions: NavigationActions,
-) {
-  val errorMessage = validateFields(name, age, description)
-  if (errorMessage != null) {
-    Log.d(LOG_TAG, "$LOG_FAILURE: $errorMessage")
-    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Log.d(LOG_TAG, LOG_SAVING_PROFILE)
-  val newUser = User(name = name, dob = age, description = description, imageUrl = profileImageUri)
-  userViewModel.saveUser(newUser)
-  if (userState.value == null) {
-    Log.d(LOG_TAG, LOG_FAILURE)
-    Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
-    return
-  }
-
-  Log.d(LOG_TAG, LOG_SUCCESS)
-  Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
-  navigationActions.navigateTo(Screen.PROFILE)
-}
-
-/**
- * Validates the fields of the profile screen.
- *
- * @param name The name of the user.
- * @param dob The date of birth of the user.
- * @param description The description of the user.
- */
-private fun validateFields(name: String, dob: String, description: String): String? {
-  return when {
-    name.isEmpty() -> ERROR_INVALID_NAME
-    !validateDate(dob) -> ERROR_INVALID_DATE
-    description.isEmpty() -> ERROR_INVALID_DESCRIPTION
-    else -> null
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -89,9 +89,7 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
           }
 
   Scaffold(
-      modifier = Modifier
-          .fillMaxSize()
-          .testTag(EditProfileScreen.SCREEN),
+      modifier = Modifier.fillMaxSize().testTag(EditProfileScreen.SCREEN),
       topBar = {
         TopAppBar(
             title = SCREEN_TITLE,
@@ -102,14 +100,13 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
   ) { paddingValues ->
     Column(
         modifier =
-        Modifier
-            .fillMaxSize()
-            .padding(paddingValues)
-            .padding(
-                horizontal = MaterialTheme.dimens.medium3,
-                vertical = MaterialTheme.dimens.small3,
-            )
-            .verticalScroll(rememberScrollState()),
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium3,
+                    vertical = MaterialTheme.dimens.small3,
+                )
+                .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement =
             Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
@@ -130,17 +127,14 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
                     contentColor = MaterialTheme.colorScheme.onTertiary,
                 ),
             modifier =
-            Modifier
-                .align(Alignment.TopEnd)
-                .size(MaterialTheme.dimens.iconButtonSize)
-                .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
+                Modifier.align(Alignment.TopEnd)
+                    .size(MaterialTheme.dimens.iconButtonSize)
+                    .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
         ) {
           Icon(
               imageVector = Icons.Outlined.Edit,
               contentDescription = "edit icon",
-              modifier = Modifier
-                  .align(Alignment.Center)
-                  .size(MaterialTheme.dimens.iconSize),
+              modifier = Modifier.align(Alignment.Center).size(MaterialTheme.dimens.iconSize),
           )
         }
       }
@@ -169,8 +163,7 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
           context,
           userViewModel,
           userState,
-          navigationActions
-      )
+          navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -61,9 +61,6 @@ import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Edit Your Profile"
 private const val TAG = "EditProfile"
-private const val DEFAULT_NAME = "Error loading name, try again later."
-private const val DEFAULT_DOB = "Error loading date of birth, try again later."
-private const val DEFAULT_DESCRIPTION = "Error loading description, try again later."
 private val DEFAULT_PROFILE_PICTURE =
     "android.resource://com.android.periodpals/${R.drawable.generic_avatar}"
 
@@ -74,6 +71,7 @@ private val DEFAULT_PROFILE_PICTURE =
  * This screen includes the user's profile picture, name, date of birth, and description. It also
  * includes a save button to save the changes and a top app bar with a back button.
  *
+ * @param userViewModel The ViewModel that handles user data.
  * @param navigationActions The navigation actions that can be performed in the app.
  */
 @Composable
@@ -87,11 +85,9 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
     Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT).show()
   }
 
-  var name by remember { mutableStateOf(userState.value?.name ?: DEFAULT_NAME) }
-  var dob by remember { mutableStateOf(userState.value?.dob ?: DEFAULT_DOB) }
-  var description by remember {
-    mutableStateOf(userState.value?.description ?: DEFAULT_DESCRIPTION)
-  }
+  var name by remember { mutableStateOf(userState.value?.name ?: "") }
+  var dob by remember { mutableStateOf(userState.value?.dob ?: "") }
+  var description by remember { mutableStateOf(userState.value?.description ?: "") }
   var profileImageUri by remember {
     mutableStateOf(userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE)
   }

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -3,6 +3,7 @@ package com.android.periodpals.ui.profile
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -20,15 +21,12 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.R
+import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
@@ -49,6 +47,12 @@ import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Edit Your Profile"
+private const val TAG = "EditProfile"
+private const val DEFAULT_NAME = "Error loading name, try again later."
+private const val DEFAULT_DOB = "Error loading date of birth, try again later."
+private const val DEFAULT_DESCRIPTION = "Error loading description, try again later."
+private val DEFAULT_PROFILE_PICTURE =
+    Uri.parse("android.resource://com.android.periodpals/${R.drawable.generic_avatar}")
 
 /**
  * A composable function that displays the Edit Profile screen, where users can edit their profile
@@ -62,20 +66,22 @@ private const val SCREEN_TITLE = "Edit Your Profile"
  * TODO: Replace the state variables with the real data when implementing profile VM.
  */
 @Composable
-fun EditProfileScreen(navigationActions: NavigationActions) {
+fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
   // TODO: State variables, to replace it with the real data when the implementing profile VM
-  var name by remember { mutableStateOf("Emilia Jones") }
-  var dob by remember { mutableStateOf("20/01/2001") }
-  var description by remember {
-    mutableStateOf(
-        "Hello guys :) I’m Emilia, I’m a student " +
-            "at EPFL and I’m here to participate and contribute to this amazing community !")
+
+  val context = LocalContext.current
+  userViewModel.loadUser()
+  val userState = userViewModel.user
+  if (userState.value == null) {
+    Log.d(TAG, "User data is null")
+    Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT).show()
   }
 
-  var profileImageUri by remember {
-    mutableStateOf<Uri?>(
-        Uri.parse("android.resource://com.android.periodpals/" + R.drawable.generic_avatar))
-  }
+  var name = userState.value?.name ?: DEFAULT_NAME
+  var dob = userState.value?.dob ?: DEFAULT_DOB
+  var description = userState.value?.description ?: DEFAULT_DESCRIPTION
+
+  var profileImageUri = userState.value?.imageUrl ?: DEFAULT_PROFILE_PICTURE
 
   val launcher =
       rememberLauncherForActivityResult(
@@ -84,8 +90,6 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
               profileImageUri = result.data?.data
             }
           }
-
-  val context = LocalContext.current
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(EditProfileScreen.SCREEN),


### PR DESCRIPTION
# Title
Integrate ViewModel into EditProfileScreen

## Description
This PR introduces the integration of `UserViewModel` into `EditProfile` to handle loading and saving user data. It closes issue #163 .

## Changes
- Implemented `UserViewModel` into `EditProfileScreen` to use for loading user data.
-  Changed variables to manage user profile data.
- Implemented `UserViewModel` into `EditProfileScreen` to use for saving user data.
- Updated validation logic to make it similar to `CreateProfile`.

## Files

#### Modified
- `app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt`

## Testing
- Adapated `EditProfileTest` to the `UserViewModel`

