### PR TITLE
Fix/style/adapt light and dark mode

### DIFF
--- a/app/src/main/java/com/android/periodpals/resources/Color.kt
+++ b/app/src/main/java/com/android/periodpals/resources/Color.kt
@@ -1,4 +1,4 @@
-package com.android.periodpals.ui.theme
+package com.android.periodpals.resources
 
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults

--- a/app/src/main/java/com/android/periodpals/resources/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/resources/Dimens.kt
@@ -1,4 +1,4 @@
-package com.android.periodpals.ui.theme
+package com.android.periodpals.resources
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/android/periodpals/resources/Dimens.kt
+++ b/app/src/main/java/com/android/periodpals/resources/Dimens.kt
@@ -54,7 +54,7 @@ val CompactMediumDimens =
         iconSize = 24.dp,
         iconSizeSmall = 16.dp,
         iconButtonSize = 40.dp,
-        profilePictureSize = 50.dp,
+        profilePictureSize = 200.dp,
         roundedPercent = 50,
     )
 

--- a/app/src/main/java/com/android/periodpals/resources/Type.kt
+++ b/app/src/main/java/com/android/periodpals/resources/Type.kt
@@ -1,4 +1,4 @@
-package com.android.periodpals.ui.theme
+package com.android.periodpals.resources
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -51,13 +51,13 @@ import com.android.periodpals.model.alert.Status
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
+import com.android.periodpals.resources.ComponentColor.getFilledPrimaryButtonColors
+import com.android.periodpals.resources.ComponentColor.getPrimaryCardColors
+import com.android.periodpals.resources.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryButtonColors
-import com.android.periodpals.ui.theme.ComponentColor.getPrimaryCardColors
-import com.android.periodpals.ui.theme.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.theme.dimens
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -47,9 +47,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.alert.Alert
-import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
-import com.android.periodpals.model.alert.Urgency
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
@@ -75,56 +73,6 @@ private const val PAL_ALERT_ACCEPT_TEXT = "Accept"
 private const val PAL_ALERT_DECLINE_TEXT = "Decline"
 private val DATE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
 const val LOG_TAG = "AlertListsScreen"
-private val MY_ALERTS_LIST: List<Alert> =
-    listOf(
-        Alert(
-            id = "1",
-            uid = "1",
-            name = "Hippo Alpha",
-            product = Product.TAMPON,
-            urgency = Urgency.HIGH,
-            createdAt = LocalDateTime.now().toString(),
-            location = "Rolex Learning Center",
-            message = "I need help!",
-            status = Status.CREATED,
-        ),
-        Alert(
-            id = "2",
-            uid = "1",
-            name = "Hippo Beta",
-            product = Product.PAD,
-            urgency = Urgency.LOW,
-            createdAt = LocalDateTime.now().toString(),
-            location = "BC",
-            message = "I forgot my pads at home :/",
-            status = Status.PENDING,
-        ),
-    )
-private val PALS_ALERTS_LIST: List<Alert> =
-    listOf(
-        Alert(
-            id = "3",
-            uid = "2",
-            name = "Hippo Gamma",
-            product = Product.TAMPON,
-            urgency = Urgency.MEDIUM,
-            createdAt = LocalDateTime.now().toString(),
-            location = "EPFL",
-            message = "I need help!",
-            status = Status.CREATED,
-        ),
-        Alert(
-            id = "4",
-            uid = "3",
-            name = "Hippo Delta",
-            product = Product.PAD,
-            urgency = Urgency.HIGH,
-            createdAt = LocalDateTime.now().toString(),
-            location = "Rolex Learning Center",
-            message = "I forgot my pads at home :/",
-            status = Status.PENDING,
-        ),
-    )
 
 /** Enum class representing the tabs in the AlertLists screen. */
 private enum class AlertListsTab {
@@ -145,8 +93,8 @@ private enum class AlertListsTab {
 @Composable
 fun AlertListsScreen(
     navigationActions: NavigationActions,
-    myAlertsList: List<Alert> = MY_ALERTS_LIST,
-    palsAlertsList: List<Alert> = PALS_ALERTS_LIST,
+    myAlertsList: List<Alert> = emptyList(),
+    palsAlertsList: List<Alert> = emptyList(),
 ) {
   var selectedTab by remember { mutableStateOf(SELECTED_TAB_DEFAULT) }
 

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.SentimentVerySatisfied
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -40,7 +41,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -57,8 +57,9 @@ import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getCardColors
-import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryButtonColors
+import com.android.periodpals.ui.theme.ComponentColor.getPrimaryCardColors
+import com.android.periodpals.ui.theme.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.theme.dimens
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -158,7 +159,7 @@ fun AlertListsScreen(
               modifier =
                   Modifier.fillMaxWidth().wrapContentHeight().testTag(AlertListsScreen.TAB_ROW),
               selectedTabIndex = selectedTab.ordinal,
-              containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+              containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
               contentColor = MaterialTheme.colorScheme.onSurface,
           ) {
             Tab(
@@ -167,6 +168,7 @@ fun AlertListsScreen(
                   Text(
                       modifier = Modifier.wrapContentSize(),
                       text = MY_ALERTS_TAB_TITLE,
+                      color = MaterialTheme.colorScheme.onSurface,
                       style = MaterialTheme.typography.headlineSmall,
                   )
                 },
@@ -179,6 +181,7 @@ fun AlertListsScreen(
                   Text(
                       modifier = Modifier.wrapContentSize(),
                       text = PALS_ALERTS_TAB_TITLE,
+                      color = MaterialTheme.colorScheme.onSurface,
                       style = MaterialTheme.typography.headlineSmall,
                   )
                 },
@@ -246,7 +249,7 @@ private fun MyAlertItem(alert: Alert) {
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(MyAlertItem.MY_ALERT + idTestTag),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = getCardColors(),
+      colors = getPrimaryCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Row(
@@ -283,7 +286,7 @@ private fun MyAlertItem(alert: Alert) {
             Toast.makeText(context, "To implement edit alert screen", Toast.LENGTH_SHORT).show()
           },
           modifier = Modifier.wrapContentSize().testTag(MyAlertItem.MY_EDIT_BUTTON + idTestTag),
-          colors = getFilledButtonPrimaryColors(),
+          colors = getFilledPrimaryButtonColors(),
       ) {
         Row(
             modifier = Modifier.wrapContentSize(),
@@ -330,7 +333,7 @@ fun PalsAlertItem(alert: Alert) {
           Modifier.fillMaxWidth().wrapContentHeight().testTag(PalsAlertItem.PAL_ALERT + idTestTag),
       onClick = { isClicked = !isClicked },
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = getCardColors(),
+      colors = getPrimaryCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
@@ -502,7 +505,11 @@ private fun AlertAcceptButtons(idTestTag: String) {
           Toast.makeText(context, "To implement accept alert action", Toast.LENGTH_SHORT).show()
         },
         contentDescription = "Accept Alert",
-        color = Color(0xFF6FCF97),
+        buttonColor =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.tertiary,
+                contentColor = MaterialTheme.colorScheme.onTertiary,
+            ),
         testTag = PalsAlertItem.PAL_ACCEPT_BUTTON + idTestTag,
     )
 
@@ -515,7 +522,11 @@ private fun AlertAcceptButtons(idTestTag: String) {
           Toast.makeText(context, "To implement decline alert action", Toast.LENGTH_SHORT).show()
         },
         contentDescription = "Decline Alert",
-        color = Color(0xFFF37065),
+        buttonColor =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.error,
+                contentColor = MaterialTheme.colorScheme.onError,
+            ),
         testTag = PalsAlertItem.PAL_DECLINE_BUTTON + idTestTag,
     )
   }
@@ -535,15 +546,13 @@ private fun AlertActionButton(
     icon: ImageVector,
     onClick: () -> Unit,
     contentDescription: String,
-    color: Color,
+    buttonColor: ButtonColors,
     testTag: String
 ) {
   Button(
       onClick = onClick,
       modifier = Modifier.wrapContentSize().testTag(testTag),
-      colors =
-          ButtonDefaults.buttonColors(
-              containerColor = color, contentColor = MaterialTheme.colorScheme.onSecondary),
+      colors = buttonColor,
   ) {
     Row(
         modifier = Modifier.wrapContentSize(),
@@ -575,7 +584,7 @@ private fun NoAlertDialog(text: String) {
   Card(
       modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.NO_ALERTS_CARD),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = getCardColors(),
+      colors = getTertiaryCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -2,7 +2,6 @@ package com.android.periodpals.ui.alert
 
 import android.util.Log
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,6 +23,7 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.SentimentVerySatisfied
 import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -40,13 +40,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.alert.Alert
+import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
+import com.android.periodpals.model.alert.Urgency
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
@@ -54,6 +57,8 @@ import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.ComponentColor.getCardColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
 import com.android.periodpals.ui.theme.dimens
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -69,6 +74,56 @@ private const val PAL_ALERT_ACCEPT_TEXT = "Accept"
 private const val PAL_ALERT_DECLINE_TEXT = "Decline"
 private val DATE_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
 const val LOG_TAG = "AlertListsScreen"
+private val MY_ALERTS_LIST: List<Alert> =
+    listOf(
+        Alert(
+            id = "1",
+            uid = "1",
+            name = "Hippo Alpha",
+            product = Product.TAMPON,
+            urgency = Urgency.HIGH,
+            createdAt = LocalDateTime.now().toString(),
+            location = "Rolex Learning Center",
+            message = "I need help!",
+            status = Status.CREATED,
+        ),
+        Alert(
+            id = "2",
+            uid = "1",
+            name = "Hippo Beta",
+            product = Product.PAD,
+            urgency = Urgency.LOW,
+            createdAt = LocalDateTime.now().toString(),
+            location = "BC",
+            message = "I forgot my pads at home :/",
+            status = Status.PENDING,
+        ),
+    )
+private val PALS_ALERTS_LIST: List<Alert> =
+    listOf(
+        Alert(
+            id = "3",
+            uid = "2",
+            name = "Hippo Gamma",
+            product = Product.TAMPON,
+            urgency = Urgency.MEDIUM,
+            createdAt = LocalDateTime.now().toString(),
+            location = "EPFL",
+            message = "I need help!",
+            status = Status.CREATED,
+        ),
+        Alert(
+            id = "4",
+            uid = "3",
+            name = "Hippo Delta",
+            product = Product.PAD,
+            urgency = Urgency.HIGH,
+            createdAt = LocalDateTime.now().toString(),
+            location = "Rolex Learning Center",
+            message = "I forgot my pads at home :/",
+            status = Status.PENDING,
+        ),
+    )
 
 /** Enum class representing the tabs in the AlertLists screen. */
 private enum class AlertListsTab {
@@ -89,8 +144,8 @@ private enum class AlertListsTab {
 @Composable
 fun AlertListsScreen(
     navigationActions: NavigationActions,
-    myAlertsList: List<Alert> = emptyList(),
-    palsAlertsList: List<Alert> = emptyList(),
+    myAlertsList: List<Alert> = MY_ALERTS_LIST,
+    palsAlertsList: List<Alert> = PALS_ALERTS_LIST,
 ) {
   var selectedTab by remember { mutableStateOf(SELECTED_TAB_DEFAULT) }
 
@@ -138,6 +193,8 @@ fun AlertListsScreen(
             selectedItem = navigationActions.currentRoute(),
         )
       },
+      containerColor = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
     LazyColumn(
         modifier =
@@ -187,6 +244,7 @@ private fun MyAlertItem(alert: Alert) {
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(MyAlertItem.MY_ALERT + idTestTag),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors = getCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Row(
@@ -223,6 +281,7 @@ private fun MyAlertItem(alert: Alert) {
             Toast.makeText(context, "To implement edit alert screen", Toast.LENGTH_SHORT).show()
           },
           modifier = Modifier.wrapContentSize().testTag(MyAlertItem.MY_EDIT_BUTTON + idTestTag),
+          colors = getFilledButtonPrimaryColors(),
       ) {
         Row(
             modifier = Modifier.wrapContentSize(),
@@ -269,6 +328,7 @@ fun PalsAlertItem(alert: Alert) {
           Modifier.fillMaxWidth().wrapContentHeight().testTag(PalsAlertItem.PAL_ALERT + idTestTag),
       onClick = { isClicked = !isClicked },
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors = getCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
@@ -440,6 +500,7 @@ private fun AlertAcceptButtons(idTestTag: String) {
           Toast.makeText(context, "To implement accept alert action", Toast.LENGTH_SHORT).show()
         },
         contentDescription = "Accept Alert",
+        color = Color(0xFF6FCF97),
         testTag = PalsAlertItem.PAL_ACCEPT_BUTTON + idTestTag,
     )
 
@@ -452,6 +513,7 @@ private fun AlertAcceptButtons(idTestTag: String) {
           Toast.makeText(context, "To implement decline alert action", Toast.LENGTH_SHORT).show()
         },
         contentDescription = "Decline Alert",
+        color = Color(0xFFF37065),
         testTag = PalsAlertItem.PAL_DECLINE_BUTTON + idTestTag,
     )
   }
@@ -471,15 +533,15 @@ private fun AlertActionButton(
     icon: ImageVector,
     onClick: () -> Unit,
     contentDescription: String,
+    color: Color,
     testTag: String
 ) {
   Button(
       onClick = onClick,
-      border =
-          BorderStroke(
-              width = MaterialTheme.dimens.borderLine,
-              color = MaterialTheme.colorScheme.onSecondaryContainer),
       modifier = Modifier.wrapContentSize().testTag(testTag),
+      colors =
+          ButtonDefaults.buttonColors(
+              containerColor = color, contentColor = MaterialTheme.colorScheme.onSecondary),
   ) {
     Row(
         modifier = Modifier.wrapContentSize(),
@@ -511,6 +573,7 @@ private fun NoAlertDialog(text: String) {
   Card(
       modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.NO_ALERTS_CARD),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors = getCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -158,6 +158,8 @@ fun AlertListsScreen(
               modifier =
                   Modifier.fillMaxWidth().wrapContentHeight().testTag(AlertListsScreen.TAB_ROW),
               selectedTabIndex = selectedTab.ordinal,
+              containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+              contentColor = MaterialTheme.colorScheme.onSurface,
           ) {
             Tab(
                 modifier = Modifier.wrapContentSize().testTag(AlertListsScreen.MY_ALERTS_TAB),

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -222,7 +222,6 @@ private fun MyAlertItem(alert: Alert) {
             // TODO: Implement edit alert action
             Toast.makeText(context, "To implement edit alert screen", Toast.LENGTH_SHORT).show()
           },
-          enabled = true,
           modifier = Modifier.wrapContentSize().testTag(MyAlertItem.MY_EDIT_BUTTON + idTestTag),
       ) {
         Row(
@@ -306,7 +305,6 @@ fun PalsAlertItem(alert: Alert) {
                   text = alert.name,
                   textAlign = TextAlign.Left,
                   style = MaterialTheme.typography.labelLarge,
-                  softWrap = true,
                   modifier =
                       Modifier.fillMaxWidth()
                           .wrapContentHeight()
@@ -319,7 +317,6 @@ fun PalsAlertItem(alert: Alert) {
                     text = alert.message,
                     textAlign = TextAlign.Left,
                     style = MaterialTheme.typography.labelMedium,
-                    softWrap = true,
                     modifier =
                         Modifier.fillMaxWidth()
                             .wrapContentHeight()
@@ -379,7 +376,6 @@ private fun AlertTimeAndLocation(alert: Alert, idTestTag: String) {
       text = "${formattedTime}, ${alert.location}",
       fontWeight = FontWeight.SemiBold,
       textAlign = TextAlign.Left,
-      softWrap = true,
       style = MaterialTheme.typography.labelMedium,
   )
 }
@@ -479,7 +475,6 @@ private fun AlertActionButton(
 ) {
   Button(
       onClick = onClick,
-      enabled = true,
       border =
           BorderStroke(
               width = MaterialTheme.dimens.borderLine,

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -240,7 +240,7 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */ },
+                onClick = { /* TODO show more results */},
                 colors = getMenuItemColors(),
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -43,16 +43,16 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.periodpals.model.location.Location
 import com.android.periodpals.model.location.LocationViewModel
 import com.android.periodpals.resources.C.Tag.CreateAlertScreen
+import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
+import com.android.periodpals.resources.ComponentColor.getMenuItemColors
+import com.android.periodpals.resources.ComponentColor.getMenuOutlinedTextFieldColors
+import com.android.periodpals.resources.ComponentColor.getMenuTextFieldColors
+import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
 import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
-import com.android.periodpals.ui.theme.ComponentColor.getMenuItemColors
-import com.android.periodpals.ui.theme.ComponentColor.getMenuOutlinedTextFieldColors
-import com.android.periodpals.ui.theme.ComponentColor.getMenuTextFieldColors
-import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Create Alert"

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -48,6 +48,11 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getMenuItemColors
+import com.android.periodpals.ui.theme.ComponentColor.getMenuOutlinedTextFieldColors
+import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
+import com.android.periodpals.ui.theme.ComponentColor.getTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Create Alert"
@@ -113,6 +118,8 @@ fun CreateAlertScreen(
             selectedItem = navigationActions.currentRoute(),
         )
       },
+      containerColor = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
     Column(
         modifier =
@@ -178,7 +185,7 @@ fun CreateAlertScreen(
               Text(text = LOCATION_FIELD_PLACEHOLDER, style = MaterialTheme.typography.labelMedium)
             },
             singleLine = true,
-            colors = ExposedDropdownMenuDefaults.textFieldColors(),
+            colors = getMenuOutlinedTextFieldColors(),
         )
 
         // Dropdown menu for location suggestions
@@ -193,13 +200,15 @@ fun CreateAlertScreen(
                 // TODO : Logic for fetching and setting current location
                 showDropdown = false // For now close dropdown on selection
               },
-              contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
               leadingIcon = {
                 Icon(
                     imageVector = Icons.Filled.GpsFixed,
                     contentDescription = "GPS icon",
                     modifier = Modifier.size(MaterialTheme.dimens.iconSize))
-              })
+              },
+              colors = getMenuItemColors(),
+              contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+          )
           Log.d("CreateAlertScreen", "Location suggestions: $locationSuggestions")
           locationSuggestions.take(MAX_LOCATION_SUGGESTIONS).forEach { location ->
             DropdownMenuItem(
@@ -222,6 +231,7 @@ fun CreateAlertScreen(
                     Modifier.testTag(CreateAlertScreen.DROPDOWN_ITEM + location.name).semantics {
                       contentDescription = CreateAlertScreen.DROPDOWN_ITEM
                     },
+                colors = getMenuItemColors(),
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }
@@ -229,7 +239,8 @@ fun CreateAlertScreen(
           if (locationSuggestions.size > MAX_LOCATION_SUGGESTIONS) {
             DropdownMenuItem(
                 text = { Text(text = "More...", style = MaterialTheme.typography.labelLarge) },
-                onClick = { /* TODO show more results */},
+                onClick = { /* TODO show more results */ },
+                colors = getMenuItemColors(),
                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
             )
           }
@@ -258,6 +269,7 @@ fun CreateAlertScreen(
             Text(text = MESSAGE_FIELD_PLACEHOLDER, style = MaterialTheme.typography.labelLarge)
           },
           minLines = 3,
+          colors = getOutlinedTextFieldColors(),
       )
 
       // "Ask for Help" button
@@ -274,6 +286,7 @@ fun CreateAlertScreen(
               navigationActions.navigateTo(Screen.ALERT_LIST)
             }
           },
+          colors = getFilledButtonPrimaryColors(),
       ) {
         Text(SUBMISSION_BUTTON_TEXT, style = MaterialTheme.typography.headlineMedium)
       }
@@ -319,7 +332,7 @@ fun ExposedDropdownMenuSample(
           ExposedDropdownMenuDefaults.TrailingIcon(
               expanded = expanded, Modifier.size(MaterialTheme.dimens.iconSize))
         },
-        colors = ExposedDropdownMenuDefaults.textFieldColors(),
+        colors = getTextFieldColors(),
     )
     ExposedDropdownMenu(
         expanded = expanded,
@@ -335,6 +348,7 @@ fun ExposedDropdownMenuSample(
               expanded = false
               setIsSelected(true)
             },
+            colors = getMenuItemColors(),
             contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
         )
       }

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -48,11 +48,11 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.theme.ComponentColor.getMenuItemColors
 import com.android.periodpals.ui.theme.ComponentColor.getMenuOutlinedTextFieldColors
+import com.android.periodpals.ui.theme.ComponentColor.getMenuTextFieldColors
 import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
-import com.android.periodpals.ui.theme.ComponentColor.getTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Create Alert"
@@ -193,6 +193,7 @@ fun CreateAlertScreen(
             expanded = showDropdown && locationSuggestions.isNotEmpty(),
             onDismissRequest = { showDropdown = false },
             modifier = Modifier.wrapContentSize(),
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
         ) {
           DropdownMenuItem(
               text = { Text(CURRENT_LOCATION_TEXT) },
@@ -286,7 +287,7 @@ fun CreateAlertScreen(
               navigationActions.navigateTo(Screen.ALERT_LIST)
             }
           },
-          colors = getFilledButtonPrimaryColors(),
+          colors = getFilledPrimaryContainerButtonColors(),
       ) {
         Text(SUBMISSION_BUTTON_TEXT, style = MaterialTheme.typography.headlineMedium)
       }
@@ -332,12 +333,13 @@ fun ExposedDropdownMenuSample(
           ExposedDropdownMenuDefaults.TrailingIcon(
               expanded = expanded, Modifier.size(MaterialTheme.dimens.iconSize))
         },
-        colors = getTextFieldColors(),
+        colors = getMenuTextFieldColors(),
     )
     ExposedDropdownMenu(
         expanded = expanded,
         onDismissRequest = { expanded = false },
         modifier = Modifier.wrapContentSize(),
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
     ) {
       itemsList.forEach { option ->
         DropdownMenuItem(

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -175,7 +175,7 @@ fun SignInScreen(
         Text(
             modifier = Modifier.wrapContentSize(),
             text = NO_ACCOUNT_TEXT,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.bodyMedium)
 
         Text(
@@ -185,7 +185,7 @@ fun SignInScreen(
                     .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
             text = SIGN_UP_TEXT,
             textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.onTertiaryContainer,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
             style = MaterialTheme.typography.bodyMedium,
         )
       }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -15,8 +15,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,8 +45,7 @@ import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
-import com.android.periodpals.ui.theme.ComponentColor.getBorderStroke
-import com.android.periodpals.ui.theme.ComponentColor.getOutlinedButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val DEFAULT_PASSWORD = ""
@@ -200,15 +199,14 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) {
-  OutlinedButton(
+  Button(
       modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
       onClick = {
         // TODO: implement Google sign in
         Toast.makeText(context, "Use other login method for now, thanks!", Toast.LENGTH_SHORT)
             .show()
       },
-      colors = getOutlinedButtonPrimaryColors(),
-      border = getBorderStroke(),
+      colors = getFilledButtonPrimaryColors(),
   ) {
     Row(
         modifier = Modifier.wrapContentSize(),

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -47,7 +47,7 @@ import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
-import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val DEFAULT_PASSWORD = ""
@@ -208,7 +208,7 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
         Toast.makeText(context, "Use other login method for now, thanks!", Toast.LENGTH_SHORT)
             .show()
       },
-      colors = getFilledButtonPrimaryColors(),
+      colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Row(
         modifier = Modifier.wrapContentSize(),

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -207,7 +207,6 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
         Toast.makeText(context, "Use other login method for now, thanks!", Toast.LENGTH_SHORT)
             .show()
       },
-      enabled = true,
       colors = getOutlinedButtonPrimaryColors(),
       border = getBorderStroke(),
   ) {
@@ -226,7 +225,6 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
           modifier = Modifier.wrapContentSize(),
           text = SIGN_UP_WITH_GOOGLE,
           fontWeight = FontWeight.Medium,
-          softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
       )
     }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
+import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
 import com.android.periodpals.ui.components.AuthenticationPasswordInput
@@ -46,7 +47,6 @@ import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
-import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val DEFAULT_PASSWORD = ""

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
-import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
 import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
@@ -83,7 +82,6 @@ fun SignInScreen(
     navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
-  val userState: UserAuthenticationState by authenticationViewModel.userAuthenticationState
   var email by remember { mutableStateOf(DEFAULT_EMAIL) }
   var password by remember { mutableStateOf(DEFAULT_PASSWORD) }
   val (emailErrorMessage, setEmailErrorMessage) =
@@ -145,7 +143,6 @@ fun SignInScreen(
                   password = password,
                   setPasswordErrorMessage = setPasswordErrorMessage,
                   authenticationViewModel = authenticationViewModel,
-                  userState = userState,
                   context = context,
                   navigationActions = navigationActions,
               )
@@ -239,7 +236,6 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
  * @param password The password entered by the user.
  * @param setPasswordErrorMessage A function to set the error message for the password field.
  * @param authenticationViewModel The ViewModel that handles authentication logic.
- * @param userState The current state of the user authentication.
  * @param context The context used to show Toast messages.
  * @param navigationActions The navigation actions to navigate between screens.
  * @return A lambda function to be called on button click.
@@ -250,7 +246,6 @@ private fun attemptSignIn(
     password: String,
     setPasswordErrorMessage: (String) -> Unit,
     authenticationViewModel: AuthenticationViewModel,
-    userState: UserAuthenticationState,
     context: Context,
     navigationActions: NavigationActions,
 ) {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -2,7 +2,6 @@ package com.android.periodpals.ui.authentication
 
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -16,9 +15,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,12 +27,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserAuthenticationState
@@ -47,6 +45,8 @@ import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.theme.ComponentColor.getBorderStroke
+import com.android.periodpals.ui.theme.ComponentColor.getOutlinedButtonPrimaryColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val DEFAULT_PASSWORD = ""
@@ -116,6 +116,7 @@ fun SignInScreen(
             modifier =
                 Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
             text = SIGN_IN_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.bodyLarge,
         )
@@ -157,6 +158,7 @@ fun SignInScreen(
                     .wrapContentHeight()
                     .testTag(SignInScreen.CONTINUE_WITH_TEXT),
             text = CONTINUE_WITH_TEXT,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.bodyLarge,
         )
@@ -172,6 +174,7 @@ fun SignInScreen(
         Text(
             modifier = Modifier.wrapContentSize(),
             text = NO_ACCOUNT_TEXT,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
             style = MaterialTheme.typography.bodyMedium)
 
         Text(
@@ -180,7 +183,8 @@ fun SignInScreen(
                     .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
                     .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
             text = SIGN_UP_TEXT,
-            color = Color.Blue,
+            textDecoration = TextDecoration.Underline,
+            color = MaterialTheme.colorScheme.onTertiaryContainer,
             style = MaterialTheme.typography.bodyMedium,
         )
       }
@@ -196,7 +200,7 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) {
-  Button(
+  OutlinedButton(
       modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
       onClick = {
         // TODO: implement Google sign in
@@ -204,8 +208,8 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
             .show()
       },
       enabled = true,
-      colors = ButtonDefaults.buttonColors(containerColor = Color.White),
-      border = BorderStroke(MaterialTheme.dimens.borderLine, Color.LightGray),
+      colors = getOutlinedButtonPrimaryColors(),
+      border = getBorderStroke(),
   ) {
     Row(
         modifier = Modifier.wrapContentSize(),
@@ -221,7 +225,6 @@ fun AuthenticationGoogleButton(context: Context, modifier: Modifier = Modifier) 
       Text(
           modifier = Modifier.wrapContentSize(),
           text = SIGN_UP_WITH_GOOGLE,
-          color = Color.Black,
           fontWeight = FontWeight.Medium,
           softWrap = true,
           style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.authentication.AuthenticationViewModel
-import com.android.periodpals.model.user.UserAuthenticationState
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignUpScreen
 import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
@@ -82,7 +81,6 @@ fun SignUpScreen(
     navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
-  val userState: UserAuthenticationState by authenticationViewModel.userAuthenticationState
 
   var email by remember { mutableStateOf(DEFAULT_EMAIL) }
   var password by remember { mutableStateOf(DEFAULT_PASSWORD) }
@@ -173,7 +171,6 @@ fun SignUpScreen(
                   setPasswordErrorMessage = setPasswordErrorMessage,
                   setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
                   authenticationViewModel = authenticationViewModel,
-                  userState = userState,
                   context = context,
                   navigationActions = navigationActions,
               )
@@ -196,7 +193,6 @@ fun SignUpScreen(
  * @param setConfirmedPasswordErrorMessage A function to set the error message for the confirmed
  *   password field.
  * @param authenticationViewModel The ViewModel that handles authentication logic.
- * @param userState The current state of the user authentication.
  * @param context The context used to show Toast messages.
  * @param navigationActions The navigation actions to navigate between screens.
  */
@@ -208,7 +204,6 @@ private fun attemptSignUp(
     setPasswordErrorMessage: (String) -> Unit,
     setConfirmedPasswordErrorMessage: (String) -> Unit,
     authenticationViewModel: AuthenticationViewModel,
-    userState: UserAuthenticationState,
     context: Context,
     navigationActions: NavigationActions,
 ) {
@@ -231,7 +226,7 @@ private fun attemptSignUp(
         }
         navigationActions.navigateTo(Screen.CREATE_PROFILE)
       },
-      onFailure = { e: Exception ->
+      onFailure = { _: Exception ->
         Handler(Looper.getMainLooper()).post {
           Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -119,6 +119,7 @@ fun SignUpScreen(
             modifier =
                 Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
             text = SIGN_UP_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.bodyLarge,
         )
@@ -143,6 +144,7 @@ fun SignUpScreen(
                     .wrapContentHeight()
                     .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
             text = CONFIRM_PASSWORD_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.bodyLarge,
         )

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -40,8 +40,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
-import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
-import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
+import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
+import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
-import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
@@ -251,7 +251,7 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
   Button(
       modifier = Modifier.wrapContentSize().testTag(testTag),
       onClick = onClick,
-      colors = getFilledButtonPrimaryColors(),
+      colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Text(
         text = text,

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -40,44 +40,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
-import com.android.periodpals.ui.theme.Pink40
-import com.android.periodpals.ui.theme.Purple80
-import com.android.periodpals.ui.theme.PurpleGrey80
 import com.android.periodpals.ui.theme.dimens
-
-/**
- * A composable function that displays a card with authentication content.
- *
- * The card is a rounded rectangle with a shadow. The content is displayed inside the card.
- *
- * @param content The content to display inside the card.
- */
-@Composable
-fun AuthenticationCard(
-    content: @Composable () -> Unit,
-) {
-  Card(
-      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
-      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
-  ) {
-    Column(
-        modifier =
-            Modifier.fillMaxWidth()
-                .wrapContentHeight()
-                .padding(
-                    horizontal = MaterialTheme.dimens.medium1,
-                    vertical = MaterialTheme.dimens.small3,
-                ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
-    ) {
-      content()
-    }
-  }
-}
 
 /**
  * A composable function that displays a graded background with a gradient.
@@ -88,9 +51,9 @@ fun AuthenticationCard(
  */
 @Composable
 fun GradedBackground(
-    gradeFrom: Color = Purple80,
-    gradeTo: Color = Pink40,
-    background: Color = PurpleGrey80,
+    gradeFrom: Color = MaterialTheme.colorScheme.primaryContainer,
+    gradeTo: Color = MaterialTheme.colorScheme.tertiary,
+    background: Color = MaterialTheme.colorScheme.tertiaryContainer,
 ) {
   Box(
       modifier =
@@ -133,6 +96,43 @@ fun AuthenticationWelcomeText(text: String = "Welcome to PeriodPals", color: Col
       color = color,
       style = MaterialTheme.typography.titleLarge,
   )
+}
+
+/**
+ * A composable function that displays a card with authentication content.
+ *
+ * The card is a rounded rectangle with a shadow. The content is displayed inside the card.
+ *
+ * @param content The content to display inside the card.
+ */
+@Composable
+fun AuthenticationCard(
+    content: @Composable () -> Unit,
+) {
+  Card(
+      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+      shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors =
+          CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.surfaceContainer,
+              contentColor = MaterialTheme.colorScheme.onSurface),
+      elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
+  ) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .wrapContentHeight()
+                .padding(
+                    horizontal = MaterialTheme.dimens.medium1,
+                    vertical = MaterialTheme.dimens.small3,
+                ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterVertically),
+    ) {
+      content()
+    }
+  }
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
-import com.android.periodpals.ui.theme.ComponentColor.getCardColors
 import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
 import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
@@ -114,7 +113,11 @@ fun AuthenticationCard(
   Card(
       modifier = Modifier.fillMaxWidth().wrapContentHeight(),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = getCardColors(),
+      colors =
+          CardDefaults.cardColors(
+              containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+              contentColor = MaterialTheme.colorScheme.onSurface,
+          ),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -53,9 +53,9 @@ import com.android.periodpals.ui.theme.dimens
  */
 @Composable
 fun GradedBackground(
-    gradeFrom: Color = MaterialTheme.colorScheme.primaryContainer,
+    gradeFrom: Color = MaterialTheme.colorScheme.tertiaryContainer,
     gradeTo: Color = MaterialTheme.colorScheme.tertiary,
-    background: Color = MaterialTheme.colorScheme.tertiaryContainer,
+    background: Color = MaterialTheme.colorScheme.secondaryContainer,
 ) {
   Box(
       modifier =
@@ -93,7 +93,7 @@ fun AuthenticationWelcomeText(text: String = "Welcome to PeriodPals") {
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(AuthenticationScreens.WELCOME_TEXT),
       text = text,
-      color = MaterialTheme.colorScheme.onPrimaryContainer,
+      color = MaterialTheme.colorScheme.onTertiaryContainer,
       textAlign = TextAlign.Center,
       style = MaterialTheme.typography.titleLarge,
   )

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -248,7 +248,6 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
   Button(
       modifier = Modifier.wrapContentSize().testTag(testTag),
       onClick = onClick,
-      enabled = true,
       colors = getFilledButtonPrimaryColors(),
   ) {
     Text(

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -256,7 +256,6 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
     Text(
         text = text,
         modifier = Modifier.wrapContentSize(),
-        color = Color.White,
         style = MaterialTheme.typography.bodyMedium,
     )
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
+import com.android.periodpals.ui.theme.ComponentColor.getCardColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 
 /**
@@ -84,16 +87,15 @@ fun GradedBackground(
  * A composable function that displays a welcome text.
  *
  * @param text The welcome text to display.
- * @param color The color of the text.
  */
 @Composable
-fun AuthenticationWelcomeText(text: String = "Welcome to PeriodPals", color: Color = Color.Black) {
+fun AuthenticationWelcomeText(text: String = "Welcome to PeriodPals") {
   Text(
       modifier =
           Modifier.fillMaxWidth().wrapContentHeight().testTag(AuthenticationScreens.WELCOME_TEXT),
       text = text,
+      color = MaterialTheme.colorScheme.onPrimaryContainer,
       textAlign = TextAlign.Center,
-      color = color,
       style = MaterialTheme.typography.titleLarge,
   )
 }
@@ -112,10 +114,7 @@ fun AuthenticationCard(
   Card(
       modifier = Modifier.fillMaxWidth().wrapContentHeight(),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors =
-          CardDefaults.cardColors(
-              containerColor = MaterialTheme.colorScheme.surfaceContainer,
-              contentColor = MaterialTheme.colorScheme.onSurface),
+      colors = getCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(
@@ -167,6 +166,7 @@ fun AuthenticationEmailInput(
                 else MaterialTheme.typography.labelLarge,
         )
       },
+      colors = getOutlinedTextFieldColors(),
   )
   if (emailErrorMessage.isNotEmpty()) {
     ErrorText(message = emailErrorMessage, testTag = AuthenticationScreens.EMAIL_ERROR_TEXT)
@@ -229,6 +229,7 @@ fun AuthenticationPasswordInput(
           )
         }
       },
+      colors = getOutlinedTextFieldColors(),
   )
   if (passwordErrorMessage.isNotEmpty()) {
     ErrorText(passwordErrorMessage, passwordErrorTestTag)
@@ -248,6 +249,7 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
       modifier = Modifier.wrapContentSize().testTag(testTag),
       onClick = onClick,
       enabled = true,
+      colors = getFilledButtonPrimaryColors(),
   ) {
     Text(
         text = text,

--- a/app/src/main/java/com/android/periodpals/ui/components/ErrorComponent.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ErrorComponent.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 
@@ -18,7 +17,7 @@ fun ErrorText(message: String, testTag: String) {
   Text(
       modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(testTag),
       text = message,
-      color = Color.Red,
+      color = MaterialTheme.colorScheme.error,
       textAlign = TextAlign.Start,
       style = MaterialTheme.typography.labelMedium)
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
@@ -78,6 +80,7 @@ fun ProfileSection(text: String, testTag: String) {
               .wrapContentHeight()
               .testTag(testTag),
       text = text,
+      color = MaterialTheme.colorScheme.onSurface,
       textAlign = TextAlign.Start,
       style = MaterialTheme.typography.titleSmall,
   )
@@ -110,6 +113,7 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
         )
       },
       placeholder = { Text(text = NAME_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
+      colors = getOutlinedTextFieldColors(),
   )
 }
 
@@ -140,6 +144,7 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
         )
       },
       placeholder = { Text(text = DOB_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
+      colors = getOutlinedTextFieldColors(),
   )
 }
 
@@ -173,6 +178,7 @@ fun ProfileInputDescription(description: String, onValueChange: (String) -> Unit
         Text(text = DESCRIPTION_PLACEHOLDER, style = MaterialTheme.typography.labelLarge)
       },
       minLines = 3,
+      colors = getOutlinedTextFieldColors(),
   )
 }
 
@@ -187,7 +193,7 @@ fun ProfileSaveButton(onClick: () -> Unit) {
   Button(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
       onClick = onClick,
-      enabled = true,
+      colors = getFilledButtonPrimaryColors(),
   ) {
     Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.ProfileScreens
-import com.android.periodpals.ui.theme.ComponentColor.getFilledButtonPrimaryColors
+import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
@@ -193,7 +193,7 @@ fun ProfileSaveButton(onClick: () -> Unit) {
   Button(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreens.SAVE_BUTTON),
       onClick = onClick,
-      colors = getFilledButtonPrimaryColors(),
+      colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
   }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.resources.C.Tag.ProfileScreens
-import com.android.periodpals.ui.theme.ComponentColor.getFilledPrimaryContainerButtonColors
-import com.android.periodpals.ui.theme.ComponentColor.getOutlinedTextFieldColors
+import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
+import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -30,10 +30,10 @@ import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
-import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
+import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
 import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
 import com.bumptech.glide.integration.compose.GlideImage
@@ -237,10 +237,9 @@ fun ProfileSaveButton(
         Toast.makeText(context, TOAST_SUCCESS, Toast.LENGTH_SHORT).show()
         navigationActions.navigateTo(Screen.PROFILE)
       },
-      colors = getFilledPrimaryContainerButtonColors()
-  ) {
-    Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
-  }
+      colors = getFilledPrimaryContainerButtonColors()) {
+        Text(text = SAVE_BUTTON_TEXT, style = MaterialTheme.typography.bodyMedium)
+      }
 }
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,24 +30,35 @@ fun BottomNavigationMenu(
           Modifier.fillMaxWidth()
               .wrapContentHeight()
               .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU),
-      containerColor = MaterialTheme.colorScheme.primaryContainer,
+      containerColor = MaterialTheme.colorScheme.secondary,
+      contentColor = MaterialTheme.colorScheme.onSecondary,
       content = {
         tabList.forEach { tab ->
           NavigationBarItem(
-              modifier =
-                  Modifier.wrapContentSize()
-                      .clip(RoundedCornerShape(percent = MaterialTheme.dimens.roundedPercent))
-                      .align(Alignment.CenterVertically)
-                      .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU_ITEM + tab.textId),
+              selected = tab.route == selectedItem,
+              onClick = { onTabSelect(tab) },
               icon = {
                 Icon(
                     imageVector = tab.icon,
                     contentDescription = null,
                     modifier = Modifier.size(MaterialTheme.dimens.iconSize))
               },
+              modifier =
+                  Modifier.wrapContentSize()
+                      .clip(RoundedCornerShape(percent = MaterialTheme.dimens.roundedPercent))
+                      .align(Alignment.CenterVertically)
+                      .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU_ITEM + tab.textId),
               label = { Text(text = tab.textId, style = MaterialTheme.typography.labelSmall) },
-              selected = tab.route == selectedItem,
-              onClick = { onTabSelect(tab) },
+              colors =
+                  NavigationBarItemDefaults.colors(
+                      selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                      selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                      indicatorColor = MaterialTheme.colorScheme.secondaryContainer,
+                      disabledIconColor = MaterialTheme.colorScheme.onSecondary,
+                      disabledTextColor = MaterialTheme.colorScheme.onSecondary,
+                      unselectedIconColor = MaterialTheme.colorScheme.onSecondary,
+                      unselectedTextColor = MaterialTheme.colorScheme.onSecondary,
+                  ),
           )
         }
       },

--- a/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/BottomNavigationMenu.kt
@@ -30,8 +30,8 @@ fun BottomNavigationMenu(
           Modifier.fillMaxWidth()
               .wrapContentHeight()
               .testTag(BottomNavigationMenu.BOTTOM_NAVIGATION_MENU),
-      containerColor = MaterialTheme.colorScheme.secondary,
-      contentColor = MaterialTheme.colorScheme.onSecondary,
+      containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+      contentColor = MaterialTheme.colorScheme.onSurface,
       content = {
         tabList.forEach { tab ->
           NavigationBarItem(
@@ -54,10 +54,8 @@ fun BottomNavigationMenu(
                       selectedIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
                       selectedTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
                       indicatorColor = MaterialTheme.colorScheme.secondaryContainer,
-                      disabledIconColor = MaterialTheme.colorScheme.onSecondary,
-                      disabledTextColor = MaterialTheme.colorScheme.onSecondary,
-                      unselectedIconColor = MaterialTheme.colorScheme.onSecondary,
-                      unselectedTextColor = MaterialTheme.colorScheme.onSecondary,
+                      unselectedIconColor = MaterialTheme.colorScheme.onSurface,
+                      unselectedTextColor = MaterialTheme.colorScheme.onSurface,
                   ),
           )
         }

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.resources.C.Tag.TopAppBar
+import com.android.periodpals.ui.theme.ComponentColor.getTopAppBarIconButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 /**
@@ -82,6 +83,7 @@ fun TopAppBar(
           IconButton(
               modifier = Modifier.wrapContentSize().testTag(TopAppBar.GO_BACK_BUTTON),
               onClick = onBackButtonClick!!,
+              colors = getTopAppBarIconButtonColors(),
           ) {
             Icon(
                 modifier = Modifier.size(MaterialTheme.dimens.iconSize),
@@ -96,6 +98,7 @@ fun TopAppBar(
           IconButton(
               modifier = Modifier.wrapContentSize().testTag(TopAppBar.EDIT_BUTTON),
               onClick = onEditButtonClick!!,
+              colors = getTopAppBarIconButtonColors(),
           ) {
             Icon(
                 modifier = Modifier.size(MaterialTheme.dimens.iconSize),
@@ -108,8 +111,8 @@ fun TopAppBar(
       colors =
           TopAppBarDefaults.centerAlignedTopAppBarColors(
               containerColor = MaterialTheme.colorScheme.inversePrimary,
-              navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
-              actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+              navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+              actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
               titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
           ),
       scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -107,7 +107,7 @@ fun TopAppBar(
       },
       colors =
           TopAppBarDefaults.centerAlignedTopAppBarColors(
-              containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+              containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
               navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
               actionIconContentColor = MaterialTheme.colorScheme.onSurface,
               titleContentColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.resources.C.Tag.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getTopAppBarIconButtonColors
+import com.android.periodpals.resources.ComponentColor.getTopAppBarIconButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 /**

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -76,7 +76,6 @@ fun TopAppBar(
             modifier = Modifier.wrapContentSize().testTag(TopAppBar.TITLE_TEXT),
             text = title,
             style = MaterialTheme.typography.titleMedium,
-            softWrap = true,
         )
       },
       navigationIcon = {

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.android.periodpals.resources.C.Tag.TopAppBar
-import com.android.periodpals.ui.theme.PurpleGrey80
 import com.android.periodpals.ui.theme.dimens
 
 /**
@@ -106,6 +105,12 @@ fun TopAppBar(
           }
         }
       },
-      colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = PurpleGrey80),
+      colors =
+          TopAppBarDefaults.centerAlignedTopAppBarColors(
+              containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+              navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+              actionIconContentColor = MaterialTheme.colorScheme.onSurface,
+              titleContentColor = MaterialTheme.colorScheme.onSurface,
+          ),
   )
 }

--- a/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
+++ b/app/src/main/java/com/android/periodpals/ui/navigation/TopAppBar.kt
@@ -107,10 +107,11 @@ fun TopAppBar(
       },
       colors =
           TopAppBarDefaults.centerAlignedTopAppBarColors(
-              containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-              navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
-              actionIconContentColor = MaterialTheme.colorScheme.onSurface,
-              titleContentColor = MaterialTheme.colorScheme.onSurface,
+              containerColor = MaterialTheme.colorScheme.inversePrimary,
+              navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+              actionIconContentColor = MaterialTheme.colorScheme.onPrimary,
+              titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
           ),
+      scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
   )
 }

--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -84,6 +84,8 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
       topBar = { TopAppBar(title = SCREEN_TITLE) },
+      containerColor = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
     Column(
         modifier =

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.testTag
 import com.android.periodpals.R
 import com.android.periodpals.resources.C.Tag.ProfileScreens
 import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
+import com.android.periodpals.resources.ComponentColor.getFilledIconButtonColors
 import com.android.periodpals.ui.components.ERROR_INVALID_DATE
 import com.android.periodpals.ui.components.ERROR_INVALID_DESCRIPTION
 import com.android.periodpals.ui.components.ERROR_INVALID_NAME
@@ -47,7 +48,6 @@ import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getFilledIconButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Edit Your Profile"

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -48,6 +47,7 @@ import com.android.periodpals.ui.components.TOAST_SUCCESS
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.ComponentColor.getFilledIconButtonColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Edit Your Profile"
@@ -98,6 +98,8 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
             onBackButtonClick = { navigationActions.navigateTo(Screen.PROFILE) },
         )
       },
+      containerColor = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
     Column(
         modifier =
@@ -122,15 +124,11 @@ fun EditProfileScreen(navigationActions: NavigationActions) {
               val pickImageIntent = Intent(Intent.ACTION_PICK).apply { type = "image/*" }
               launcher.launch(pickImageIntent)
             },
-            colors =
-                IconButtonDefaults.iconButtonColors(
-                    containerColor = MaterialTheme.colorScheme.tertiary,
-                    contentColor = MaterialTheme.colorScheme.onTertiary,
-                ),
             modifier =
                 Modifier.align(Alignment.TopEnd)
                     .size(MaterialTheme.dimens.iconButtonSize)
                     .testTag(EditProfileScreen.EDIT_PROFILE_PICTURE),
+            colors = getFilledIconButtonColors(),
         ) {
           Icon(
               imageVector = Icons.Outlined.Edit,

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.R
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
+import com.android.periodpals.resources.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
@@ -38,7 +39,6 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Your Profile"

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -38,6 +38,7 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
+import com.android.periodpals.ui.theme.ComponentColor.getCardColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Your Profile"
@@ -165,6 +166,7 @@ private fun NoReviewCard() {
   Card(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_CARD),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
+      colors = getCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -38,7 +38,7 @@ import com.android.periodpals.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
-import com.android.periodpals.ui.theme.ComponentColor.getCardColors
+import com.android.periodpals.ui.theme.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.theme.dimens
 
 private const val SCREEN_TITLE = "Your Profile"
@@ -166,7 +166,7 @@ private fun NoReviewCard() {
   Card(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_CARD),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
-      colors = getCardColors(),
+      colors = getTertiaryCardColors(),
       elevation = CardDefaults.cardElevation(defaultElevation = MaterialTheme.dimens.cardElevation),
   ) {
     Column(

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -93,6 +93,8 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
             selectedItem = navigationActions.currentRoute(),
         )
       },
+      containerColor = MaterialTheme.colorScheme.surface,
+      contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
     Column(
         modifier =
@@ -115,7 +117,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
           modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
           text = userState.value?.name ?: DEFAULT_NAME,
           textAlign = TextAlign.Center,
-          softWrap = true,
           style = MaterialTheme.typography.titleSmall,
       )
 
@@ -125,7 +126,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
               Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.DESCRIPTION_FIELD),
           text = userState.value?.description ?: DEFAULT_DESCRIPTION,
           textAlign = TextAlign.Center,
-          softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
       )
 
@@ -137,7 +137,6 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
               if (numberInteractions == 0) NEW_USER_TEXT
               else NUMBER_INTERACTION_TEXT + numberInteractions,
           textAlign = TextAlign.Left,
-          softWrap = true,
           style = MaterialTheme.typography.bodyMedium,
       )
 

--- a/app/src/main/java/com/android/periodpals/ui/theme/AppUtil.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/AppUtil.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
+import com.android.periodpals.resources.CompactLargeDimens
+import com.android.periodpals.resources.Dimens
 
 /**
  * A composable function that provides the application dimensions to the composition.

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -17,15 +17,6 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
-// TODO: delete
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
-
 object PeriodPalsColor {
   val LightTheme: ColorScheme =
       lightColorScheme(

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -109,8 +109,8 @@ object ComponentColor {
   @Composable
   fun getCardColors(): CardColors {
     return CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     )
   }
 

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
@@ -106,7 +108,7 @@ object ComponentColor {
   @Composable
   fun getCardColors(): CardColors {
     return CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
         contentColor = MaterialTheme.colorScheme.onSurface,
     )
   }
@@ -127,6 +129,15 @@ object ComponentColor {
     )
   }
 
+  /** Returns the default filled icon button colors for PeriodPals application. */
+  @Composable
+  fun getFilledIconButtonColors(): IconButtonColors {
+    return IconButtonDefaults.iconButtonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+    )
+  }
+
   /** Returns the default outlined text field colors for PeriodPals application. */
   @Composable
   fun getOutlinedTextFieldColors(): TextFieldColors {
@@ -140,6 +151,7 @@ object ComponentColor {
     )
   }
 
+  /** Returns the default border stroke for PeriodPals application. */
   @Composable
   fun getBorderStroke(): BorderStroke {
     return BorderStroke(

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -141,13 +141,20 @@ object ComponentColor {
     )
   }
 
+  @Composable
+  fun getTopAppBarIconButtonColors(): IconButtonColors {
+    return IconButtonDefaults.iconButtonColors(
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+  }
+
   /** Returns the outlined text field colors. */
   @Composable
   fun getOutlinedTextFieldColors(): TextFieldColors {
     return OutlinedTextFieldDefaults.colors(
         focusedTextColor = MaterialTheme.colorScheme.primary,
         unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-        focusedBorderColor = MaterialTheme.colorScheme.outline,
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
         unfocusedBorderColor = MaterialTheme.colorScheme.outline,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
@@ -162,7 +169,7 @@ object ComponentColor {
         unfocusedTextColor = MaterialTheme.colorScheme.secondary,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
-        focusedBorderColor = MaterialTheme.colorScheme.outline,
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
         unfocusedBorderColor = MaterialTheme.colorScheme.outline,
         focusedLeadingIconColor = MaterialTheme.colorScheme.secondary,
         unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -1,8 +1,17 @@
 package com.android.periodpals.ui.theme
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 // TODO: delete
@@ -90,4 +99,50 @@ object PeriodPalsColor {
           surfaceContainer = Color(0xFF1D2024),
           surfaceContainerHigh = Color(0xFF282A2F),
           surfaceContainerHighest = Color(0xFF33353A))
+}
+
+object ComponentColor {
+  /** Returns the default card colors for PeriodPals application. */
+  @Composable
+  fun getCardColors(): CardColors {
+    return CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    )
+  }
+
+  /** Returns the default filled button colors for PeriodPals application. */
+  @Composable
+  fun getFilledButtonPrimaryColors(): ButtonColors {
+    return ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary)
+  }
+
+  /** Returns the default outlined button colors for PeriodPals application. */
+  @Composable
+  fun getOutlinedButtonPrimaryColors(): ButtonColors {
+    return ButtonDefaults.outlinedButtonColors(
+        contentColor = MaterialTheme.colorScheme.primary,
+    )
+  }
+
+  /** Returns the default outlined text field colors for PeriodPals application. */
+  @Composable
+  fun getOutlinedTextFieldColors(): TextFieldColors {
+    return OutlinedTextFieldDefaults.colors(
+        focusedTextColor = MaterialTheme.colorScheme.primary,
+        unfocusedTextColor = MaterialTheme.colorScheme.secondary,
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
+        unfocusedBorderColor = MaterialTheme.colorScheme.secondary,
+        focusedLabelColor = MaterialTheme.colorScheme.primary,
+        unfocusedLabelColor = MaterialTheme.colorScheme.secondary,
+    )
+  }
+
+  @Composable
+  fun getBorderStroke(): BorderStroke {
+    return BorderStroke(
+        width = MaterialTheme.dimens.borderLine, color = MaterialTheme.colorScheme.primary)
+  }
 }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -105,24 +105,43 @@ object PeriodPalsColor {
 }
 
 object ComponentColor {
-  /** Returns the default card colors for PeriodPals application. */
+  /** Returns the primary card colors for alert items. */
   @Composable
-  fun getCardColors(): CardColors {
+  fun getPrimaryCardColors(): CardColors {
     return CardDefaults.cardColors(
-        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
     )
   }
 
-  /** Returns the default filled button colors for PeriodPals application. */
+  /** Returns the tertiary card colors for other cards. */
   @Composable
-  fun getFilledButtonPrimaryColors(): ButtonColors {
-    return ButtonDefaults.buttonColors(
-        containerColor = MaterialTheme.colorScheme.primary,
-        contentColor = MaterialTheme.colorScheme.onPrimary)
+  fun getTertiaryCardColors(): CardColors {
+    return CardDefaults.cardColors(
+        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    )
   }
 
-  /** Returns the default filled icon button colors for PeriodPals application. */
+  /** Returns the filled primary container button colors. */
+  @Composable
+  fun getFilledPrimaryContainerButtonColors(): ButtonColors {
+    return ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+  }
+
+  /** Returns the filled tertiary container button colors. */
+  @Composable
+  fun getFilledPrimaryButtonColors(): ButtonColors {
+    return ButtonDefaults.buttonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+    )
+  }
+
+  /** Returns the filled icon button colors. */
   @Composable
   fun getFilledIconButtonColors(): IconButtonColors {
     return IconButtonDefaults.iconButtonColors(
@@ -131,45 +150,50 @@ object ComponentColor {
     )
   }
 
-  /** Returns the default outlined text field colors for PeriodPals application. */
+  /** Returns the outlined text field colors. */
   @Composable
   fun getOutlinedTextFieldColors(): TextFieldColors {
     return OutlinedTextFieldDefaults.colors(
         focusedTextColor = MaterialTheme.colorScheme.primary,
-        unfocusedTextColor = MaterialTheme.colorScheme.secondary,
-        focusedBorderColor = MaterialTheme.colorScheme.primary,
-        unfocusedBorderColor = MaterialTheme.colorScheme.secondary,
+        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+        focusedBorderColor = MaterialTheme.colorScheme.outline,
+        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
-        unfocusedLabelColor = MaterialTheme.colorScheme.secondary,
+        unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
     )
   }
 
-  /** Returns the default outlined text field colors for PeriodPals application. */
+  /** Returns the menu outlined text field colors. */
   @Composable
   fun getMenuOutlinedTextFieldColors(): TextFieldColors {
     return OutlinedTextFieldDefaults.colors(
-        focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
-        focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-        focusedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        focusedTextColor = MaterialTheme.colorScheme.primary,
+        unfocusedTextColor = MaterialTheme.colorScheme.secondary,
+        focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
-        focusedBorderColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        unfocusedBorderColor = MaterialTheme.colorScheme.onSurface,
-        focusedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        focusedBorderColor = MaterialTheme.colorScheme.outline,
+        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+        focusedLeadingIconColor = MaterialTheme.colorScheme.secondary,
         unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurface,
     )
   }
 
-  /** Returns the default text field colors for PeriodPals application. */
+  /** Returns the menu text field colors. */
   @Composable
-  fun getTextFieldColors(): TextFieldColors {
+  fun getMenuTextFieldColors(): TextFieldColors {
     return TextFieldDefaults.colors(
         focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
         focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        focusedLabelColor = MaterialTheme.colorScheme.primary,
+        unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
+        focusedTrailingIconColor = MaterialTheme.colorScheme.primary,
+        unfocusedTrailingIconColor = MaterialTheme.colorScheme.onSurface,
     )
   }
 
+  /** Returns the dropdown menu item colors. */
   @Composable
   fun getMenuItemColors(): MenuItemColors {
     return MenuItemColors(

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -1,6 +1,5 @@
 package com.android.periodpals.ui.theme
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
@@ -121,14 +120,6 @@ object ComponentColor {
         contentColor = MaterialTheme.colorScheme.onPrimary)
   }
 
-  /** Returns the default outlined button colors for PeriodPals application. */
-  @Composable
-  fun getOutlinedButtonPrimaryColors(): ButtonColors {
-    return ButtonDefaults.outlinedButtonColors(
-        contentColor = MaterialTheme.colorScheme.primary,
-    )
-  }
-
   /** Returns the default filled icon button colors for PeriodPals application. */
   @Composable
   fun getFilledIconButtonColors(): IconButtonColors {
@@ -149,12 +140,5 @@ object ComponentColor {
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.secondary,
     )
-  }
-
-  /** Returns the default border stroke for PeriodPals application. */
-  @Composable
-  fun getBorderStroke(): BorderStroke {
-    return BorderStroke(
-        width = MaterialTheme.dimens.borderLine, color = MaterialTheme.colorScheme.primary)
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Color.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuItemColors
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -139,6 +141,44 @@ object ComponentColor {
         unfocusedBorderColor = MaterialTheme.colorScheme.secondary,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.secondary,
+    )
+  }
+
+  /** Returns the default outlined text field colors for PeriodPals application. */
+  @Composable
+  fun getMenuOutlinedTextFieldColors(): TextFieldColors {
+    return OutlinedTextFieldDefaults.colors(
+        focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unfocusedTextColor = MaterialTheme.colorScheme.onSurface,
+        focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        unfocusedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        focusedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unfocusedLabelColor = MaterialTheme.colorScheme.onSurface,
+        focusedBorderColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unfocusedBorderColor = MaterialTheme.colorScheme.onSurface,
+        focusedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        unfocusedLeadingIconColor = MaterialTheme.colorScheme.onSurface,
+    )
+  }
+
+  /** Returns the default text field colors for PeriodPals application. */
+  @Composable
+  fun getTextFieldColors(): TextFieldColors {
+    return TextFieldDefaults.colors(
+        focusedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+    )
+  }
+
+  @Composable
+  fun getMenuItemColors(): MenuItemColors {
+    return MenuItemColors(
+        textColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        leadingIconColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        trailingIconColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        disabledTextColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        disabledLeadingIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        disabledTrailingIconColor = MaterialTheme.colorScheme.onSecondaryContainer,
     )
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/theme/Theme.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Theme.kt
@@ -14,6 +14,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.android.periodpals.MainActivity
+import com.android.periodpals.resources.CompactLargeDimens
+import com.android.periodpals.resources.CompactLargeTypography
+import com.android.periodpals.resources.CompactMediumDimens
+import com.android.periodpals.resources.CompactMediumTypography
+import com.android.periodpals.resources.CompactSmallDimens
+import com.android.periodpals.resources.CompactSmallTypography
+import com.android.periodpals.resources.ExpandedDimens
+import com.android.periodpals.resources.ExpandedTypography
+import com.android.periodpals.resources.MediumDimens
+import com.android.periodpals.resources.MediumTypography
+import com.android.periodpals.resources.PeriodPalsColor
 
 // Largest compact S width
 private const val COMPACT_S = 360

--- a/app/src/main/java/com/android/periodpals/ui/theme/Theme.kt
+++ b/app/src/main/java/com/android/periodpals/ui/theme/Theme.kt
@@ -1,7 +1,6 @@
 package com.android.periodpals.ui.theme
 
 import android.app.Activity
-import android.widget.Toast
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -46,41 +45,33 @@ fun PeriodPalsAppTheme(
 
   var appDimens = CompactLargeDimens
   var typography = CompactLargeTypography
-  var toasty = ""
   when (window.widthSizeClass) {
     WindowWidthSizeClass.Compact -> {
       if (config.screenWidthDp <= COMPACT_S) {
         // Emulator Small Phone API 34
         appDimens = CompactSmallDimens
         typography = CompactSmallTypography
-        toasty = "CompactSmall"
       } else if (config.screenWidthDp <= COMPACT_M) {
         // Emulator Pixel 2 API 34
         appDimens = CompactMediumDimens
         typography = CompactMediumTypography
-        toasty = "CompactMedium"
       } else {
         // Emulator Pixel 9 Pro XL API 34
         appDimens = CompactLargeDimens
         typography = CompactLargeTypography
-        toasty = "CompactLarge"
       }
     }
     WindowWidthSizeClass.Medium -> {
       // Emulator Medium Tablet API 34
       appDimens = MediumDimens
       typography = MediumTypography
-      toasty = "Medium"
     }
     WindowWidthSizeClass.Expanded -> {
       // Pixel C API 34
       appDimens = ExpandedDimens
       typography = ExpandedTypography
-      toasty = "Expanded"
     }
   }
-  // TODO: delete
-  Toast.makeText(activity, toasty, Toast.LENGTH_SHORT).show()
 
   ProvideAppUtils(appDimens = appDimens) {
     MaterialTheme(colorScheme = colorScheme, typography = typography, content = content)


### PR DESCRIPTION
# Adapt app to light and dark mode

## Description
This PR introduces our app's responsiveness to dark and light mode. It closes issue #182, subtask from #178.  
It also solves a few issues found out while working.

## Changes
- Try to reduce uncovered to by moving from `app/src/main/java/com/android/periodpals/ui/theme/` to `app/src/main/java/com/android/periodpals/resources/` :
  - `Color.kt`,
  - `Dimens.kt`,
  - and `Type.kt`.
- Clean up unused variables about `userState` in `SignInScreen` and `SignUpScreen`.
- Adapted colours in all UI screens.


## Files 

#### Moved
From : `app/src/main/java/com/android/periodpals/ui/theme/`  
To : `app/src/main/java/com/android/periodpals/resources/`  
Reason: trying to augment code coverage (as this resources package might not be checked by SonarCloud).

#### Modified
- `Color.kt`:
  - New `object` `ComponentColor` which contains some "default" colour settings to be called in components for `color = ...` (usually).
  - Deleted old hard-coded pink and purple values.
- `Type.kt`: fixed compact M screen's profile picture size to `200.dp`, was `50.dp`
- `Theme.kt`:
  - Removed toast messages for screen size and related variables.
- `SignInScreen.kt`: Removed unused `userState` parameter and related variables from `attemptSignIn()`.
- `SignUpScreen.kt`: Removed unused `userState` parameter and related variables from `attemptSignUp()`.
- All UI screens have adapted colours parameters.


## Dependencies Added
- None.

## Testing
- Verified on emulators to ensure consistent and responsive design in both light and dark mode.

## Screenshots

| Screen                               | Before Light                                                                                                      | After Light                                                                                                       | Before Dark                                                                                                      | After Dark                                                                                                       |
|--------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
| **`SignInScreen`**                   | ![image](https://github.com/user-attachments/assets/2cbbabae-95a2-4b26-8849-aacf801ac2c9)                         | ![image](https://github.com/user-attachments/assets/5c7e5809-c02c-40db-946b-ac9cf042f345)                         | ![image](https://github.com/user-attachments/assets/738cb1ea-670d-4970-80b0-b0ae4cce40c7)                         | ![image](https://github.com/user-attachments/assets/5f2626d2-947a-4b86-9681-e337e1d0b2b3)                         |
| **`SignUpScreen`**                   | ![image](https://github.com/user-attachments/assets/605486cc-e7c7-4bf6-b4d1-b353f1887d82)                         | ![image](https://github.com/user-attachments/assets/db522148-5ddc-4f51-9974-abdeb6621cd0)                         | ![image](https://github.com/user-attachments/assets/116e0524-236d-4a51-bfac-665001575bcb)                         | ![image](https://github.com/user-attachments/assets/a6b24fd0-a923-4038-9711-168f449a2573)                         |
| **`CreateProfileScreen`**            | ![image](https://github.com/user-attachments/assets/a19b7100-ba86-4338-97ef-76bd6cd4bcad)                         | ![image](https://github.com/user-attachments/assets/4fc40671-e097-41d8-8590-08607779607e)                         | ![image](https://github.com/user-attachments/assets/30af760c-6c7b-446c-901e-5bc6b08ec0b7)                         | ![image](https://github.com/user-attachments/assets/82621e97-d705-4bd8-9fea-1d33477ab18e)                         |
| **`ProfileScreen`**                  | ![image](https://github.com/user-attachments/assets/6dafa189-1fb9-46b9-889a-98a6e3f74679)                         | ![image](https://github.com/user-attachments/assets/ece6acbf-de63-481c-8d1d-41b5f362aee1)                         | ![image](https://github.com/user-attachments/assets/7ac0a6b1-f55f-471d-933c-bf46446f15c5)                         | ![image](https://github.com/user-attachments/assets/4696ddd5-8a9c-480b-adf6-b8e57764e04f)                         |
| **`EditProfileScreen`**              | ![image](https://github.com/user-attachments/assets/db756cf8-5743-453c-b1c5-2b822e6e4261)                         | ![image](https://github.com/user-attachments/assets/e9531f20-8184-4fa3-84e4-6a51b2357bdb)                         | ![image](https://github.com/user-attachments/assets/90572592-544b-4528-8777-2a321526feaa)                         | ![image](https://github.com/user-attachments/assets/0b63716a-5d37-4985-90fe-19cf1070d486)                         |
| **`CreateAlertScreen`**              | ![image](https://github.com/user-attachments/assets/d5a42ae6-5a6d-4eb6-b6a1-e081bce93753)                         | ![image](https://github.com/user-attachments/assets/c364011d-c58c-4a21-a6a4-ea02775e180d)                         | ![image](https://github.com/user-attachments/assets/75af8267-e629-4a8e-9b76-618902df54d4)                         | ![image](https://github.com/user-attachments/assets/9b01bccd-678d-4016-8ac8-490bc96b1133)                         |
| **`AlertListsScreen` - My alerts (empty)** | ![image](https://github.com/user-attachments/assets/dafc355d-144f-46c7-8f6d-80e7fd1cd104)                         | ![image](https://github.com/user-attachments/assets/d6c802be-3c1c-4582-985e-991c76b9c19b)                         | ![image](https://github.com/user-attachments/assets/0688161f-0e3d-4e50-92d8-b95ff368ff13)                         | ![image](https://github.com/user-attachments/assets/2a93fdb6-c5fd-413e-8035-f63f8de1f4df)                         |
| **`AlertListsScreen` - My alerts (non-empty)** | ![image](https://github.com/user-attachments/assets/612872bf-80b3-456c-97b7-bdaa6156b6c1)                         | ![image](https://github.com/user-attachments/assets/37154e5a-1497-4fdb-ad16-04f17f21ce7f)                         | ![image](https://github.com/user-attachments/assets/b9fa390e-50b7-4348-ace2-a6e501fe41b7)                         | ![image](https://github.com/user-attachments/assets/ff7851a5-e3ba-4640-bf18-693b6c2dc244)                         |
| **`AlertListsScreen` - Pals' alerts (empty)** | ![image](https://github.com/user-attachments/assets/51c94325-0c7e-48b9-a983-1baaa9ab9ae6)                         | ![image](https://github.com/user-attachments/assets/455cd0cc-8087-4cc6-8d06-5ed72301e912)                         | ![image](https://github.com/user-attachments/assets/a5fe7129-241e-4f6d-8e3a-ae84091bcff4)                         | ![image](https://github.com/user-attachments/assets/ed16de85-ede1-43cd-93b3-70e9d2d1e64b)                         |
| **`AlertListsScreen` - Pals' alerts (non-empty)** | ![image](https://github.com/user-attachments/assets/4951d60d-0b00-4815-a31a-3bdf5683fc16)                         | ![image](https://github.com/user-attachments/assets/1e761b78-a838-4adb-a4c9-0394c363843c)                         | ![image](https://github.com/user-attachments/assets/dc839e22-f42e-4870-af6c-84cbb1cc3e08)                         | ![image](https://github.com/user-attachments/assets/59f360ba-da77-41c5-b348-d9712cb342d4)                         |
| **`MapScreen`**                      | ![image](https://github.com/user-attachments/assets/765fef8e-ab3a-412e-9fef-ffa11563444f)                         | ![image](https://github.com/user-attachments/assets/39899f2a-e7d9-4f2c-9737-42c242116c6d)                         | ![image](https://github.com/user-attachments/assets/418fcb71-6f8b-47db-a78f-ac098b4fbbfc)                         | ![image](https://github.com/user-attachments/assets/522eec96-74cf-43de-b3cc-7583782aec5a)                         |
| **`TimerScreen`**                    | ![image](https://github.com/user-attachments/assets/b74aabad-5785-4bdd-a0b1-a319627f454b)                         | ![image](https://github.com/user-attachments/assets/c2aab0e2-d2be-48b2-ba71-2aa4f507621e)                         | ![image](https://github.com/user-attachments/assets/fa24e2f1-ce20-4a30-bd06-c3a19ec28c21)                         | ![image](https://github.com/user-attachments/assets/325a3ed4-d5aa-42b8-a67c-363ef9644220)                         |
