### PR TITLE
Test/misc/end to end m2: EndToEnd for Sign-In and Edit Profile

### DIFF
--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -48,6 +48,7 @@ class EndToEndM2 : TestCase() {
   @Test
   fun signInAndEditProfile() {
     // Sign in using existing account
+    composeTestRule.waitForIdle()
     Log.d(TAG, "User arrives on SignIn Screen")
     composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertExists() // or is displayed?
     composeTestRule
@@ -63,6 +64,7 @@ class EndToEndM2 : TestCase() {
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).assertIsDisplayed().performClick()
 
     // Profile Screen is displayed
+    composeTestRule.waitForIdle()
     Log.d(TAG, "User arrives on Profile Screen")
     composeTestRule.waitUntil(20000) {
       composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
@@ -72,7 +74,10 @@ class EndToEndM2 : TestCase() {
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
 
     // Edit Profile Screen is displayed, edit name, dob and description
-    composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
+    composeTestRule.waitForIdle()
+    composeTestRule.waitUntil(20000) {
+      composeTestRule.onAllNodesWithTag(EditProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .assertIsDisplayed()
@@ -90,6 +95,7 @@ class EndToEndM2 : TestCase() {
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
 
     // Profile Screen, check if the changes are saved
+    composeTestRule.waitForIdle()
     composeTestRule.waitUntil(20000) {
       composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
     }

--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -1,0 +1,79 @@
+package com.android.periodpals.endtoend
+
+import android.util.Log
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.Espresso
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import com.android.periodpals.MainActivity
+import com.android.periodpals.resources.C
+import com.android.periodpals.resources.C.Tag.AuthenticationScreens
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
+import com.android.periodpals.resources.C.Tag.TopAppBar
+import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val TAG = "EndToEnd2"
+
+@RunWith(AndroidJUnit4::class)
+class EndToEndM2 : TestCase(){
+    @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule val activityRule = ActivityTestRule(MainActivity::class.java)
+
+    companion object {
+        private val randomNumber = (1..9).random()
+        private const val EMAIL = "end2end@test"
+        private const val PASSWORD = "Secure!password123"
+        private val name = "Mocknica$randomNumber"
+        private val dob = "0$randomNumber/01/2000"
+        private val description = "I'm a mathematician, my favourite number is $randomNumber!"
+    }
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent { MainActivity() }
+    }
+
+    @Test
+    fun signInEndToEnd(){
+        // Sign in using existing account
+        Log.d(TAG, "User arrives on SignIn Screen")
+        composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertExists() //or is displayed?
+        composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).assertIsDisplayed().performTextInput(EMAIL)
+        composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).assertIsDisplayed().performTextInput(PASSWORD)
+        Espresso.closeSoftKeyboard()
+        composeTestRule
+            .onNodeWithTag(SignInScreen.SIGN_IN_BUTTON)
+            .assertIsDisplayed()
+            .performClick()
+
+        // Edit Profile, change name, dob, description
+        Log.d(TAG, "User arrives on Edit Profile Screen")
+        composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
+        composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertExists()
+        composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed().performTextInput(name)
+        composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed().performTextInput(dob)
+        composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed().performTextInput(description)
+        Espresso.closeSoftKeyboard()
+        composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
+
+        // Profile Screen, check if the changes are saved
+        Log.d(TAG, "User arrives on Profile Screen")
+        composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
+        composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertExists().assertTextEquals(name)
+        composeTestRule.onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD).assertExists().assertTextEquals(description)
+    }
+}

--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -58,13 +59,20 @@ class EndToEndM2 : TestCase() {
         .assertIsDisplayed()
         .performTextInput(PASSWORD)
     Espresso.closeSoftKeyboard()
+    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).assertIsDisplayed().performClick()
 
-    // Edit Profile, change name, dob, description
+    // Profile Screen is displayed
+    Log.d(TAG, "User arrives on Profile Screen")
+    composeTestRule.waitUntil(20000) {
+      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
     Log.d(TAG, "User arrives on Edit Profile Screen")
-    composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
+    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
-    composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertExists()
+
+    // Edit Profile Screen is displayed, edit name, dob and description
+    composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .assertIsDisplayed()
@@ -78,11 +86,14 @@ class EndToEndM2 : TestCase() {
         .assertIsDisplayed()
         .performTextInput(description)
     Espresso.closeSoftKeyboard()
+    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
 
     // Profile Screen, check if the changes are saved
+    composeTestRule.waitUntil(20000) {
+      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
     Log.d(TAG, "User arrives on Profile Screen")
-    composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
     composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertExists().assertTextEquals(name)
     composeTestRule
         .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)

--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -4,76 +4,89 @@ import android.util.Log
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso
-import org.junit.runner.RunWith
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.android.periodpals.MainActivity
-import com.android.periodpals.resources.C
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
-import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
+import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
 import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
-import com.android.periodpals.resources.C.Tag.ProfileScreens.EditProfileScreen
-import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
 private const val TAG = "EndToEnd2"
 
 @RunWith(AndroidJUnit4::class)
-class EndToEndM2 : TestCase(){
-    @get:Rule val composeTestRule = createComposeRule()
-    @get:Rule val activityRule = ActivityTestRule(MainActivity::class.java)
+class EndToEndM2 : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val activityRule = ActivityTestRule(MainActivity::class.java)
 
-    companion object {
-        private val randomNumber = (1..9).random()
-        private const val EMAIL = "end2end@test"
-        private const val PASSWORD = "Secure!password123"
-        private val name = "Mocknica$randomNumber"
-        private val dob = "0$randomNumber/01/2000"
-        private val description = "I'm a mathematician, my favourite number is $randomNumber!"
-    }
+  companion object {
+    private val randomNumber = (1..9).random()
+    private const val EMAIL = "end2end@test"
+    private const val PASSWORD = "Secure!password123"
+    private val name = "Mocknica$randomNumber"
+    private val dob = "0$randomNumber/01/2000"
+    private val description = "I'm a mathematician, my favourite number is $randomNumber!"
+  }
 
-    @Before
-    fun setUp() {
-        composeTestRule.setContent { MainActivity() }
-    }
+  @Before
+  fun setUp() {
+    composeTestRule.setContent { MainActivity() }
+  }
 
-    @Test
-    fun signInEndToEnd(){
-        // Sign in using existing account
-        Log.d(TAG, "User arrives on SignIn Screen")
-        composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertExists() //or is displayed?
-        composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).assertIsDisplayed().performTextInput(EMAIL)
-        composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).assertIsDisplayed().performTextInput(PASSWORD)
-        Espresso.closeSoftKeyboard()
-        composeTestRule
-            .onNodeWithTag(SignInScreen.SIGN_IN_BUTTON)
-            .assertIsDisplayed()
-            .performClick()
+  @Test
+  fun signInEndToEnd() {
+    // Sign in using existing account
+    Log.d(TAG, "User arrives on SignIn Screen")
+    composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertExists() // or is displayed?
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.EMAIL_FIELD)
+        .assertIsDisplayed()
+        .performTextInput(EMAIL)
+    composeTestRule
+        .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
+        .assertIsDisplayed()
+        .performTextInput(PASSWORD)
+    Espresso.closeSoftKeyboard()
+    composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).assertIsDisplayed().performClick()
 
-        // Edit Profile, change name, dob, description
-        Log.d(TAG, "User arrives on Edit Profile Screen")
-        composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
-        composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertExists()
-        composeTestRule.onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD).assertIsDisplayed().performTextInput(name)
-        composeTestRule.onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD).assertIsDisplayed().performTextInput(dob)
-        composeTestRule.onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD).assertIsDisplayed().performTextInput(description)
-        Espresso.closeSoftKeyboard()
-        composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
+    // Edit Profile, change name, dob, description
+    Log.d(TAG, "User arrives on Edit Profile Screen")
+    composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
+    composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag(EditProfileScreen.SCREEN).assertExists()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .assertIsDisplayed()
+        .performTextInput(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .assertIsDisplayed()
+        .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .assertIsDisplayed()
+        .performTextInput(description)
+    Espresso.closeSoftKeyboard()
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
 
-        // Profile Screen, check if the changes are saved
-        Log.d(TAG, "User arrives on Profile Screen")
-        composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
-        composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertExists().assertTextEquals(name)
-        composeTestRule.onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD).assertExists().assertTextEquals(description)
-    }
+    // Profile Screen, check if the changes are saved
+    Log.d(TAG, "User arrives on Profile Screen")
+    composeTestRule.onNodeWithTag(ProfileScreen.SCREEN).assertExists()
+    composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertExists().assertTextEquals(name)
+    composeTestRule
+        .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)
+        .assertExists()
+        .assertTextEquals(description)
+  }
 }

--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -46,7 +46,7 @@ class EndToEndM2 : TestCase() {
   }
 
   @Test
-  fun signInEndToEnd() {
+  fun signInAndEditProfile() {
     // Sign in using existing account
     Log.d(TAG, "User arrives on SignIn Screen")
     composeTestRule.onNodeWithTag(SignInScreen.SCREEN).assertExists() // or is displayed?

--- a/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
+++ b/app/src/androidTest/java/com/android/periodpals/endtoend/EndToEndM2.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
 import com.android.periodpals.MainActivity
@@ -25,6 +24,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 private const val TAG = "EndToEnd2"
+private const val TIMEOUT = 10000L // 10 seconds, adjust for slower devices, networks and CI
 
 @RunWith(AndroidJUnit4::class)
 class EndToEndM2 : TestCase() {
@@ -59,25 +59,22 @@ class EndToEndM2 : TestCase() {
         .onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD)
         .assertIsDisplayed()
         .performTextInput(PASSWORD)
-    Espresso.closeSoftKeyboard()
-    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(SignInScreen.SIGN_IN_BUTTON).assertIsDisplayed().performClick()
+    composeTestRule.waitUntil(TIMEOUT) {
+      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
 
     // Profile Screen is displayed
     composeTestRule.waitForIdle()
     Log.d(TAG, "User arrives on Profile Screen")
-    composeTestRule.waitUntil(20000) {
-      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
-    }
-    Log.d(TAG, "User arrives on Edit Profile Screen")
-    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(TopAppBar.EDIT_BUTTON).assertIsDisplayed().performClick()
+    composeTestRule.waitUntil(TIMEOUT) {
+      composeTestRule.onAllNodesWithTag(EditProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
 
     // Edit Profile Screen is displayed, edit name, dob and description
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(20000) {
-      composeTestRule.onAllNodesWithTag(EditProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
-    }
+    Log.d(TAG, "User arrives on Edit Profile Screen")
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
         .assertIsDisplayed()
@@ -90,15 +87,13 @@ class EndToEndM2 : TestCase() {
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .assertIsDisplayed()
         .performTextInput(description)
-    Espresso.closeSoftKeyboard()
-    composeTestRule.waitUntil(6000) { true }
     composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).assertIsDisplayed().performClick()
+    composeTestRule.waitUntil(TIMEOUT) {
+      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
+    }
 
     // Profile Screen, check if the changes are saved
     composeTestRule.waitForIdle()
-    composeTestRule.waitUntil(20000) {
-      composeTestRule.onAllNodesWithTag(ProfileScreen.SCREEN).fetchSemanticsNodes().size == 1
-    }
     Log.d(TAG, "User arrives on Profile Screen")
     composeTestRule.onNodeWithTag(ProfileScreen.NAME_FIELD).assertExists().assertTextEquals(name)
     composeTestRule


### PR DESCRIPTION
#  EndToEnd for Sign-In and Edit Profile

## Description
This PR introduces an end-to-end test for user flow 2: **signing in to an existing account**; and user flow 3: **editing the profile** (name, date of birth and description). 

The test logs in to an existing account `end2end@test` (created before-hand), clicks `EditButton` in `ProfileScreen`, modifies all the fields i.e `name`, `dob` and `description` (each time using a randomised number), then saves changes and finally verifies that these changes are correctly displayed in `ProfileScreen`. 

## Changes

## Files 

#### Added
- `androidTest/.../endtoend/EndToEndM2`

## Testing
All features of the "Edit profile" flow are tested, _except_ the selection of the profile picture is not yet a fully developed feature, therefore it is not tested that modifications to such are correctly saved (TBD!). 

## Screenshots
<img width="693" alt="Screenshot 2024-11-14 at 22 25 30" src="https://github.com/user-attachments/assets/22e80501-4557-46cb-8b87-c0e84d0ba57e">

