### PR TITLE
feat/misc/notifications/permissions request : Implement push notifications permission requests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   alias(libs.plugins.compose.compiler)
 
   id("com.android.application")
+  id("com.google.gms.google-services")
   id("kotlin-android")
   id("jacoco")
   id("org.sonarqube") version "5.1.0.4882"
@@ -141,6 +142,10 @@ dependencies {
   // implementation(libs.androidx.constraintlayout)
   // implementation(libs.androidx.fragment.ktx)
   // implementation(libs.kotlinx.serialization.json)
+
+  // Firebase
+  implementation(platform(libs.firebase.bom))
+  implementation(libs.firebase.messaging.ktx)
 
   implementation(libs.androidx.activity.ktx)
   implementation(libs.androidx.fragment.ktx.v184)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,5 +34,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="com.android.periodpals.services.PushNotificationsServiceImpl"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 </manifest>

--- a/app/src/main/java/com/android/periodpals/services/PushNotificationsService.kt
+++ b/app/src/main/java/com/android/periodpals/services/PushNotificationsService.kt
@@ -1,0 +1,11 @@
+package com.android.periodpals.services
+
+/**
+ * Interface for the push notifications service. Provides a method to ask for notification
+ * permissions.
+ */
+interface PushNotificationsService {
+
+  /** Asks the user for permission to send push notifications. */
+  fun askPermission()
+}

--- a/app/src/main/java/com/android/periodpals/services/PushNotificationsServiceImpl.kt
+++ b/app/src/main/java/com/android/periodpals/services/PushNotificationsServiceImpl.kt
@@ -1,0 +1,73 @@
+package com.android.periodpals.services
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import kotlinx.coroutines.flow.MutableStateFlow
+
+private const val TAG = "PushNotificationsServiceImpl"
+
+/**
+ * Implementation of the PushNotificationsService interface. This class handles the push
+ * notification permissions and integrates with Firebase Messaging Service.
+ *
+ * @property activity The activity context used for requesting permissions.
+ */
+class PushNotificationsServiceImpl(private val activity: ComponentActivity) :
+    FirebaseMessagingService(), PushNotificationsService {
+
+  private var _pushPermissionsGranted = MutableStateFlow(false)
+  val pushPermissionsGranted = _pushPermissionsGranted
+
+  constructor() : this(ComponentActivity())
+
+  override fun onNewToken(token: String) {
+    // TODO: send the new token to the server
+    Log.d(TAG, "Refreshed token: $token")
+  }
+
+  private val requestPermissionLauncher =
+      activity.registerForActivityResult(
+          ActivityResultContracts.RequestPermission(),
+      ) { isGranted: Boolean ->
+        if (isGranted) {
+          Log.d(TAG, "Notification permission granted")
+          Toast.makeText(activity, "Notification permission granted", Toast.LENGTH_SHORT).show()
+          _pushPermissionsGranted.value = true
+        } else {
+          Log.d(TAG, "Notification permission denied")
+          Toast.makeText(activity, "Notification permission denied", Toast.LENGTH_SHORT).show()
+          _pushPermissionsGranted.value = false
+        }
+      }
+
+  /** Asks the user for permission to send push notifications. */
+  override fun askPermission() {
+    // no need to ask for permission on API level < 33 (TIRAMISU)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      _pushPermissionsGranted.value = true
+      return
+    }
+
+    _pushPermissionsGranted.value =
+        ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+    if (_pushPermissionsGranted.value) {
+      Log.d(TAG, "Notification permission already granted")
+      return
+    }
+
+    // TODO: if the user had previously denied the permission, show a dialog explaining why the
+    //       permission is needed using shouldShowRequestPermissionRationale(activity,
+    //       Manifest.permission.POST_NOTIFICATIONS)
+
+    Log.d(TAG, "Requesting notification permission")
+    requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+  }
+}

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -34,6 +35,7 @@ import com.android.periodpals.R
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens.ProfileScreen
 import com.android.periodpals.resources.ComponentColor.getTertiaryCardColors
+import com.android.periodpals.services.PushNotificationsService
 import com.android.periodpals.ui.components.ProfilePicture
 import com.android.periodpals.ui.components.ProfileSection
 import com.android.periodpals.ui.navigation.BottomNavigationMenu
@@ -67,7 +69,11 @@ private const val NO_REVIEWS_TEXT = "No reviews yet..."
  * @sample ProfileScreen
  */
 @Composable
-fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
+fun ProfileScreen(
+    userViewModel: UserViewModel,
+    notificationService: PushNotificationsService,
+    navigationActions: NavigationActions
+) {
   val context = LocalContext.current
   val numberInteractions =
       0 // TODO: placeholder to be replaced when we integrate it to the User data class
@@ -82,6 +88,9 @@ fun ProfileScreen(userViewModel: UserViewModel, navigationActions: NavigationAct
         }
       })
   val userState = userViewModel.user
+
+  // Only executed once
+  LaunchedEffect(Unit) { notificationService.askPermission() }
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(ProfileScreen.SCREEN),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.ktfmt) apply false
   kotlin("plugin.serialization") version "2.0.0-RC1" apply false
   alias(libs.plugins.compose.compiler) apply false
+  id("com.google.gms.google-services") version "4.4.2" apply false
 }
 
 buildscript { dependencies { classpath(libs.secrets.gradle.plugin) } }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ agp = "8.6.1"
 androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
+firebaseBom = "33.6.0"
 fragmentKtxVersion = "1.8.4"
 dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
@@ -81,6 +82,7 @@ composeViewModel = "2.7.0"
 sonar = "4.4.1.3373"
 navigationCommonKtx = "2.8.2"
 navigationRuntimeKtx = "2.8.2"
+firebaseMessagingKtx = "24.1.0"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
@@ -109,6 +111,7 @@ androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
 dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }
@@ -158,6 +161,7 @@ realtime-kt = { module = "io.github.jan-tennert.supabase:realtime-kt" }
 supabase-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version.ref = "navigationCommonKtx" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
+firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx", version.ref = "firebaseMessagingKtx" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# Implement push notifications permission requests
**This PR is still a WIP**
## Description
This PR introduces the handling of the permissions for the push notifications. It uses [FCM](https://firebase.google.com/docs/cloud-messaging) as the push notification service provider. It closes issue #233.

The new `PushNotificationsServiceImpl` launches a permission request dialog on first landing on the Profile screen. It handles the cases where the permission has already been granted by the user to avoid pestering them. If the user denies the permission, it will ask again next time. This behavior could be changed in the future.
It also handles the difference between android API below and above TIRAMISU (before TIRAMISU, the permissions did not exist, so is granted by default).

## Changes


## Files 

#### Added
- file 1
- file 2
- ...
#### Modified

#### Removed

## Dependencies Added
- dependency 1 for XXX
- ...

## Testing

## Screenshots (if applicable)
