### PR TITLE
Fix Alert View Model

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -178,8 +178,18 @@ class AlertViewModel(
   }
 
   /**
-   * Sets the filter for the filter alert list.
-   *
+   * Sets the filter for the `filterAlerts` list. Some filter examples could be:
+   * ```
+   * alertViewModel.setFilter(filter = { it.urgency == Urgency.HIGH } )
+   * // or
+   * alertViewModel.setFilter(filter = { it.product == Product.TAMPON )
+   * ```
+   * You could also make more complex filters like:
+   * ```
+   * alertViewModel.setFilter(
+   *    filter = { it.urgency == Urgency.HIGH && it.product == Product.TAMPON}
+   * )
+   * ```
    * @param filter Filter to be set on the alert list
    */
   fun setFilter(filter: (Alert) -> Boolean) {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -14,14 +14,21 @@ private const val TAG = "AlertViewModel"
  * ViewModel for managing alert data.
  *
  * @property alertModelSupabase The repository used for loading and saving alerts.
+ * @property userId the id linked to the current user
  * @property _alerts Mutable state holding the list of alerts.
  * @property alerts Public state exposing the list of alerts.
+ * @property _myAlerts Mutable state holding the list of current users alerts.
+ * @property myAlerts Public state exposing the list of current users alerts.4
+ * @property _palAlerts Mutable state holding the list of other users alerts.
+ * @property palAlerts Public state exposing the list of other users alerts.
+ * @property alertFilter Mutable state holding a filter for `filterAlerts`
+ * @property _filterAlerts Mutable state holding the list of alerts filtered by `alertFilter`
+ * @property filterAlerts Public state exposing the list of alerts filtered y `alertFilter`
  */
 class AlertViewModel(
     private val alertModelSupabase: AlertModelSupabase,
     private val userId: String
 ) : ViewModel() {
-  // remove this?
   private var _alerts = mutableStateOf<List<Alert>>(listOf())
   val alerts: State<List<Alert>> = _alerts
 
@@ -117,7 +124,6 @@ class AlertViewModel(
   ) {
     viewModelScope.launch {
       alertModelSupabase.getAlertsFilteredBy(
-          // ideally the uid would not be passed as argument and instead we could get uid by
           cond = { eq("uid", uid) },
           onSuccess = { alerts ->
             Log.d(TAG, "getAlertsByUser: Success")
@@ -134,6 +140,7 @@ class AlertViewModel(
    * Updates an existing alert.
    *
    * @param alert The alert with updated parameters.
+   * @param onSuccess Callback function to be called on success.
    * @param onFailure Callback function to be called on failure.
    */
   fun updateAlert(alert: Alert, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -158,12 +158,14 @@ class AlertViewModel(
    * // or
    * alertViewModel.setFilter(filter = { it.product == Product.TAMPON )
    * ```
+   *
    * You could also make more complex filters like:
    * ```
    * alertViewModel.setFilter(
    *    filter = { it.urgency == Urgency.HIGH && it.product == Product.TAMPON}
    * )
    * ```
+   *
    * @param filter Filter to be set on the alert list
    */
   fun setFilter(filter: (Alert) -> Boolean) {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -2,6 +2,7 @@ package com.android.periodpals.model.alert
 
 import android.util.Log
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -16,25 +17,44 @@ private const val TAG = "AlertViewModel"
  * @property _alerts Mutable state holding the list of alerts.
  * @property alerts Public state exposing the list of alerts.
  */
-class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewModel() {
+class AlertViewModel(
+    private val alertModelSupabase: AlertModelSupabase,
+    private val userId: String
+) : ViewModel() {
   // remove this?
-  private var _alerts = mutableStateOf<List<Alert>?>(listOf())
-  val alerts: State<List<Alert>?> = _alerts
+  private var _alerts = mutableStateOf<List<Alert>>(listOf())
+  val alerts: State<List<Alert>> = _alerts
+
+  private var _myAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId } }
+  val myAlerts: State<List<Alert>> = _myAlerts
+
+  private var _palAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId } }
+  val palAlerts: State<List<Alert>> = _palAlerts
+
+  private var alertFilter = mutableStateOf<(Alert) -> Boolean>({false})
+  private var _filterAlerts = derivedStateOf { _alerts.value.filter { alertFilter.value(it) } }
+  private var filterAlerts: State<List<Alert>> = _filterAlerts
 
   /**
    * Creates a new alert.
    *
    * @param alert The alert to be created.
+   * @param onSuccess Callback function to be called on success
+   * @param onFailure Callback function to be called on failure
    */
-  fun createAlert(alert: Alert) {
+  fun createAlert(alert: Alert, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {
       alertModelSupabase.addAlert(
           alert = alert,
           onSuccess = {
             Log.d(TAG, "createAlert: Success")
-            getAllAlerts() // refresh the alerts list
+            fetchAlerts(onSuccess, onFailure) // refresh the alerts list
           },
-          onFailure = { e -> Log.e(TAG, "createAlert: fail to create alert: ${e.message}") })
+          onFailure = { e ->
+              Log.e(TAG, "createAlert: fail to create alert: ${e.message}")
+              onFailure(e)
+          }
+      )
     }
   }
 
@@ -42,101 +62,128 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
    * Retrieves an alert by its ID.
    *
    * @param idAlert The ID of the alert to be retrieved.
+   * @param onSuccess Callback function called upon successful run of function
+   * @param onFailure Callback function called upon a failed run of function
    * @return The alert if found, null otherwise.
    */
-  fun getAlert(idAlert: String): Alert? {
-    var alert: Alert? = null
+  fun getAlert(idAlert: String, onSuccess: (Alert) -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {
       alertModelSupabase.getAlert(
           idAlert = idAlert,
-          onSuccess = { fetched ->
+          onSuccess = {
             Log.d(TAG, "getAlert: Success")
-            alert = fetched
+            onSuccess(it)
           },
-          onFailure = { e -> Log.e(TAG, "getAlert: fail to get alert: ${e.message}") })
+          onFailure = { e ->
+            Log.e(TAG, "getAlert: fail to get alert: ${e.message}")
+            onFailure(e)
+          })
     }
-    return alert
   }
 
   /**
    * Retrieves all alerts.
-   *
+   * @param onSuccess Callback function to be called on success, use the states to get results
+   * @param onFailure Callback function to be called on failure
    * @return The list of all alerts.
    */
-  fun getAllAlerts(): List<Alert>? {
-    var alertsList: List<Alert>? = null
+  fun fetchAlerts(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     viewModelScope.launch {
       alertModelSupabase.getAllAlerts(
           onSuccess = { alerts ->
             Log.d(TAG, "getAllAlerts: Success")
             _alerts.value = alerts
-            alertsList = alerts
+            onSuccess()
           },
-          onFailure = { e -> Log.e(TAG, "getAllAlerts: fail to get alerts: ${e.message}") })
+          onFailure = { e ->
+            Log.e(TAG, "getAllAlerts: fail to get alerts: ${e.message}")
+            onFailure(e)
+          })
     }
-    return alertsList
-  }
-
-  fun getPalAlerts(uid: String): List<Alert>? {
-    val palAlertList: List<Alert>? = getAllAlerts()
-    return palAlertList?.filter { it.uid != uid }
   }
 
   /**
    * Retrieves alerts for a specific user by their UID.
    *
-   * @param uid The UID of the user.
+   * @param uid The UID of a user.
+   * @param onSuccess Callback function called upon successful run of function
+   * @param onFailure Callback function called upon a failed run of function
    * @return The list of alerts for the user.
    */
-  fun getAlertsByUser(uid: String): List<Alert>? {
-    var alertsList: List<Alert>? = null
+  fun getAlertsByUser(
+      uid: String,
+      onSuccess: (List<Alert>) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
     viewModelScope.launch {
       alertModelSupabase.getAlertsFilteredBy(
           // ideally the uid would not be passed as argument and instead we could get uid by
-          // UserViewModel.currentUser?.uid
           cond = { eq("uid", uid) },
           onSuccess = { alerts ->
-            Log.d(TAG, "getMyAlerts: Success")
-            alertsList = alerts
+            Log.d(TAG, "getAlertsByUser: Success")
+            onSuccess(alerts)
           },
-          onFailure = { e -> Log.e(TAG, "getMyAlerts: fail to get alerts: ${e.message}") })
+          onFailure = {
+            e -> Log.e(TAG, "getAlertsByUser: fail to get alerts: ${e.message}")
+            onFailure(e)
+          }
+      )
     }
-    return alertsList
   }
 
   /**
    * Updates an existing alert.
    *
    * @param alert The alert with updated parameters.
+   * @param onFailure Callback function to be called on failure.
    */
-  fun updateAlert(alert: Alert) {
+  fun updateAlert(alert: Alert, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {
       alertModelSupabase.updateAlert(
           alert = alert,
           onSuccess = {
             Log.d(TAG, "updateAlert: Success")
-            getAllAlerts()
+            fetchAlerts(onSuccess, onFailure)
           },
-          onFailure = { e -> Log.e(TAG, "updateAlert: fail to update alert: ${e.message}") })
+          onFailure = { e ->
+            Log.e(TAG, "updateAlert: fail to update alert: ${e.message}")
+            onFailure(e)
+          }
+      )
     }
   }
 
   /**
    * Deletes an alert.
    *
-   * @param alert The alert to be deleted.
+   * @param idAlert The ID of the alert to be retrieved.
+   * @param onSuccess Callback function to be called on success
+   * @param onFailure Callback function to be called on failure
    */
-  fun deleteAlert(alert: Alert) {
+  fun deleteAlert(idAlert: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {
-      alert.id?.let {
         alertModelSupabase.deleteAlertById(
-            idAlert = it,
+            idAlert = idAlert,
             onSuccess = {
               Log.d(TAG, "deleteAlert: Success")
-              getAllAlerts()
+              fetchAlerts(onSuccess, onFailure)
             },
-            onFailure = { e -> Log.e(TAG, "deleteAlert: fail to delete alert: ${e.message}") })
-      } ?: run { Log.e(TAG, "deleteAlert: fail to delete alert: id of the Alert is null") }
+            onFailure = { e ->
+              Log.e(TAG, "deleteAlert: fail to delete alert: ${e.message}")
+              onFailure(e)
+            }
+        )
     }
+  }
+
+  /**
+   * Sets the filter for the filter alert list.
+   *
+   * @param filter Filter to be set on the alert list
+   */
+  fun setFilter(filter: (Alert) -> Boolean){
+      viewModelScope.launch {
+          alertFilter.value = filter
+      }
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -108,32 +108,6 @@ class AlertViewModel(
   }
 
   /**
-   * Retrieves alerts for a specific user by their UID.
-   *
-   * @param uid The UID of a user.
-   * @param onSuccess Callback function called upon successful run of function
-   * @param onFailure Callback function called upon a failed run of function
-   */
-  fun getAlertsByUser(
-      uid: String,
-      onSuccess: (List<Alert>) -> Unit,
-      onFailure: (Exception) -> Unit
-  ) {
-    viewModelScope.launch {
-      alertModelSupabase.getAlertsFilteredBy(
-          cond = { eq("uid", uid) },
-          onSuccess = { alerts ->
-            Log.d(TAG, "getAlertsByUser: Success")
-            onSuccess(alerts)
-          },
-          onFailure = { e ->
-            Log.e(TAG, "getAlertsByUser: fail to get alerts: ${e.message}")
-            onFailure(e)
-          })
-    }
-  }
-
-  /**
    * Updates an existing alert.
    *
    * @param alert The alert with updated parameters.

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -113,7 +113,6 @@ class AlertViewModel(
    * @param uid The UID of a user.
    * @param onSuccess Callback function called upon successful run of function
    * @param onFailure Callback function called upon a failed run of function
-   * @return The list of alerts for the user.
    */
   fun getAlertsByUser(
       uid: String,

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -92,7 +92,6 @@ class AlertViewModel(
    *
    * @param onSuccess Callback function to be called on success, use the states to get results
    * @param onFailure Callback function to be called on failure
-   * @return The list of all alerts.
    */
   fun fetchAlerts(onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
     viewModelScope.launch {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -70,7 +70,6 @@ class AlertViewModel(
    * @param idAlert The ID of the alert to be retrieved.
    * @param onSuccess Callback function called upon successful run of function
    * @param onFailure Callback function called upon a failed run of function
-   * @return The alert if found, null otherwise.
    */
   fun getAlert(idAlert: String, onSuccess: (Alert) -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -31,7 +31,7 @@ class AlertViewModel(
   private var _palAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId } }
   val palAlerts: State<List<Alert>> = _palAlerts
 
-  private var alertFilter = mutableStateOf<(Alert) -> Boolean>({false})
+  private var alertFilter = mutableStateOf<(Alert) -> Boolean>({ false })
   private var _filterAlerts = derivedStateOf { _alerts.value.filter { alertFilter.value(it) } }
   private var filterAlerts: State<List<Alert>> = _filterAlerts
 
@@ -51,10 +51,9 @@ class AlertViewModel(
             fetchAlerts(onSuccess, onFailure) // refresh the alerts list
           },
           onFailure = { e ->
-              Log.e(TAG, "createAlert: fail to create alert: ${e.message}")
-              onFailure(e)
-          }
-      )
+            Log.e(TAG, "createAlert: fail to create alert: ${e.message}")
+            onFailure(e)
+          })
     }
   }
 
@@ -83,6 +82,7 @@ class AlertViewModel(
 
   /**
    * Retrieves all alerts.
+   *
    * @param onSuccess Callback function to be called on success, use the states to get results
    * @param onFailure Callback function to be called on failure
    * @return The list of all alerts.
@@ -123,11 +123,10 @@ class AlertViewModel(
             Log.d(TAG, "getAlertsByUser: Success")
             onSuccess(alerts)
           },
-          onFailure = {
-            e -> Log.e(TAG, "getAlertsByUser: fail to get alerts: ${e.message}")
+          onFailure = { e ->
+            Log.e(TAG, "getAlertsByUser: fail to get alerts: ${e.message}")
             onFailure(e)
-          }
-      )
+          })
     }
   }
 
@@ -148,8 +147,7 @@ class AlertViewModel(
           onFailure = { e ->
             Log.e(TAG, "updateAlert: fail to update alert: ${e.message}")
             onFailure(e)
-          }
-      )
+          })
     }
   }
 
@@ -162,17 +160,16 @@ class AlertViewModel(
    */
   fun deleteAlert(idAlert: String, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
     viewModelScope.launch {
-        alertModelSupabase.deleteAlertById(
-            idAlert = idAlert,
-            onSuccess = {
-              Log.d(TAG, "deleteAlert: Success")
-              fetchAlerts(onSuccess, onFailure)
-            },
-            onFailure = { e ->
-              Log.e(TAG, "deleteAlert: fail to delete alert: ${e.message}")
-              onFailure(e)
-            }
-        )
+      alertModelSupabase.deleteAlertById(
+          idAlert = idAlert,
+          onSuccess = {
+            Log.d(TAG, "deleteAlert: Success")
+            fetchAlerts(onSuccess, onFailure)
+          },
+          onFailure = { e ->
+            Log.e(TAG, "deleteAlert: fail to delete alert: ${e.message}")
+            onFailure(e)
+          })
     }
   }
 
@@ -181,9 +178,7 @@ class AlertViewModel(
    *
    * @param filter Filter to be set on the alert list
    */
-  fun setFilter(filter: (Alert) -> Boolean){
-      viewModelScope.launch {
-          alertFilter.value = filter
-      }
+  fun setFilter(filter: (Alert) -> Boolean) {
+    viewModelScope.launch { alertFilter.value = filter }
   }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -313,5 +313,22 @@ class AlertViewModelTest {
     viewModel.fetchAlerts()
     verify(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isNotEmpty())
+    assertEquals(alerts, viewModel.alerts.value)
+  }
+
+  @Test
+  fun fetchAlertsFailure() = runBlocking {
+      doAnswer { it.getArgument<(Exception) -> Unit>(1)(Exception("Supabase Fail :(")) }
+          .`when`(alertModelSupabase)
+          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+
+      assert(viewModel.alerts.value.isEmpty())
+
+      viewModel.fetchAlerts{ fail("Should not call `onSuccess`") }
+
+      verify(alertModelSupabase)
+          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+      assert(viewModel.alerts.value.isEmpty())
   }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -319,16 +319,16 @@ class AlertViewModelTest {
 
   @Test
   fun fetchAlertsFailure() = runBlocking {
-      doAnswer { it.getArgument<(Exception) -> Unit>(1)(Exception("Supabase Fail :(")) }
-          .`when`(alertModelSupabase)
-          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    doAnswer { it.getArgument<(Exception) -> Unit>(1)(Exception("Supabase Fail :(")) }
+        .`when`(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-      assert(viewModel.alerts.value.isEmpty())
+    assert(viewModel.alerts.value.isEmpty())
 
-      viewModel.fetchAlerts{ fail("Should not call `onSuccess`") }
+    viewModel.fetchAlerts { fail("Should not call `onSuccess`") }
 
-      verify(alertModelSupabase)
-          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
-      assert(viewModel.alerts.value.isEmpty())
+    verify(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isEmpty())
   }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -248,56 +248,6 @@ class AlertViewModelTest {
   }
 
   @Test
-  fun getAlertsByUserSuccess() = runBlocking {
-    val n = Random.nextInt(EXAMPLES)
-    val userID = uid[n]
-    val alert = alerts[n]
-
-    doAnswer { it.getArgument<(List<Alert>) -> Unit>(1)(listOf(alert)) }
-        .`when`(alertModelSupabase)
-        .getAlertsFilteredBy(
-            any<PostgrestFilterBuilder.() -> Unit>(),
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>())
-
-    var result: List<Alert> = listOf()
-    viewModel.getAlertsByUser(userID, { result = it }, { fail("Should not call `onFailure`") })
-
-    verify(alertModelSupabase)
-        .getAlertsFilteredBy(
-            any<PostgrestFilterBuilder.() -> Unit>(),
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>())
-
-    assertNotNull(result)
-    assertEquals(listOf(alert), result)
-  }
-
-  @Test
-  fun getAlertByUserFailure() = runBlocking {
-    val n = Random.nextInt(EXAMPLES)
-    val userID = uid[n]
-
-    doAnswer { it.getArgument<(Exception) -> Unit>(2)(Exception("Supabase Fails :(")) }
-        .`when`(alertModelSupabase)
-        .getAlertsFilteredBy(
-            any<PostgrestFilterBuilder.() -> Unit>(),
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>())
-
-    var result = false
-    viewModel.getAlertsByUser(userID, { fail("Should not call `onSuccess`") }, { result = true })
-
-    verify(alertModelSupabase)
-        .getAlertsFilteredBy(
-            any<PostgrestFilterBuilder.() -> Unit>(),
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>())
-
-    assert(result)
-  }
-
-  @Test
   fun updateAlertSuccess() = runBlocking {
     val n = Random.nextInt(EXAMPLES)
     val alert = alerts[n]

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.android.periodpals.model.alert
 
 import com.android.periodpals.MainCoroutineRule
-import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
 import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -305,15 +304,14 @@ class AlertViewModelTest {
 
   @Test
   fun fetchAlertsSuccess() = runBlocking {
-      doAnswer{
-          it.getArgument<(List<Alert>) -> Unit>(0)(alerts)
-      }.`when`(alertModelSupabase)
-          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(alerts) }
+        .`when`(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-      assert(viewModel.alerts.value.isEmpty())
-      
-      viewModel.fetchAlerts()
-      verify(alertModelSupabase)
-          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isEmpty())
+
+    viewModel.fetchAlerts()
+    verify(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
   }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -294,7 +294,7 @@ class AlertViewModelTest {
 
     verify(alertModelSupabase)
         .getAlertsFilteredBy(
-            {eq("uid", userID)},
+            any<PostgrestFilterBuilder.() -> Unit>(),
             any<(List<Alert>) -> Unit>(),
             any<(Exception) -> Unit>()
         )
@@ -320,7 +320,7 @@ class AlertViewModelTest {
 
     verify(alertModelSupabase)
         .getAlertsFilteredBy(
-            {eq("uid", userID)},
+            any<PostgrestFilterBuilder.() -> Unit>(),
             any<(List<Alert>) -> Unit>(),
             any<(Exception) -> Unit>()
         )

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -2,19 +2,26 @@ package com.android.periodpals.model.alert
 
 import com.android.periodpals.MainCoroutineRule
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
+import io.github.jan.supabase.supabaseJson
+import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDateTime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.never
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+
+const val EXAMPLES = 2
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AlertViewModelTest {
@@ -24,76 +31,57 @@ class AlertViewModelTest {
   @ExperimentalCoroutinesApi @get:Rule var mainCoroutineRule = MainCoroutineRule()
 
   companion object {
-    const val ID = "idAlert"
-    const val ID2 = "idAlert2"
-    const val UID = "mock_uid"
-    const val UID2 = "mock_uid2"
-    val name = "test_name"
-    val name_update = "test_update_name"
-    val product = Product.PAD
-    val product_update = Product.TAMPON
-    val urgency = Urgency.LOW
-    val urgency_update = Urgency.MEDIUM
-    val createdAt = LocalDateTime(2022, 1, 1, 0, 0).toString()
-    val createdAt_update = LocalDateTime(2023, 2, 2, 1, 1).toString()
-    val location = "test_location"
-    val location_update = "test_update_location"
-    val message = "test_message"
-    val message_update = "test_update_message"
-    val status = Status.CREATED
-    val status_update = Status.PENDING
+    val tagList: (String) -> List<String> = {
+      (0 until EXAMPLES).toList().map { n -> it + "_" + n.toString() }
+    }
 
-    val alert =
-        Alert(
-            id = ID,
-            uid = UID,
-            name = name,
-            product = product,
-            urgency = urgency,
-            createdAt = createdAt,
-            location = location,
-            message = message,
-            status = status)
-    val alertNullID =
-        Alert(
-            id = null,
-            uid = UID,
-            name = name,
-            product = product,
-            urgency = urgency,
-            createdAt = createdAt,
-            location = location,
-            message = message,
-            status = status)
-    val alertUpdated =
-        Alert(
-            id = ID,
-            uid = UID,
-            name = name_update,
-            product = product_update,
-            urgency = urgency_update,
-            createdAt = createdAt_update,
-            location = location_update,
-            message = message_update,
-            status = status_update)
-    val alertOther =
-        Alert(
-            id = ID2,
-            uid = UID2,
-            name = name,
-            product = product,
-            urgency = urgency,
-            createdAt = createdAt,
-            location = location,
-            message = message,
-            status = status)
+    val id = tagList("id")
+    val uid = tagList("uid")
+    val name = tagList("name")
+    val product = List(EXAMPLES) { Product.entries[Random.nextInt(Product.entries.size)] }
+    val urgency = List(EXAMPLES) { Urgency.entries[Random.nextInt(Urgency.entries.size)] }
+    val createdAt =
+        (0 until EXAMPLES).toList().map { LocalDateTime(2022 + it, 1 + it, 1 + it, it, it).toString() }
+    val location = tagList("location")
+    val message = tagList("message")
+    val status = List(EXAMPLES) { Status.entries[Random.nextInt(Status.entries.size)] }
   }
+
+  private fun alertBuild(index: Int): Alert =
+      Alert(
+          id = id[index],
+          uid = uid[index],
+          name = name[index],
+          product = product[index],
+          urgency = urgency[index],
+          createdAt = createdAt[index],
+          location = location[index],
+          message = message[index],
+          status = status[index])
+
+  private fun updateAlert(index: Int, offset: Int): Alert {
+      val n = (index + offset) % EXAMPLES
+      return Alert(
+          id = id[index],
+          uid = uid[n],
+          name = name[n],
+          product = product[n],
+          urgency = urgency[n],
+          createdAt = createdAt[n],
+          location = location[n],
+          message = message[n],
+          status = status[n]
+      )
+  }
+
+
+  val alerts = (0 until EXAMPLES).toList().map { alertBuild(it) }
 
   @Before
   fun setup() {
     MockitoAnnotations.openMocks(this)
     // Create ViewModel with mocked AlertModelSupabase
-    viewModel = AlertViewModel(alertModelSupabase)
+    viewModel = AlertViewModel(alertModelSupabase, id[0])
   }
 
   @Test
@@ -104,17 +92,17 @@ class AlertViewModelTest {
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     // Mock getAllAlerts to verify it is called after successful addition
-    doAnswer { invocation ->
-          val onSuccess = invocation.getArgument<(List<Alert>) -> Unit>(0)
-          onSuccess(listOf(alert)) // Return a list with our mock alert
-          null
-        }
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alerts[0])) }
         .`when`(alertModelSupabase)
-        .getAllAlerts(any(), any())
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
+    viewModel.createAlert(alerts[0], {}, { fail("Should not call `onFailure`") })
 
-    assertEquals(listOf(alert), viewModel.alerts.value)
+    verify(alertModelSupabase)
+        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    verify(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    assertEquals(listOf(alerts[0]), viewModel.alerts.value)
   }
 
   @Test
@@ -124,8 +112,10 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
-    assert(viewModel.alerts.value!!.isEmpty())
+    viewModel.createAlert(alerts[0], { fail("Should not call `onFailure`") }, {})
+
+    verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isEmpty())
   }
 
   @Test
@@ -134,13 +124,17 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    doAnswer { it.getArgument<(Exception) -> Unit>(1)(Exception(" ")) }
+    doAnswer { it.getArgument<(Exception) -> Unit>(1)(Exception("Supabase faild :(")) }
         .`when`(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
+    viewModel.createAlert(alerts[0], { fail("Should not call `onSuccess`") }, {})
 
-    assert(viewModel.alerts.value!!.isEmpty())
+    verify(alertModelSupabase)
+        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    verify(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isEmpty())
   }
 
   @Test
@@ -152,7 +146,7 @@ class AlertViewModelTest {
     var calls = 0
     doAnswer {
           if (calls == 0) {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert))
+            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alerts[0]))
           } else {
             it.getArgument<(List<Alert>) -> Unit>(0)(listOf())
           }
@@ -161,33 +155,40 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-    doAnswer { it.getArgument<() -> Unit>(1)() }
+    doAnswer {
+        assertEquals(id[0], it.getArgument<String>(0))
+        it.getArgument<() -> Unit>(1)()
+    }
         .`when`(alertModelSupabase)
         .deleteAlertById(any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
-    assert(viewModel.alerts.value!!.isNotEmpty())
-    assertEquals(listOf(alert), viewModel.alerts.value)
+    viewModel.createAlert(alerts[0], {}, { fail("Should not `onFailure`") })
 
-    viewModel.deleteAlert(alert)
-    assert(viewModel.alerts.value!!.isEmpty())
-  }
+    verify(alertModelSupabase)
+        .addAlert(
+            any<Alert>(),
+            any<() -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+    verify(alertModelSupabase)
+        .getAllAlerts(
+            any<(List<Alert>) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
 
-  @Test
-  fun deleteAlertNullIdFailure() = runBlocking {
-    doAnswer { it.getArgument<() -> Unit>(1)() }
-        .`when`(alertModelSupabase)
-        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    assert(viewModel.alerts.value.isNotEmpty())
+    assertEquals(listOf(alerts[0]), viewModel.alerts.value)
 
-    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert)) }
-        .`when`(alertModelSupabase)
-        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    viewModel.deleteAlert(id[0], {}, { fail("Should not `onFailure`") })
 
-    viewModel.createAlert(alert)
-    viewModel.deleteAlert(alertNullID)
+    verify(alertModelSupabase)
+        .deleteAlertById(
+            any<String>(),
+            any<() -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
 
-    assert(!viewModel.alerts.value!!.isEmpty())
-    assertEquals(listOf(alert), viewModel.alerts.value)
+    assert(viewModel.alerts.value.isEmpty())
   }
 
   @Test
@@ -196,7 +197,7 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert)) }
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alerts[0])) }
         .`when`(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
@@ -204,43 +205,83 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .deleteAlertById(any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
-    assert(viewModel.alerts.value!!.isNotEmpty())
-    assertEquals(listOf(alert), viewModel.alerts.value)
+    viewModel.createAlert(alerts[0], {}, { fail("Should not call `onFailure`") })
 
-    viewModel.deleteAlert(alert)
-    assert(viewModel.alerts.value!!.isNotEmpty())
-    assertEquals(listOf(alert), viewModel.alerts.value)
+    verify(alertModelSupabase)
+        .addAlert(
+            any<Alert>(),
+            any<() -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+    verify(alertModelSupabase)
+        .getAllAlerts(
+            any<(List<Alert>) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+
+    assert(viewModel.alerts.value.isNotEmpty())
+    assertEquals(alerts.slice(0 until 1), viewModel.alerts.value)
+
+    viewModel.deleteAlert(id[0], { fail("Should not call `onSuccess`") }, {})
+    assert(viewModel.alerts.value.isNotEmpty())
+    assertEquals(alerts.slice(0 until 1), viewModel.alerts.value)
   }
 
   @Test
   fun getAlertSuccess() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val alertID = id[n]
+    val alert = alerts[n]
+
     doAnswer {
-          assertEquals(ID, it.getArgument<String>(0))
+          assertEquals(alertID, it.getArgument<String>(0))
           it.getArgument<(Alert) -> Unit>(1)(alert)
         }
         .`when`(alertModelSupabase)
         .getAlert(any<String>(), any<(Alert) -> Unit>(), any<(Exception) -> Unit>())
 
-    val result = viewModel.getAlert(ID)
+    var result: Alert? = null
+    viewModel.getAlert(alertID, { result = it }, { fail("Should not call `onFailure`") })
+
+    assertNotNull(result)
     assertEquals(alert, result)
   }
 
   @Test
   fun getAlertGetAlertFailure() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val alertID = id[n]
+    val alert = alerts[n]
     doAnswer {
-          assertEquals(ID, it.getArgument<String>(0))
+          assertEquals(alertID, it.getArgument<String>(0))
           it.getArgument<(Exception) -> Unit>(2)(Exception("Supabase Fails :("))
-        }
-        .`when`(alertModelSupabase)
+    }.`when`(alertModelSupabase)
         .getAlert(any<String>(), any<(Alert) -> Unit>(), any<(Exception) -> Unit>())
 
-    val result = viewModel.getAlert(ID)
-    assertNull(result)
+    var result = false
+    viewModel.getAlert(alertID, { fail("Supabase Fails :(") }, { result = true })
+
+    verify(alertModelSupabase)
+        .getAlert(
+            any<String>(),
+            any<(Alert) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+    verify(alertModelSupabase, never())
+        .getAllAlerts(
+            any<(List<Alert>) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+
+    assert(result)
   }
 
   @Test
   fun getAlertsByUserSuccess() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val userID = uid[n]
+    val alert = alerts[n]
+
     doAnswer { it.getArgument<(List<Alert>) -> Unit>(1)(listOf(alert)) }
         .`when`(alertModelSupabase)
         .getAlertsFilteredBy(
@@ -248,12 +289,25 @@ class AlertViewModelTest {
             any<(List<Alert>) -> Unit>(),
             any<(Exception) -> Unit>())
 
-    val result = viewModel.getAlertsByUser(UID)
+    var result: List<Alert> = listOf()
+    viewModel.getAlertsByUser(userID, { result = it }, { fail("Should not call `onFailure`") })
+
+    verify(alertModelSupabase)
+        .getAlertsFilteredBy(
+            {eq("uid", userID)},
+            any<(List<Alert>) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+
+    assertNotNull(result)
     assertEquals(listOf(alert), result)
   }
 
   @Test
   fun getAlertByUserFailure() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val userID = uid[n]
+
     doAnswer { it.getArgument<(Exception) -> Unit>(2)(Exception("Supabase Fails :(")) }
         .`when`(alertModelSupabase)
         .getAlertsFilteredBy(
@@ -261,12 +315,25 @@ class AlertViewModelTest {
             any<(List<Alert>) -> Unit>(),
             any<(Exception) -> Unit>())
 
-    val result = viewModel.getAlertsByUser(UID)
-    assertNull(result)
+    var result = false
+    viewModel.getAlertsByUser(userID, { fail("Should not call `onSuccess`") }, { result = true })
+
+    verify(alertModelSupabase)
+        .getAlertsFilteredBy(
+            {eq("uid", userID)},
+            any<(List<Alert>) -> Unit>(),
+            any<(Exception) -> Unit>()
+        )
+
+    assert(result)
   }
 
   @Test
   fun updateAlertSuccess() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val alert = alerts[n]
+    val alertUpdate = updateAlert(n, 1)
+
     doAnswer { it.getArgument<() -> Unit>(1)() }
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
@@ -278,22 +345,26 @@ class AlertViewModelTest {
           if (count < 1) {
             it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert))
           } else {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alertUpdated))
+            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alertUpdate))
           }
           count++
         }
         .`when`(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
+    viewModel.createAlert(alert, {}, { fail("Should not call `onFailure`") })
     assertEquals(listOf(alert), viewModel.alerts.value)
 
-    viewModel.updateAlert(alertUpdated)
-    assertEquals(listOf(alertUpdated), viewModel.alerts.value)
+    viewModel.updateAlert(alertUpdate, {}, { fail("Should not call `onFailure`") })
+    assertEquals(listOf(alertUpdate), viewModel.alerts.value)
   }
 
   @Test
   fun updateAlertFailure() = runBlocking {
+    val n = Random.nextInt(EXAMPLES)
+    val alert = alerts[n]
+    val alertUpdate = updateAlert(n, 1)
+
     doAnswer { it.getArgument<() -> Unit>(1)() }
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
@@ -306,67 +377,10 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .updateAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alert)
+    viewModel.createAlert(alert, {}, { fail("Should not call `onFailure`") })
     assertEquals(listOf(alert), viewModel.alerts.value)
 
-    viewModel.updateAlert(alertUpdated)
+    viewModel.updateAlert(alertUpdate, { fail("Should not cal `onSuccess`") }, {})
     assertEquals(listOf(alert), viewModel.alerts.value)
-  }
-
-  @Test
-  fun getPalAlertsSuccess() = runBlocking {
-    doAnswer { it.getArgument<() -> Unit>(1)() }
-        .`when`(alertModelSupabase)
-        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
-    var count = 0
-    doAnswer {
-          if (count == 0) {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert))
-          } else {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert, alertOther))
-          }
-          count++
-        }
-        .`when`(alertModelSupabase)
-        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
-    assertEquals(listOf<Alert>(), viewModel.alerts.value)
-    viewModel.createAlert(alert)
-    assertEquals(listOf(alert), viewModel.alerts.value)
-    viewModel.createAlert(alertOther)
-    assertEquals(listOf(alert, alertOther), viewModel.alerts.value)
-
-    val result: List<Alert>? = viewModel.getPalAlerts(alert.uid)
-
-    assertNotNull(result)
-    assert(result!!.isNotEmpty())
-    assertEquals(listOf(alertOther), result)
-  }
-
-  @Test
-  fun getPalAlertsFailure() = runBlocking {
-    doAnswer { it.getArgument<() -> Unit>(1)() }
-        .`when`(alertModelSupabase)
-        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
-    var count = 0
-    doAnswer {
-          if (count == 0) {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert))
-          } else if (count == 1) {
-            it.getArgument<(List<Alert>) -> Unit>(0)(listOf(alert, alertOther))
-          } else {
-            it.getArgument<(Exception) -> Unit>(1)(Exception("Supabase fail :("))
-          }
-          count++
-        }
-        .`when`(alertModelSupabase)
-        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
-    assertEquals(listOf<Alert>(), viewModel.alerts.value)
-    viewModel.createAlert(alert)
-    assertEquals(listOf(alert), viewModel.alerts.value)
-    viewModel.createAlert(alertOther)
-    assertEquals(listOf(alert, alertOther), viewModel.alerts.value)
-
-    val result: List<Alert>? = viewModel.getPalAlerts(alert.uid)
-    assertNull(result)
   }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -302,4 +302,18 @@ class AlertViewModelTest {
     viewModel.updateAlert(alertUpdate, { fail("Should not cal `onSuccess`") }, {})
     assertEquals(listOf(alert), viewModel.alerts.value)
   }
+
+  @Test
+  fun fetchAlertsSuccess() = runBlocking {
+      doAnswer{
+          it.getArgument<(List<Alert>) -> Unit>(0)(alerts)
+      }.`when`(alertModelSupabase)
+          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+
+      assert(viewModel.alerts.value.isEmpty())
+      
+      viewModel.fetchAlerts()
+      verify(alertModelSupabase)
+          .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+  }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.never
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 const val EXAMPLES = 2
@@ -170,7 +171,7 @@ class AlertViewModelTest {
     viewModel.deleteAlert(id[0], {}, { fail("Should not `onFailure`") })
 
     verify(alertModelSupabase)
-        .deleteAlertById(any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        .deleteAlertById(eq(id[0]), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     assert(viewModel.alerts.value.isEmpty())
   }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -2,14 +2,12 @@ package com.android.periodpals.model.alert
 
 import com.android.periodpals.MainCoroutineRule
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
-import io.github.jan.supabase.supabaseJson
 import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDateTime
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -41,7 +39,9 @@ class AlertViewModelTest {
     val product = List(EXAMPLES) { Product.entries[Random.nextInt(Product.entries.size)] }
     val urgency = List(EXAMPLES) { Urgency.entries[Random.nextInt(Urgency.entries.size)] }
     val createdAt =
-        (0 until EXAMPLES).toList().map { LocalDateTime(2022 + it, 1 + it, 1 + it, it, it).toString() }
+        (0 until EXAMPLES).toList().map {
+          LocalDateTime(2022 + it, 1 + it, 1 + it, it, it).toString()
+        }
     val location = tagList("location")
     val message = tagList("message")
     val status = List(EXAMPLES) { Status.entries[Random.nextInt(Status.entries.size)] }
@@ -60,20 +60,18 @@ class AlertViewModelTest {
           status = status[index])
 
   private fun updateAlert(index: Int, offset: Int): Alert {
-      val n = (index + offset) % EXAMPLES
-      return Alert(
-          id = id[index],
-          uid = uid[n],
-          name = name[n],
-          product = product[n],
-          urgency = urgency[n],
-          createdAt = createdAt[n],
-          location = location[n],
-          message = message[n],
-          status = status[n]
-      )
+    val n = (index + offset) % EXAMPLES
+    return Alert(
+        id = id[index],
+        uid = uid[n],
+        name = name[n],
+        product = product[n],
+        urgency = urgency[n],
+        createdAt = createdAt[n],
+        location = location[n],
+        message = message[n],
+        status = status[n])
   }
-
 
   val alerts = (0 until EXAMPLES).toList().map { alertBuild(it) }
 
@@ -98,8 +96,7 @@ class AlertViewModelTest {
 
     viewModel.createAlert(alerts[0], {}, { fail("Should not call `onFailure`") })
 
-    verify(alertModelSupabase)
-        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
     verify(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
     assertEquals(listOf(alerts[0]), viewModel.alerts.value)
@@ -130,8 +127,7 @@ class AlertViewModelTest {
 
     viewModel.createAlert(alerts[0], { fail("Should not call `onSuccess`") }, {})
 
-    verify(alertModelSupabase)
-        .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+    verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
     verify(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
     assert(viewModel.alerts.value.isEmpty())
@@ -156,25 +152,17 @@ class AlertViewModelTest {
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
     doAnswer {
-        assertEquals(id[0], it.getArgument<String>(0))
-        it.getArgument<() -> Unit>(1)()
-    }
+          assertEquals(id[0], it.getArgument<String>(0))
+          it.getArgument<() -> Unit>(1)()
+        }
         .`when`(alertModelSupabase)
         .deleteAlertById(any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     viewModel.createAlert(alerts[0], {}, { fail("Should not `onFailure`") })
 
+    verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
     verify(alertModelSupabase)
-        .addAlert(
-            any<Alert>(),
-            any<() -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
-    verify(alertModelSupabase)
-        .getAllAlerts(
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
     assert(viewModel.alerts.value.isNotEmpty())
     assertEquals(listOf(alerts[0]), viewModel.alerts.value)
@@ -182,11 +170,7 @@ class AlertViewModelTest {
     viewModel.deleteAlert(id[0], {}, { fail("Should not `onFailure`") })
 
     verify(alertModelSupabase)
-        .deleteAlertById(
-            any<String>(),
-            any<() -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+        .deleteAlertById(any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     assert(viewModel.alerts.value.isEmpty())
   }
@@ -207,17 +191,9 @@ class AlertViewModelTest {
 
     viewModel.createAlert(alerts[0], {}, { fail("Should not call `onFailure`") })
 
+    verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
     verify(alertModelSupabase)
-        .addAlert(
-            any<Alert>(),
-            any<() -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
-    verify(alertModelSupabase)
-        .getAllAlerts(
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
     assert(viewModel.alerts.value.isNotEmpty())
     assertEquals(alerts.slice(0 until 1), viewModel.alerts.value)
@@ -255,23 +231,17 @@ class AlertViewModelTest {
     doAnswer {
           assertEquals(alertID, it.getArgument<String>(0))
           it.getArgument<(Exception) -> Unit>(2)(Exception("Supabase Fails :("))
-    }.`when`(alertModelSupabase)
+        }
+        .`when`(alertModelSupabase)
         .getAlert(any<String>(), any<(Alert) -> Unit>(), any<(Exception) -> Unit>())
 
     var result = false
     viewModel.getAlert(alertID, { fail("Supabase Fails :(") }, { result = true })
 
     verify(alertModelSupabase)
-        .getAlert(
-            any<String>(),
-            any<(Alert) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+        .getAlert(any<String>(), any<(Alert) -> Unit>(), any<(Exception) -> Unit>())
     verify(alertModelSupabase, never())
-        .getAllAlerts(
-            any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
     assert(result)
   }
@@ -296,8 +266,7 @@ class AlertViewModelTest {
         .getAlertsFilteredBy(
             any<PostgrestFilterBuilder.() -> Unit>(),
             any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+            any<(Exception) -> Unit>())
 
     assertNotNull(result)
     assertEquals(listOf(alert), result)
@@ -322,8 +291,7 @@ class AlertViewModelTest {
         .getAlertsFilteredBy(
             any<PostgrestFilterBuilder.() -> Unit>(),
             any<(List<Alert>) -> Unit>(),
-            any<(Exception) -> Unit>()
-        )
+            any<(Exception) -> Unit>())
 
     assert(result)
   }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -110,7 +110,7 @@ class AlertViewModelTest {
         .`when`(alertModelSupabase)
         .addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
-    viewModel.createAlert(alerts[0], { fail("Should not call `onFailure`") }, {})
+    viewModel.createAlert(alerts[0], { fail("Should not call `onSuccess`") }, {})
 
     verify(alertModelSupabase).addAlert(any<Alert>(), any<() -> Unit>(), any<(Exception) -> Unit>())
     assert(viewModel.alerts.value.isEmpty())


### PR DESCRIPTION
# Fix Alert View Model

## Description
This PR fixes some issues the `AlertViewModel`, notably the lack of consistency with previous code that uses callbacks, functions that return values, unoptimized use of `palsLists`. To update the `alerts` state, call `loadAlerts`, make sure to regualarly call it to have updated values. All functions that update the alerts list call `loadAlerts`. It closes issue #231 

## Changes
Removed `getAllAlerts` and replaced it with `fetchAlerts` its purpose is to update the `alerts` property, it is called on all the functions that modify the list. This function is left public to allow UI to refresh or even implement a refresh button feature.
## Files 
#### Modified
- `app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt`
- `app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt`

## Testing
Tested that model functions are called, implemented more check within tests to insure code is working correctly. Removed test for deleted funtions and added functionality to mocked functions.
