### PR TITLE
Feat/settings/integrate sign out delete vm

### DIFF
--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -135,7 +135,9 @@ fun PeriodPalsApp(
     navigation(startDestination = Screen.PROFILE, route = Route.PROFILE) {
       composable(Screen.PROFILE) { ProfileScreen(userViewModel, navigationActions) }
       composable(Screen.EDIT_PROFILE) { EditProfileScreen(userViewModel, navigationActions) }
-      composable(Screen.SETTINGS) { SettingsScreen(userViewModel, navigationActions) }
+      composable(Screen.SETTINGS) {
+        SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+      }
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.SettingsScreen
 import com.android.periodpals.resources.ComponentColor.getMenuItemColors
@@ -109,7 +110,11 @@ private val THEME_DROPDOWN_CHOICES =
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(userViewModel: UserViewModel, navigationActions: NavigationActions) {
+fun SettingsScreen(
+    userViewModel: UserViewModel,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions
+) {
 
   // notifications states
   var receiveNotifications by remember { mutableStateOf(true) }
@@ -127,7 +132,7 @@ fun SettingsScreen(userViewModel: UserViewModel, navigationActions: NavigationAc
 
   // delete account dialog logic
   if (showDialog) {
-    DeleteAccountDialog(navigationActions, onDismiss = { showDialog = false })
+    DeleteAccountDialog(userViewModel, navigationActions, onDismiss = { showDialog = false })
   }
 
   Scaffold(
@@ -258,7 +263,10 @@ fun SettingsScreen(userViewModel: UserViewModel, navigationActions: NavigationAc
         )
         SettingsIconRow(
             text = ACCOUNT_SIGN_OUT,
-            onClick = { navigationActions.navigateTo(Screen.SIGN_IN) },
+            onClick = {
+              authenticationViewModel.logOut()
+              navigationActions.navigateTo(Screen.SIGN_IN)
+            },
             icon = Icons.AutoMirrored.Outlined.Logout,
             textTestTag = SettingsScreen.SIGN_OUT_TEXT,
             iconTestTag = SettingsScreen.SIGN_OUT_ICON,
@@ -400,7 +408,11 @@ private fun SettingsIconRow(
  * @param onDismiss The callback to dismiss the dialog.
  */
 @Composable
-private fun DeleteAccountDialog(navigationActions: NavigationActions, onDismiss: () -> Unit) {
+private fun DeleteAccountDialog(
+    userViewModel: UserViewModel,
+    navigationActions: NavigationActions,
+    onDismiss: () -> Unit
+) {
   Dialog(
       onDismissRequest = onDismiss,
       properties = DialogProperties(usePlatformDefaultWidth = false)) {
@@ -439,7 +451,10 @@ private fun DeleteAccountDialog(navigationActions: NavigationActions, onDismiss:
             )
             Row {
               Button(
-                  onClick = { navigationActions.navigateTo(Screen.SIGN_IN) },
+                  onClick = {
+                    // userViewModel.deleteUser()
+                    navigationActions.navigateTo(Screen.SIGN_IN)
+                  },
                   colors =
                       ButtonDefaults.buttonColors(
                           containerColor = MaterialTheme.colorScheme.error,

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -514,20 +514,26 @@ private fun DeleteAccountDialog(
                                   Handler(Looper.getMainLooper())
                                       .post { // used to show the Toast on the main thread
                                         Toast.makeText(
-                                            context,
-                                            TOAST_SETTINGS_SUCCESS_DELETE,
-                                            Toast.LENGTH_SHORT)
+                                                context,
+                                                TOAST_SETTINGS_SUCCESS_DELETE,
+                                                Toast.LENGTH_SHORT)
+                                            .show()
+
+                                        Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
+                                        Handler(Looper.getMainLooper())
+                                            .post { // used to show the Toast on the main thread
+                                              navigationActions.navigateTo(Screen.SIGN_IN)
+                                            }
                                       }
-                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
-                                  navigationActions.navigateTo(Screen.SIGN_IN)
                                 },
                                 onFailure = {
                                   Handler(Looper.getMainLooper())
                                       .post { // used to show the Toast on the main thread
                                         Toast.makeText(
-                                            context,
-                                            TOAST_SETTINGS_FAILURE_DELETE,
-                                            Toast.LENGTH_SHORT)
+                                                context,
+                                                TOAST_SETTINGS_FAILURE_DELETE,
+                                                Toast.LENGTH_SHORT)
+                                            .show()
                                       }
                                   Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
                                 })
@@ -535,29 +541,12 @@ private fun DeleteAccountDialog(
                         },
                         onFailure = {
                           Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
-                          Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
+                          Handler(Looper.getMainLooper())
+                              .post { // used to show the Toast on the main thread
+                                Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
+                                    .show()
+                              }
                         })
-                    authenticationViewModel.authUserData.value?.let {
-                      userViewModel.deleteUser(
-                          it.uid,
-                          onSuccess = {
-                            Handler(Looper.getMainLooper())
-                                .post { // used to show the Toast on the main thread
-                                  Toast.makeText(
-                                      context, TOAST_SETTINGS_SUCCESS_DELETE, Toast.LENGTH_SHORT)
-                                }
-                            Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
-                            navigationActions.navigateTo(Screen.SIGN_IN)
-                          },
-                          onFailure = {
-                            Handler(Looper.getMainLooper())
-                                .post { // used to show the Toast on the main thread
-                                  Toast.makeText(
-                                      context, TOAST_SETTINGS_FAILURE_DELETE, Toast.LENGTH_SHORT)
-                                }
-                            Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
-                          })
-                    }
                   },
                   colors =
                       ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -112,6 +112,10 @@ private const val LOG_SETTINGS_FAILURE_SIGN_OUT = "Failed to sign out"
 private const val LOG_SETTINGS_SUCCESS_DELETE = "Account deleted successfully"
 private const val LOG_SETTINGS_FAILURE_DELETE = "Failed to delete account"
 
+private const val LOG_SETTINGS_SUCCESS_LOAD_DATA =
+    "user data loaded successfully, deleting the user"
+private const val LOG_SETTINGS_FAILURE_LOAD_DATA = "failed to load user data, can't delete the user"
+
 // Toast messages
 
 private const val TOAST_SETTINGS_SUCCESS_SIGN_OUT = "Sign out successful"
@@ -509,36 +513,33 @@ private fun DeleteAccountDialog(
                   onClick = {
                     authenticationViewModel.loadAuthenticationUserData(
                         onSuccess = {
-                          Log.d(
-                              LOG_SETTINGS_TAG, "user data loaded successfully, deleting the user")
-                          authenticationViewModel.authUserData.value?.let {
-                            userViewModel.deleteUser(
-                                it.uid,
-                                onSuccess = {
-                                  Handler(Looper.getMainLooper())
-                                      .post { // used to show the Toast on the main thread
-                                        Toast.makeText(
-                                                context,
-                                                TOAST_SETTINGS_SUCCESS_DELETE,
-                                                Toast.LENGTH_SHORT)
-                                            .show()
-                                      }
-                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
-                                  navigationActions.navigateTo(Screen.SIGN_IN)
-                                  navigationActions.navigateTo(Route.AUTH)
-                                },
-                                onFailure = {
-                                  Handler(Looper.getMainLooper())
-                                      .post { // used to show the Toast on the main thread
-                                        Toast.makeText(
-                                                context,
-                                                TOAST_SETTINGS_FAILURE_DELETE,
-                                                Toast.LENGTH_SHORT)
-                                            .show()
-                                      }
-                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
-                                })
-                          }
+                          Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_LOAD_DATA)
+                          userViewModel.deleteUser(
+                              authenticationViewModel.authUserData.value!!.uid,
+                              onSuccess = {
+                                Handler(Looper.getMainLooper())
+                                    .post { // used to show the Toast on the main thread
+                                      Toast.makeText(
+                                              context,
+                                              TOAST_SETTINGS_SUCCESS_DELETE,
+                                              Toast.LENGTH_SHORT)
+                                          .show()
+                                    }
+                                Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
+                                navigationActions.navigateTo(Screen.SIGN_IN)
+                                navigationActions.navigateTo(Route.AUTH)
+                              },
+                              onFailure = {
+                                Handler(Looper.getMainLooper())
+                                    .post { // used to show the Toast on the main thread
+                                      Toast.makeText(
+                                              context,
+                                              TOAST_SETTINGS_FAILURE_DELETE,
+                                              Toast.LENGTH_SHORT)
+                                          .show()
+                                    }
+                                Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
+                              })
                         },
                         onFailure = {
                           Handler(Looper.getMainLooper())
@@ -546,7 +547,7 @@ private fun DeleteAccountDialog(
                                 Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
                                     .show()
                               }
-                          Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
+                          Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_LOAD_DATA)
                         })
                   },
                   colors =

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -65,6 +65,7 @@ import com.android.periodpals.resources.ComponentColor.getMenuTextFieldColors
 import com.android.periodpals.resources.ComponentColor.getSwitchColors
 import com.android.periodpals.resources.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
@@ -307,6 +308,7 @@ fun SettingsScreen(
                         }
                     Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_SIGN_OUT)
                     navigationActions.navigateTo(Screen.SIGN_IN)
+                    navigationActions.navigateTo(Route.AUTH)
                   },
                   onFailure = {
                     Handler(Looper.getMainLooper())
@@ -523,6 +525,7 @@ private fun DeleteAccountDialog(
                                       }
                                   Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
                                   navigationActions.navigateTo(Screen.SIGN_IN)
+                                  navigationActions.navigateTo(Route.AUTH)
                                 },
                                 onFailure = {
                                   Handler(Looper.getMainLooper())

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -65,7 +65,6 @@ import com.android.periodpals.resources.ComponentColor.getMenuTextFieldColors
 import com.android.periodpals.resources.ComponentColor.getSwitchColors
 import com.android.periodpals.resources.ComponentColor.getTertiaryCardColors
 import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
@@ -312,7 +311,6 @@ fun SettingsScreen(
                         }
                     Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_SIGN_OUT)
                     navigationActions.navigateTo(Screen.SIGN_IN)
-                    navigationActions.navigateTo(Route.AUTH)
                   },
                   onFailure = {
                     Handler(Looper.getMainLooper())
@@ -527,7 +525,6 @@ private fun DeleteAccountDialog(
                                     }
                                 Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
                                 navigationActions.navigateTo(Screen.SIGN_IN)
-                                navigationActions.navigateTo(Route.AUTH)
                               },
                               onFailure = {
                                 Handler(Looper.getMainLooper())

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -302,7 +302,8 @@ fun SettingsScreen(
                     Handler(Looper.getMainLooper())
                         .post { // used to show the Toast on the main thread
                           Toast.makeText(
-                              context, TOAST_SETTINGS_SUCCESS_SIGN_OUT, Toast.LENGTH_SHORT)
+                                  context, TOAST_SETTINGS_SUCCESS_SIGN_OUT, Toast.LENGTH_SHORT)
+                              .show()
                         }
                     Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_SIGN_OUT)
                     navigationActions.navigateTo(Screen.SIGN_IN)
@@ -311,7 +312,8 @@ fun SettingsScreen(
                     Handler(Looper.getMainLooper())
                         .post { // used to show the Toast on the main thread
                           Toast.makeText(
-                              context, TOAST_SETTINGS_FAILURE_SIGN_OUT, Toast.LENGTH_SHORT)
+                                  context, TOAST_SETTINGS_FAILURE_SIGN_OUT, Toast.LENGTH_SHORT)
+                              .show()
                         }
                     Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_SIGN_OUT)
                   })
@@ -518,13 +520,9 @@ private fun DeleteAccountDialog(
                                                 TOAST_SETTINGS_SUCCESS_DELETE,
                                                 Toast.LENGTH_SHORT)
                                             .show()
-
-                                        Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
-                                        Handler(Looper.getMainLooper())
-                                            .post { // used to show the Toast on the main thread
-                                              navigationActions.navigateTo(Screen.SIGN_IN)
-                                            }
                                       }
+                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
+                                  navigationActions.navigateTo(Screen.SIGN_IN)
                                 },
                                 onFailure = {
                                   Handler(Looper.getMainLooper())
@@ -540,12 +538,12 @@ private fun DeleteAccountDialog(
                           }
                         },
                         onFailure = {
-                          Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
                           Handler(Looper.getMainLooper())
                               .post { // used to show the Toast on the main thread
                                 Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
                                     .show()
                               }
+                          Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
                         })
                   },
                   colors =

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -119,6 +119,8 @@ private const val TOAST_SETTINGS_FAILURE_SIGN_OUT = "Failed to sign out"
 private const val TOAST_SETTINGS_SUCCESS_DELETE = "Account deleted successfully"
 private const val TOAST_SETTINGS_FAILURE_DELETE = "Failed to delete account"
 
+private const val TOAST_LOAD_DATA_FAILURE = "Failed loading user authentication data"
+
 /**
  * A composable function that displays the Settings screen, where users can manage their
  * notifications, themes, and account settings.
@@ -501,7 +503,40 @@ private fun DeleteAccountDialog(
             Row {
               Button(
                   onClick = {
-                    authenticationViewModel.loadAuthenticationUserData()
+                    authenticationViewModel.loadAuthenticationUserData(
+                        onSuccess = {
+                          Log.d(
+                              LOG_SETTINGS_TAG, "user data loaded successfully, deleting the user")
+                          authenticationViewModel.authUserData.value?.let {
+                            userViewModel.deleteUser(
+                                it.uid,
+                                onSuccess = {
+                                  Handler(Looper.getMainLooper())
+                                      .post { // used to show the Toast on the main thread
+                                        Toast.makeText(
+                                            context,
+                                            TOAST_SETTINGS_SUCCESS_DELETE,
+                                            Toast.LENGTH_SHORT)
+                                      }
+                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
+                                  navigationActions.navigateTo(Screen.SIGN_IN)
+                                },
+                                onFailure = {
+                                  Handler(Looper.getMainLooper())
+                                      .post { // used to show the Toast on the main thread
+                                        Toast.makeText(
+                                            context,
+                                            TOAST_SETTINGS_FAILURE_DELETE,
+                                            Toast.LENGTH_SHORT)
+                                      }
+                                  Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
+                                })
+                          }
+                        },
+                        onFailure = {
+                          Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
+                          Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
+                        })
                     authenticationViewModel.authUserData.value?.let {
                       userViewModel.deleteUser(
                           it.uid,

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -279,7 +279,7 @@ class SettingsScreenTest {
         .performClick()
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
 
-    verify(userViewModel).deleteUser(any(), any(), any())
+    verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
     verify(navigationActions).navigateTo(Screen.SIGN_IN)
     // verify(navigationActions).navigateTo(Route.AUTH)

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -17,6 +17,7 @@ import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import com.android.periodpals.ui.navigation.TopLevelDestination
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -209,8 +210,8 @@ class SettingsScreenTest {
 
     verify(authenticationViewModel).logOut(any(), any())
 
-    verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
-    verify(navigationActions, never()).navigateTo(Route.AUTH)
+    verify(navigationActions, never()).navigateTo(any<String>())
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
   }
 
   @Test
@@ -254,8 +255,8 @@ class SettingsScreenTest {
 
     verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
-    verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
-    verify(navigationActions, never()).navigateTo(Route.AUTH)
+    verify(navigationActions, never()).navigateTo(any<String>())
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
   }
 
   @Test

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.AuthenticationUserData
-import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.SettingsScreen
@@ -37,12 +36,6 @@ class SettingsScreenTest {
   @get:Rule val composeTestRule = createComposeRule()
 
   companion object {
-    private val name = "John Doe"
-    private val imageUrl = "https://example.com"
-    private val description = "A short description"
-    private val dob = "01/01/2000"
-    private val userState =
-        mutableStateOf(User(name = name, imageUrl = imageUrl, description = description, dob = dob))
     private val userData = mutableStateOf(AuthenticationUserData("uid", "email@epfl.com"))
   }
 
@@ -236,6 +229,10 @@ class SettingsScreenTest {
   @Test
   fun deleteAccountVMFailure() {
     `when`(authenticationViewModel.authUserData).thenReturn(userData)
+    `when`(authenticationViewModel.loadAuthenticationUserData(any(), any())).thenAnswer {
+      val onSuccess = it.arguments[0] as () -> Unit
+      onSuccess()
+    }
     `when`(userViewModel.deleteUser(any(), any(), any())).thenAnswer {
       val onFailure = it.arguments[2] as (Exception) -> Unit
       onFailure(Exception("Error deleting user account"))
@@ -251,6 +248,8 @@ class SettingsScreenTest {
         .performClick()
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
 
+    composeTestRule.waitForIdle()
+
     org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
 
     org.mockito.kotlin.verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
@@ -259,6 +258,10 @@ class SettingsScreenTest {
   @Test
   fun deleteAccountVMSuccess() {
     `when`(authenticationViewModel.authUserData).thenReturn(userData)
+    `when`(authenticationViewModel.loadAuthenticationUserData(any(), any())).thenAnswer {
+      val onSuccess = it.arguments[0] as () -> Unit
+      onSuccess()
+    }
     `when`(userViewModel.deleteUser(any(), any(), any())).thenAnswer {
       val onSuccess = it.arguments[1] as () -> Unit
       onSuccess()
@@ -274,9 +277,10 @@ class SettingsScreenTest {
         .performClick()
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
 
+    composeTestRule.waitForIdle()
+
     org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
 
-    composeTestRule.waitForIdle()
     org.mockito.kotlin.verify(navigationActions).navigateTo(Screen.SIGN_IN)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -25,6 +25,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -205,9 +206,10 @@ class SettingsScreenTest {
     }
     composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
 
-    org.mockito.kotlin.verify(authenticationViewModel).logOut(any(), any())
+    verify(authenticationViewModel).logOut(any(), any())
 
-    org.mockito.kotlin.verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+    verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+    // verify(navigationActions, never()).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -221,9 +223,10 @@ class SettingsScreenTest {
     }
     composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
 
-    org.mockito.kotlin.verify(authenticationViewModel).logOut(any(), any())
+    verify(authenticationViewModel).logOut(any(), any())
 
-    org.mockito.kotlin.verify(navigationActions).navigateTo(Screen.SIGN_IN)
+    verify(navigationActions).navigateTo(Screen.SIGN_IN)
+    // verify(navigationActions).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -248,11 +251,10 @@ class SettingsScreenTest {
         .performClick()
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
 
-    composeTestRule.waitForIdle()
+    verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
-    org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
-
-    org.mockito.kotlin.verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+    verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+    // verify(navigationActions, never()).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -277,10 +279,9 @@ class SettingsScreenTest {
         .performClick()
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
 
-    composeTestRule.waitForIdle()
+    verify(userViewModel).deleteUser(any(), any(), any())
 
-    org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
-
-    org.mockito.kotlin.verify(navigationActions).navigateTo(Screen.SIGN_IN)
+    verify(navigationActions).navigateTo(Screen.SIGN_IN)
+    // verify(navigationActions).navigateTo(Route.AUTH)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -15,6 +15,7 @@ import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.SettingsScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
+import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import org.junit.Before
 import org.junit.Rule
@@ -209,7 +210,7 @@ class SettingsScreenTest {
     verify(authenticationViewModel).logOut(any(), any())
 
     verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
-    // verify(navigationActions, never()).navigateTo(Route.AUTH)
+    verify(navigationActions, never()).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -226,7 +227,7 @@ class SettingsScreenTest {
     verify(authenticationViewModel).logOut(any(), any())
 
     verify(navigationActions).navigateTo(Screen.SIGN_IN)
-    // verify(navigationActions).navigateTo(Route.AUTH)
+    verify(navigationActions).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -254,7 +255,7 @@ class SettingsScreenTest {
     verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
     verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
-    // verify(navigationActions, never()).navigateTo(Route.AUTH)
+    verify(navigationActions, never()).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -282,6 +283,6 @@ class SettingsScreenTest {
     verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
     verify(navigationActions).navigateTo(Screen.SIGN_IN)
-    // verify(navigationActions).navigateTo(Route.AUTH)
+    verify(navigationActions).navigateTo(Route.AUTH)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -15,7 +15,6 @@ import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.SettingsScreen
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
-import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopLevelDestination
 import org.junit.Before
@@ -228,7 +227,6 @@ class SettingsScreenTest {
     verify(authenticationViewModel).logOut(any(), any())
 
     verify(navigationActions).navigateTo(Screen.SIGN_IN)
-    verify(navigationActions).navigateTo(Route.AUTH)
   }
 
   @Test
@@ -284,6 +282,5 @@ class SettingsScreenTest {
     verify(userViewModel).deleteUser(eq(userData.value.uid), any(), any())
 
     verify(navigationActions).navigateTo(Screen.SIGN_IN)
-    verify(navigationActions).navigateTo(Route.AUTH)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.SettingsScreen
@@ -26,12 +27,14 @@ import org.robolectric.RobolectricTestRunner
 class SettingsScreenTest {
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var authenticationViewModel: AuthenticationViewModel
   private lateinit var userViewModel: UserViewModel
   @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    authenticationViewModel = mock(AuthenticationViewModel::class.java)
     userViewModel = mock(UserViewModel::class.java)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.SETTINGS)
@@ -39,7 +42,9 @@ class SettingsScreenTest {
 
   @Test
   fun allComponentsAreDisplayed() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag(SettingsScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.TOP_BAR).assertIsDisplayed()
@@ -125,7 +130,9 @@ class SettingsScreenTest {
 
   @Test
   fun allCardsComponentsAreDisplayed() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)
@@ -141,7 +148,9 @@ class SettingsScreenTest {
 
   @Test
   fun goBackButtonNavigatesToProfileScreen() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).performClick()
 
@@ -150,7 +159,9 @@ class SettingsScreenTest {
 
   @Test
   fun performClickOnDropDownMenu() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag(SettingsScreen.THEME_DROP_DOWN_MENU_BOX)
@@ -162,7 +173,9 @@ class SettingsScreenTest {
 
   @Test
   fun signOutButtonNavigatesToSignInScreen() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
 
@@ -171,7 +184,9 @@ class SettingsScreenTest {
 
   @Test
   fun deleteAccountButtonNavigatesToSignInScreen() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)
@@ -184,7 +199,9 @@ class SettingsScreenTest {
 
   @Test
   fun notDeleteAccountButtonDismissDialog() {
-    composeTestRule.setContent { SettingsScreen(userViewModel, navigationActions) }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
 
     composeTestRule
         .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -19,8 +19,10 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -210,5 +212,80 @@ class SettingsScreenTest {
     composeTestRule.onNodeWithTag(SettingsScreen.NOT_DELETE_BUTTON).performClick()
 
     composeTestRule.onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_CARD).assertIsNotDisplayed()
+  }
+
+  @Test
+  fun signOutVMFailure() {
+    `when`(authenticationViewModel.logOut(any(), any())).thenAnswer {
+      val onFailure = it.arguments[1] as (Exception) -> Unit
+      onFailure(Exception("Error signing out user"))
+    }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
+    composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
+
+    org.mockito.kotlin.verify(authenticationViewModel).logOut(any(), any())
+
+    org.mockito.kotlin.verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+  }
+
+  @Test
+  fun signOutVMSuccess() {
+    `when`(authenticationViewModel.logOut(any(), any())).thenAnswer {
+      val onSuccess = it.arguments[0] as () -> Unit
+      onSuccess()
+    }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
+    composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
+
+    org.mockito.kotlin.verify(authenticationViewModel).logOut(any(), any())
+
+    org.mockito.kotlin.verify(navigationActions).navigateTo(Screen.SIGN_IN)
+  }
+
+  @Test
+  fun deleteAccountVMFailure() {
+    // `when`(authenticationViewModel.authUserData).thenReturn(mutableStateOf(null))
+    `when`(userViewModel.deleteUser(any(), any(), any())).thenAnswer {
+      val onFailure = it.arguments[2] as (Exception) -> Unit
+      onFailure(Exception("Error deleting user account"))
+    }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
+
+    composeTestRule
+        .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)
+        .performScrollTo()
+        .performClick()
+    composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
+
+    org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
+
+    org.mockito.kotlin.verify(navigationActions, never()).navigateTo(Screen.SIGN_IN)
+  }
+
+  @Test
+  fun deleteAccountVMSuccess() {
+    `when`(userViewModel.saveUser(any(), any(), any())).thenAnswer {
+      val onSuccess = it.arguments[1] as () -> Unit
+      onSuccess()
+    }
+    composeTestRule.setContent {
+      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
+    }
+
+    composeTestRule
+        .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)
+        .performScrollTo()
+        .performClick()
+    composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
+
+    org.mockito.kotlin.verify(userViewModel).deleteUser(any(), any(), any())
+
+    org.mockito.kotlin.verify(navigationActions).navigateTo(Screen.SIGN_IN)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -174,32 +174,6 @@ class SettingsScreenTest {
   }
 
   @Test
-  fun signOutButtonNavigatesToSignInScreen() {
-    composeTestRule.setContent {
-      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
-    }
-
-    composeTestRule.onNodeWithTag(SettingsScreen.SIGN_OUT_ICON).performScrollTo().performClick()
-
-    verify(navigationActions).navigateTo(Screen.SIGN_IN)
-  }
-
-  @Test
-  fun deleteAccountButtonNavigatesToSignInScreen() {
-    composeTestRule.setContent {
-      SettingsScreen(userViewModel, authenticationViewModel, navigationActions)
-    }
-
-    composeTestRule
-        .onNodeWithTag(SettingsScreen.DELETE_ACCOUNT_ICON)
-        .performScrollTo()
-        .performClick()
-    composeTestRule.onNodeWithTag(SettingsScreen.DELETE_BUTTON).performClick()
-
-    verify(navigationActions).navigateTo(Screen.SIGN_IN)
-  }
-
-  @Test
   fun notDeleteAccountButtonDismissDialog() {
     composeTestRule.setContent {
       SettingsScreen(userViewModel, authenticationViewModel, navigationActions)


### PR DESCRIPTION
# Integrate Delete and Sign Out Functions in SettingsScreen  

## Description  
This PR integrates the `deleteUser` and `logOut` functions of  `UserViewModel` and `AuthenticationViewModel` into the `SettingsScreen` UI. It also adds comprehensive tests for both functionalities. These enhancements aim to improve the user experience by handling account deletion and sign-out flows directly in the settings interface.  

**Note:** The `deleteUser` function currently deletes only the user's data and not their ID from Supabase. As a result, the user can still log in after deletion. This is not the expected behavior and will be addressed in a separate PR.  


It closes issue #237

## Changes  

- Integrated `deleteUser` function into the `SettingsScreen` with proper navigation and error handling.  
- Integrated `logOut` function into the `SettingsScreen` with proper navigation and error handling.  
- Added logging and toast messages for both success and failure scenarios for better user feedback.  
- Adapted the tests to work as expected for the new `deleteUser` and `logOut` implementations.  

## Files  

#### Added  
- N/A  

#### Modified  
- `SettingsScreen.kt`: Added integration for `deleteUser` and `logOut` functions.  
- `SettingsScreenTest.kt`: Added tests for delete account and sign-out functionality, and adapt the existing tests.  

#### Removed  
- N/A  

## Dependencies Added  
- N/A  

## Testing  

- **Delete Account Tests**: Verified successful and failed deletion scenarios and navigation flow.  
- **Sign Out Tests**: Verified successful and failed sign-out scenarios and navigation flow.  
- **General UI Behavior**: Ensured UI interactions (button clicks) trigger the correct ViewModel calls.
