### PR TITLE
Refactor `userId` parameter in `AlertViewModel`

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -173,4 +173,13 @@ class AlertViewModel(
   fun setFilter(filter: (Alert) -> Boolean) {
     viewModelScope.launch { alertFilter.value = filter }
   }
+
+  /**
+   * Sets the `userID` state of View Model
+   *
+   * @param uid user id to be stored in a private state
+   */
+  fun setUserID(uid: String) {
+    viewModelScope.launch { userId.value = uid }
+  }
 }

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -26,16 +26,18 @@ private const val TAG = "AlertViewModel"
  * @property filterAlerts Public state exposing the list of alerts filtered y `alertFilter`
  */
 class AlertViewModel(
-    private val alertModelSupabase: AlertModelSupabase,
-    private val userId: String
+    private val alertModelSupabase: AlertModelSupabase
 ) : ViewModel() {
+
+  private var userId = mutableStateOf<String?>(null)
+
   private var _alerts = mutableStateOf<List<Alert>>(listOf())
   val alerts: State<List<Alert>> = _alerts
 
-  private var _myAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId } }
+  private var _myAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId.value } }
   val myAlerts: State<List<Alert>> = _myAlerts
 
-  private var _palAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId } }
+  private var _palAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId.value } }
   val palAlerts: State<List<Alert>> = _palAlerts
 
   private var alertFilter = mutableStateOf<(Alert) -> Boolean>({ false })

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -25,19 +25,19 @@ private const val TAG = "AlertViewModel"
  * @property _filterAlerts Mutable state holding the list of alerts filtered by `alertFilter`
  * @property filterAlerts Public state exposing the list of alerts filtered y `alertFilter`
  */
-class AlertViewModel(
-    private val alertModelSupabase: AlertModelSupabase
-) : ViewModel() {
+class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewModel() {
 
   private var userId = mutableStateOf<String?>(null)
 
   private var _alerts = mutableStateOf<List<Alert>>(listOf())
   val alerts: State<List<Alert>> = _alerts
 
-  private var _myAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId.value } }
+  private var _myAlerts =
+      derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId.value } }
   val myAlerts: State<List<Alert>> = _myAlerts
 
-  private var _palAlerts = derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId.value } }
+  private var _palAlerts =
+      derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId.value } }
   val palAlerts: State<List<Alert>> = _palAlerts
 
   private var alertFilter = mutableStateOf<(Alert) -> Boolean>({ false })

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -326,7 +326,7 @@ class AlertViewModelTest {
 
     assert(viewModel.alerts.value.isEmpty())
 
-    viewModel.fetchAlerts ( onSuccess = { fail("Should not call `onSuccess`") })
+    viewModel.fetchAlerts(onSuccess = { fail("Should not call `onSuccess`") })
 
     verify(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -79,7 +79,8 @@ class AlertViewModelTest {
   fun setup() {
     MockitoAnnotations.openMocks(this)
     // Create ViewModel with mocked AlertModelSupabase
-    viewModel = AlertViewModel(alertModelSupabase, id[0])
+    viewModel = AlertViewModel(alertModelSupabase)
+    viewModel.setUserID(id[0])
   }
 
   @Test
@@ -325,7 +326,7 @@ class AlertViewModelTest {
 
     assert(viewModel.alerts.value.isEmpty())
 
-    viewModel.fetchAlerts { fail("Should not call `onSuccess`") }
+    viewModel.fetchAlerts ( onSuccess = { fail("Should not call `onSuccess`") })
 
     verify(alertModelSupabase)
         .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())


### PR DESCRIPTION
# Refactor `userId` parameter in `AlertViewModel`

## Description
This PR refactors the `userId` private parameter into a new private state `userId` that can be set. It closes issue #249. This code should be revisited once a new `SharedContext` data class is shared. This is a simple patch fix. `userId` state's default value is null.

## Changes
Added new setter function `setUserID` for the private mutable state `userId` in  `AlertViewModel.kt` and the new private mutable state is not ideal but works and avoids any innitialization issues when implementing.
## Files 
#### Modified
- `app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt`
- `app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt`

## Testing
Refactored how view model is innitialized.
