### PR TITLE
Feat/alert/alertlists vm integration

### DIFF
--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -14,6 +14,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
+import com.android.periodpals.model.alert.AlertModelSupabase
+import com.android.periodpals.model.alert.AlertViewModel
 import com.android.periodpals.model.authentication.AuthenticationModelSupabase
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.location.LocationViewModel
@@ -61,6 +63,9 @@ class MainActivity : ComponentActivity() {
   private val userModel = UserRepositorySupabase(supabaseClient)
   private val userViewModel = UserViewModel(userModel)
 
+  private val alertModel = AlertModelSupabase(supabaseClient)
+  val alertViewModel = AlertViewModel(alertModel)
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -75,7 +80,11 @@ class MainActivity : ComponentActivity() {
         // A surface container using the 'background' color from the theme
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
           PeriodPalsApp(
-              gpsService, pushNotificationsService, authenticationViewModel, userViewModel)
+              gpsService,
+              pushNotificationsService,
+              authenticationViewModel,
+              userViewModel,
+              alertViewModel)
         }
       }
     }
@@ -102,7 +111,8 @@ fun PeriodPalsApp(
     gpsService: GPSServiceImpl,
     pushNotificationsService: PushNotificationsService,
     authenticationViewModel: AuthenticationViewModel,
-    userViewModel: UserViewModel
+    userViewModel: UserViewModel,
+    alertViewModel: AlertViewModel
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -126,7 +136,9 @@ fun PeriodPalsApp(
 
     // Notifications received or pushed
     navigation(startDestination = Screen.ALERT_LIST, route = Route.ALERT_LIST) {
-      composable(Screen.ALERT_LIST) { AlertListsScreen(navigationActions) }
+      composable(Screen.ALERT_LIST) {
+        AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+      }
     }
 
     // Map

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -80,7 +80,7 @@ private const val PAL_ALERT_ACCEPT_TEXT = "Accept"
 private const val PAL_ALERT_DECLINE_TEXT = "Decline"
 private val INPUT_DATE_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 private val OUTPUT_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
-const val TAG = "AlertListsScreen"
+private const val TAG = "AlertListsScreen"
 
 /** Enum class representing the tabs in the AlertLists screen. */
 private enum class AlertListsTab {

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -117,10 +117,7 @@ fun AlertListsScreen(
   val uid by remember { mutableStateOf(authenticationViewModel.authUserData.value!!.uid) }
   alertViewModel.setUserID(uid)
   alertViewModel.fetchAlerts(
-      onSuccess = {
-        val alerts = alertViewModel.alerts.value
-        Log.d(TAG, "alerts: $alerts")
-      },
+      onSuccess = { alertViewModel.alerts.value },
       onFailure = { e -> Log.d(TAG, "Error fetching alerts: $e") })
   val myAlertsList = alertViewModel.myAlerts.value
   val palsAlertsList = alertViewModel.palAlerts.value
@@ -394,13 +391,18 @@ private fun AlertProfilePicture(idTestTag: String) {
   )
 }
 
-fun formatAlertTime(createdAt: String?): String {
+/**
+ * Formats the alert creation time to a readable string.
+ *
+ * @param createdAt The creation time of the alert in ISO_OFFSET_DATE_TIME format.
+ * @return A formatted time string or "Invalid Time" if the input is invalid.
+ */
+private fun formatAlertTime(createdAt: String?): String {
   return try {
     val dateTime = OffsetDateTime.parse(createdAt, INPUT_DATE_FORMATTER)
     dateTime.format(OUTPUT_TIME_FORMATTER)
   } catch (e: DateTimeParseException) {
-    // Handle invalid or null input
-    "Invalid Time"
+    throw DateTimeParseException("Invalid or null input for alert creation time", createdAt, 0)
   }
 }
 

--- a/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/CreateAlert.kt
@@ -97,25 +97,25 @@ fun CreateAlertScreen(
 
   LaunchedEffect(Unit) {
     gpsService.askPermissionAndStartUpdates() // Permission to access location
-    authenticationViewModel.loadAuthenticationUserData(
-        onFailure = {
-          Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
-            Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
-                .show()
-          }
-          Log.d(TAG, "Authentication data is null")
-        },
-    )
-    userViewModel.loadUser(
-        onFailure = {
-          Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
-            Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
-                .show()
-          }
-          Log.d(TAG, "User data is null")
-        },
-    )
   }
+  authenticationViewModel.loadAuthenticationUserData(
+      onFailure = {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
+          Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+              .show()
+        }
+        Log.d(TAG, "Authentication data is null")
+      },
+  )
+  userViewModel.loadUser(
+      onFailure = {
+        Handler(Looper.getMainLooper()).post { // used to show the Toast in the main thread
+          Toast.makeText(context, "Error loading your data! Try again later.", Toast.LENGTH_SHORT)
+              .show()
+        }
+        Log.d(TAG, "User data is null")
+      },
+  )
 
   val name by remember { mutableStateOf(userViewModel.user.value?.name ?: "") }
   val uid by remember { mutableStateOf(authenticationViewModel.authUserData.value!!.uid) }

--- a/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
@@ -12,9 +12,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.android.periodpals.model.alert.Alert
+import com.android.periodpals.model.alert.AlertViewModel
 import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
 import com.android.periodpals.model.alert.Urgency
+import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
@@ -35,6 +37,8 @@ import org.robolectric.RobolectricTestRunner
 class AlertListsScreenTest {
 
   private lateinit var navigationActions: NavigationActions
+  private lateinit var alertViewModel: AlertViewModel
+  private lateinit var authenticationViewModel: AuthenticationViewModel
   @get:Rule val composeTestRule = createComposeRule()
 
   companion object {
@@ -95,13 +99,17 @@ class AlertListsScreenTest {
   @Before
   fun setUp() {
     navigationActions = mock(NavigationActions::class.java)
+    alertViewModel = mock(AlertViewModel::class.java)
+    authenticationViewModel = mock(AuthenticationViewModel::class.java)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
   }
 
   @Test
   fun sharedComponentsCorrectlyDisplayed() {
-    composeTestRule.setContent { AlertListsScreen(navigationActions, emptyList(), emptyList()) }
+    composeTestRule.setContent {
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+    }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.TAB_ROW).assertIsDisplayed()
@@ -120,7 +128,9 @@ class AlertListsScreenTest {
 
   @Test
   fun myAlertsTabIsSelectedByDefault() {
-    composeTestRule.setContent { AlertListsScreen(navigationActions, emptyList(), emptyList()) }
+    composeTestRule.setContent {
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+    }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
     composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
@@ -128,7 +138,9 @@ class AlertListsScreenTest {
 
   @Test
   fun switchingTabWorks() {
-    composeTestRule.setContent { AlertListsScreen(navigationActions, emptyList(), emptyList()) }
+    composeTestRule.setContent {
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+    }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
     composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
@@ -147,7 +159,7 @@ class AlertListsScreenTest {
   @Test
   fun myAlertsEmptyIsCorrect() {
     composeTestRule.setContent {
-      AlertListsScreen(navigationActions, emptyList(), PALS_ALERTS_LIST)
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
     }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
@@ -171,7 +183,9 @@ class AlertListsScreenTest {
 
   @Test
   fun myAlertsListIsCorrect() {
-    composeTestRule.setContent { AlertListsScreen(navigationActions, MY_ALERTS_LIST, emptyList()) }
+    composeTestRule.setContent {
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+    }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
     composeTestRule.onNodeWithTag(AlertListsScreen.PALS_ALERTS_TAB).assertIsNotSelected()
@@ -215,7 +229,9 @@ class AlertListsScreenTest {
 
   @Test
   fun palsAlertsEmptyIsCorrect() {
-    composeTestRule.setContent { AlertListsScreen(navigationActions, MY_ALERTS_LIST, emptyList()) }
+    composeTestRule.setContent {
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
+    }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
     composeTestRule
@@ -244,7 +260,7 @@ class AlertListsScreenTest {
   @Test
   fun palsAlertsListNoActionIsCorrect() {
     composeTestRule.setContent {
-      AlertListsScreen(navigationActions, emptyList(), PALS_ALERTS_LIST)
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
     }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()
@@ -310,7 +326,7 @@ class AlertListsScreenTest {
   @Test
   fun palsAlertsListDoubleClickIsCorrect() {
     composeTestRule.setContent {
-      AlertListsScreen(navigationActions, emptyList(), PALS_ALERTS_LIST)
+      AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
     }
 
     composeTestRule.onNodeWithTag(AlertListsScreen.MY_ALERTS_TAB).assertIsSelected()

--- a/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.ui.alert
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
@@ -17,6 +18,7 @@ import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
 import com.android.periodpals.model.alert.Urgency
 import com.android.periodpals.model.authentication.AuthenticationViewModel
+import com.android.periodpals.model.user.AuthenticationUserData
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.MyAlertItem
 import com.android.periodpals.resources.C.Tag.AlertListsScreen.PalsAlertItem
@@ -24,7 +26,6 @@ import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
 import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
-import java.time.LocalDateTime
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,6 +42,10 @@ class AlertListsScreenTest {
   private lateinit var authenticationViewModel: AuthenticationViewModel
   @get:Rule val composeTestRule = createComposeRule()
 
+  private val uid = "12345"
+  private val email = "john.doe@example.com"
+  private val authUserData = mutableStateOf(AuthenticationUserData(uid, email))
+
   companion object {
     private const val NO_MY_ALERTS_TEXT = "You haven't asked for help yet !"
     private const val NO_PALS_ALERTS_TEXT = "No pal needs help yet !"
@@ -52,8 +57,8 @@ class AlertListsScreenTest {
                 name = "Hippo Alpha",
                 product = Product.TAMPON,
                 urgency = Urgency.HIGH,
-                createdAt = LocalDateTime.now().toString(),
-                location = "Rolex Learning Center",
+                createdAt = "2011-12-03T10:15:30+01:00",
+                location = "46.9484,7.4521,Bern",
                 message = "I need help!",
                 status = Status.CREATED,
             ),
@@ -63,8 +68,8 @@ class AlertListsScreenTest {
                 name = "Hippo Beta",
                 product = Product.PAD,
                 urgency = Urgency.LOW,
-                createdAt = LocalDateTime.now().toString(),
-                location = "BC",
+                createdAt = "2011-12-03T10:15:30+01:00",
+                location = "46.9484,7.4521,Bern",
                 message = "I forgot my pads at home :/",
                 status = Status.PENDING,
             ),
@@ -77,8 +82,8 @@ class AlertListsScreenTest {
                 name = "Hippo Gamma",
                 product = Product.TAMPON,
                 urgency = Urgency.MEDIUM,
-                createdAt = LocalDateTime.now().toString(),
-                location = "EPFL",
+                createdAt = "2011-12-03T10:15:30+01:00",
+                location = "19.4326,-99.1331,Mexico City",
                 message = "I need help!",
                 status = Status.CREATED,
             ),
@@ -88,8 +93,8 @@ class AlertListsScreenTest {
                 name = "Hippo Delta",
                 product = Product.PAD,
                 urgency = Urgency.HIGH,
-                createdAt = LocalDateTime.now().toString(),
-                location = "Rolex Learning Center",
+                createdAt = "2011-12-03T10:15:30+01:00",
+                location = "19.4326,-99.1331,Mexico City",
                 message = "I forgot my pads at home :/",
                 status = Status.PENDING,
             ),
@@ -103,6 +108,10 @@ class AlertListsScreenTest {
     authenticationViewModel = mock(AuthenticationViewModel::class.java)
 
     `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT_LIST)
+    `when`(authenticationViewModel.authUserData).thenReturn(authUserData)
+    `when`(alertViewModel.myAlerts).thenReturn(mutableStateOf(MY_ALERTS_LIST))
+    `when`(alertViewModel.palAlerts).thenReturn(mutableStateOf(PALS_ALERTS_LIST))
+    `when`(alertViewModel.alerts).thenReturn(mutableStateOf(MY_ALERTS_LIST + PALS_ALERTS_LIST))
   }
 
   @Test
@@ -158,6 +167,8 @@ class AlertListsScreenTest {
 
   @Test
   fun myAlertsEmptyIsCorrect() {
+    `when`(alertViewModel.alerts).thenReturn(mutableStateOf(PALS_ALERTS_LIST))
+    `when`(alertViewModel.myAlerts).thenReturn(mutableStateOf(emptyList()))
     composeTestRule.setContent {
       AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
     }
@@ -229,6 +240,8 @@ class AlertListsScreenTest {
 
   @Test
   fun palsAlertsEmptyIsCorrect() {
+    `when`(alertViewModel.alerts).thenReturn(mutableStateOf(MY_ALERTS_LIST))
+    `when`(alertViewModel.palAlerts).thenReturn(mutableStateOf(emptyList()))
     composeTestRule.setContent {
       AlertListsScreen(navigationActions, alertViewModel, authenticationViewModel)
     }


### PR DESCRIPTION
# Integrate Alert VM to AlertLists

## Description
This PR closes issue #17 and [#119](https://github.com/PeriodPals/periodpals/issues/119). 
It passes the `AlertViewModel` as parameter to `AlertListsScreen()` from `PeriodPalsApp()` in `MainActivity`.
It then integrates the Alert View Model to `AlertListsScreen()`, which now directly fetches the real data from repository for `myAlertList` and `palsAlertList`. UI was already amazingly done. 

**Note**: I had to add a private function `formatAlertTime()` to facilitate the parsing of the `alert.createdAt` value, because the previous expected format wasn't right.  

## Changes

## Files 

#### Added
None

#### Modified
- `app/src/main/java/com/android/periodpals/MainActivity.kt`
- `app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt`
- `app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt`

#### Removed
None

## Dependencies Added
None

## Testing
I adapted `AlertListsTests` by : 
- mocking AlertViewModel and AuthenticationViewModel
- refactoring the calls to `AlertListsScreen()`
- correcting the format of `location` and `createdAt` parameters of the mock Alerts
- mocking the response of the calls to `authenticationViewModel.authUserData`, `alertViewModel.alerts`, `alertViewModel.myAlerts` and `alertViewModel.palAlerts` depending on each tests

## Screenshots (if applicable)
<img width="375" alt="Screenshot 2024-11-28 at 22 07 57" src="https://github.com/user-attachments/assets/5166b9c7-8e60-4df7-9a26-d1ad7b533e7a">
<img width="375" alt="Screenshot 2024-11-28 at 22 08 05" src="https://github.com/user-attachments/assets/a97cd317-3dba-445c-9f3a-6241510494ba">


