### PR TITLE
Feat/authentication/form-validation : Integrate form validation library into authentication screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,12 +143,13 @@ dependencies {
   // implementation(libs.androidx.fragment.ktx)
   // implementation(libs.kotlinx.serialization.json)
 
+  // form validation
+  implementation(libs.form.builder)
 
   // credentials
   implementation("androidx.credentials:credentials:1.3.0-alpha01")
   implementation("androidx.credentials:credentials-play-services-auth:1.3.0-alpha01")
   implementation("com.google.android.libraries.identity.googleid:googleid:1.1.0")
-
 
   // Firebase
   implementation(platform(libs.firebase.bom))

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -11,56 +11,62 @@ import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
 import io.github.jan.supabase.auth.user.UserInfo
-import java.security.MessageDigest
 import kotlinx.coroutines.launch
+import java.security.MessageDigest
 
 private const val TAG = "AuthenticationViewModel"
 
 private const val PASSWORD_MIN_LENGTH = 8
-private const val PASSWORD_MAX_LENGTH = 128
+private const val INPUT_MAX_LENGTH = 128
 private const val EMPTY_EMAIL_ERROR_MESSAGE = "Email cannot be empty"
+private const val TOO_LONG_EMAIL_ERROR_MESSAGE =
+  "Email must be at most $INPUT_MAX_LENGTH characters long"
 private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
 private const val TOO_SHORT_PASSWORD_ERROR_MESSAGE =
-    "Password must be at least $PASSWORD_MIN_LENGTH characters long"
+  "Password must be at least $PASSWORD_MIN_LENGTH characters long"
 private const val TOO_LONG_PASSWORD_ERROR_MESSAGE =
-    "Password must be at most $PASSWORD_MAX_LENGTH characters long"
+  "Password must be at most $INPUT_MAX_LENGTH characters long"
 private const val NO_CAPITAL_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one capital letter"
+  "Password must contain at least one capital letter"
 private const val NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one lower case letter"
+  "Password must contain at least one lower case letter"
 private const val NO_NUMBER_PASSWORD_ERROR_MESSAGE = "Password must contain at least one number"
 private const val NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one special character"
+  "Password must contain at least one special character"
 
 private val emailValidators =
-    listOf(Validators.Email(), Validators.Required(message = EMPTY_EMAIL_ERROR_MESSAGE))
+  listOf(
+    Validators.Email(),
+    Validators.Required(message = EMPTY_EMAIL_ERROR_MESSAGE),
+    Validators.Max(message = TOO_LONG_EMAIL_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+  )
 private val passwordLoginValidators =
-    listOf(
-        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
-        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MAX_LENGTH),
-    )
+  listOf(
+    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+  )
 private val passwordSignupValidators =
-    listOf(
-        Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
-        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MAX_LENGTH),
-        Validators.Custom(
-            message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
-            function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
-        ),
-        Validators.Custom(
-            message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
-            function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
-        ),
-        Validators.Custom(
-            message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
-            function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
-        ),
-        Validators.Custom(
-            message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
-            function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
-        ),
-        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
-    )
+  listOf(
+    Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
+    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+    Validators.Custom(
+      message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
+    ),
+    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+  )
 
 /**
  * ViewModel for handling authentication-related operations.
@@ -77,24 +83,22 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
   }
 
   private val _userAuthenticationState =
-      mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
+    mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
   val userAuthenticationState: State<UserAuthenticationState> = _userAuthenticationState
 
   private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
   val authUserData: State<AuthenticationUserData?> = _authUserData
 
   val formState =
-      FormState(
-          fields =
-              listOf(
-                  TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
-                  TextFieldState(
-                      name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
-                  TextFieldState(
-                      name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
-                  TextFieldState(
-                      name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
-              ))
+    FormState(
+      fields =
+        listOf(
+          TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
+          TextFieldState(name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
+          TextFieldState(name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
+          TextFieldState(name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
+        )
+    )
 
   /**
    * Registers a new user with the provided email and password.
@@ -105,29 +109,27 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the registration fails.
    */
   fun signUpWithEmail(
-      userEmail: String,
-      userPassword: String,
-      onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "signUp failure callback: $e")
-      },
+    userEmail: String,
+    userPassword: String,
+    onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.register(
-          userEmail = userEmail,
-          userPassword = userPassword,
-          onSuccess = {
-            Log.d(TAG, "signUpWithEmail: registered user successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Registered user successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "signUpWithEmail: failed to register user: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        userEmail = userEmail,
+        userPassword = userPassword,
+        onSuccess = {
+          Log.d(TAG, "signUpWithEmail: registered user successfully")
+          _userAuthenticationState.value =
+            UserAuthenticationState.Success("Registered user successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "signUpWithEmail: failed to register user: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -141,29 +143,26 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun logInWithEmail(
-      userEmail: String,
-      userPassword: String,
-      onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "signIn failure callback: $e")
-      },
+    userEmail: String,
+    userPassword: String,
+    onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.login(
-          userEmail = userEmail,
-          userPassword = userPassword,
-          onSuccess = {
-            Log.d(TAG, "logInWithEmail: logged in successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged in successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "logInWithEmail: failed to log in: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        userEmail = userEmail,
+        userPassword = userPassword,
+        onSuccess = {
+          Log.d(TAG, "logInWithEmail: logged in successfully")
+          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "logInWithEmail: failed to log in: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -175,25 +174,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the logout fails.
    */
   fun logOut(
-      onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "logOut failure callback: $e")
-      },
+    onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.logout(
-          onSuccess = {
-            Log.d(TAG, "logOut: logged out successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged out successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "logOut: failed to log out: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "logOut: logged out successfully")
+          _userAuthenticationState.value =
+            UserAuthenticationState.Success("Logged out successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "logOut: failed to log out: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -205,23 +202,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user is not logged in.
    */
   fun isUserLoggedIn(
-      onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "isUserLoggedIn failure callback: $e")
-      },
+    onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "isUserLoggedIn failure callback: $e")
+    },
   ) {
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
-          onSuccess = {
-            Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
-            _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "isUserLoggedIn: user is not logged in")
-            _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
+          _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "isUserLoggedIn: user is not logged in")
+          _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
+          onFailure(e)
+        },
       )
     }
   }
@@ -233,23 +230,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user data fails to load.
    */
   fun loadAuthenticationUserData(
-      onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
-      },
+    onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
+    },
   ) {
     viewModelScope.launch {
       authenticationModel.currentAuthenticationUser(
-          onSuccess = {
-            Log.d(TAG, "loadAuthUserData: user data successfully loaded")
-            _authUserData.value = it.asAuthenticationUserData()
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "loadAuthUserData: failed to load user data")
-            _authUserData.value = null
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "loadAuthUserData: user data successfully loaded")
+          _authUserData.value = it.asAuthenticationUserData()
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "loadAuthUserData: failed to load user data")
+          _authUserData.value = null
+          onFailure(e)
+        },
       )
     }
   }
@@ -263,29 +260,28 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun loginWithGoogle(
-      googleIdToken: String,
-      rawNonce: String?,
-      onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "loginWithGoogle failure callback: $e")
-      },
+    googleIdToken: String,
+    rawNonce: String?,
+    onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "loginWithGoogle failure callback: $e")
+    },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.loginGoogle(
-          googleIdToken,
-          rawNonce,
-          onSuccess = {
-            Log.d(TAG, "loginWithGoogle: logged in successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged in successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "loginWithGoogle: failed to log in: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        googleIdToken,
+        rawNonce,
+        onSuccess = {
+          Log.d(TAG, "loginWithGoogle: logged in successfully")
+          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "loginWithGoogle: failed to log in: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -7,11 +7,55 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.periodpals.model.user.AuthenticationUserData
 import com.android.periodpals.model.user.UserAuthenticationState
+import com.dsc.form_builder.FormState
+import com.dsc.form_builder.TextFieldState
+import com.dsc.form_builder.Validators
 import io.github.jan.supabase.auth.user.UserInfo
-import java.security.MessageDigest
 import kotlinx.coroutines.launch
+import java.security.MessageDigest
 
 private const val TAG = "AuthenticationViewModel"
+
+private const val PASSWORD_MIN_LENGTH = 8
+private const val PASSWORD_MAX_LENGTH = 128
+private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
+private const val TOO_SHORT_PASSWORD_ERROR_MESSAGE =
+  "Password must be at least $PASSWORD_MIN_LENGTH characters long"
+private const val TOO_LONG_PASSWORD_ERROR_MESSAGE =
+  "Password must be at most $PASSWORD_MAX_LENGTH characters long"
+private const val NO_CAPITAL_PASSWORD_ERROR_MESSAGE =
+  "Password must contain at least one capital letter"
+private const val NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE =
+  "Password must contain at least one lower case letter"
+private const val NO_NUMBER_PASSWORD_ERROR_MESSAGE = "Password must contain at least one number"
+private const val NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE =
+  "Password must contain at least one special character"
+
+private val emailValidators = listOf(Validators.Email(), Validators.Required())
+private val passwordLoginValidators =
+  listOf(Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE))
+private val passwordSignupValidators =
+  listOf(
+    Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
+    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
+    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+    Validators.Custom(
+      message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
+    ),
+    Validators.Custom(
+      message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
+      function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
+    ),
+  )
 
 /**
  * ViewModel for handling authentication-related operations.
@@ -20,12 +64,31 @@ private const val TAG = "AuthenticationViewModel"
  */
 class AuthenticationViewModel(private val authenticationModel: AuthenticationModel) : ViewModel() {
 
-  private val _userAuthenticationState =
-      mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
-  private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
+  companion object {
+    const val EMAIL_STATE_NAME = "email"
+    const val PASSWORD_SIGNUP_STATE_NAME = "password_signup"
+    const val CONFIRM_PASSWORD_STATE_NAME = "confirm_password_signup"
+    const val PASSWORD_LOGIN_STATE_NAME = "password_login"
+  }
 
+  private val _userAuthenticationState =
+    mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
+
+  private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
   val userAuthenticationState: State<UserAuthenticationState> = _userAuthenticationState
+
   val authUserData: State<AuthenticationUserData?> = _authUserData
+
+  val formState =
+    FormState(
+      fields =
+        listOf(
+          TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
+          TextFieldState(name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
+          TextFieldState(name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
+          TextFieldState(name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
+        )
+    )
 
   /**
    * Registers a new user with the provided email and password.
@@ -36,27 +99,27 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the registration fails.
    */
   fun signUpWithEmail(
-      userEmail: String,
-      userPassword: String,
-      onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") }
+    userEmail: String,
+    userPassword: String,
+    onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.register(
-          userEmail = userEmail,
-          userPassword = userPassword,
-          onSuccess = {
-            Log.d(TAG, "signUpWithEmail: registered user successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Registered user successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "signUpWithEmail: failed to register user: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        userEmail = userEmail,
+        userPassword = userPassword,
+        onSuccess = {
+          Log.d(TAG, "signUpWithEmail: registered user successfully")
+          _userAuthenticationState.value =
+            UserAuthenticationState.Success("Registered user successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "signUpWithEmail: failed to register user: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -70,27 +133,26 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun logInWithEmail(
-      userEmail: String,
-      userPassword: String,
-      onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") }
+    userEmail: String,
+    userPassword: String,
+    onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.login(
-          userEmail = userEmail,
-          userPassword = userPassword,
-          onSuccess = {
-            Log.d(TAG, "logInWithEmail: logged in successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged in successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "logInWithEmail: failed to log in: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        userEmail = userEmail,
+        userPassword = userPassword,
+        onSuccess = {
+          Log.d(TAG, "logInWithEmail: logged in successfully")
+          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "logInWithEmail: failed to log in: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -102,23 +164,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the logout fails.
    */
   fun logOut(
-      onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") }
+    onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.logout(
-          onSuccess = {
-            Log.d(TAG, "logOut: logged out successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged out successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "logOut: failed to log out: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "logOut: logged out successfully")
+          _userAuthenticationState.value =
+            UserAuthenticationState.Success("Logged out successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "logOut: failed to log out: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
       )
     }
   }
@@ -130,23 +192,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user is not logged in.
    */
   fun isUserLoggedIn(
-      onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "isUserLoggedIn failure callback: $e")
-      }
+    onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "isUserLoggedIn failure callback: $e")
+    },
   ) {
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
-          onSuccess = {
-            Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
-            _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "isUserLoggedIn: user is not logged in")
-            _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
+          _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "isUserLoggedIn: user is not logged in")
+          _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
+          onFailure(e)
+        },
       )
     }
   }
@@ -158,23 +220,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user data fails to load.
    */
   fun loadAuthenticationUserData(
-      onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
-      }
+    onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
+    },
   ) {
     viewModelScope.launch {
       authenticationModel.currentAuthenticationUser(
-          onSuccess = {
-            Log.d(TAG, "loadAuthUserData: user data successfully loaded")
-            _authUserData.value = it.asAuthenticationUserData()
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "loadAuthUserData: failed to load user data")
-            _authUserData.value = null
-            onFailure(e)
-          },
+        onSuccess = {
+          Log.d(TAG, "loadAuthUserData: user data successfully loaded")
+          _authUserData.value = it.asAuthenticationUserData()
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "loadAuthUserData: failed to load user data")
+          _authUserData.value = null
+          onFailure(e)
+        },
       )
     }
   }
@@ -188,29 +250,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun loginWithGoogle(
-      googleIdToken: String,
-      rawNonce: String?,
-      onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
-      onFailure: (Exception) -> Unit = { e: Exception ->
-        Log.d(TAG, "loginWithGoogle failure callback: $e")
-      }
+    googleIdToken: String,
+    rawNonce: String?,
+    onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
+    onFailure: (Exception) -> Unit = { e: Exception ->
+      Log.d(TAG, "loginWithGoogle failure callback: $e")
+    },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.loginGoogle(
-          googleIdToken,
-          rawNonce,
-          onSuccess = {
-            Log.d(TAG, "loginWithGoogle: logged in successfully")
-            _userAuthenticationState.value =
-                UserAuthenticationState.Success("Logged in successfully")
-            onSuccess()
-          },
-          onFailure = { e: Exception ->
-            Log.d(TAG, "loginWithGoogle: failed to log in: $e")
-            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-            onFailure(e)
-          })
+        googleIdToken,
+        rawNonce,
+        onSuccess = {
+          Log.d(TAG, "loginWithGoogle: logged in successfully")
+          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
+          onSuccess()
+        },
+        onFailure = { e: Exception ->
+          Log.d(TAG, "loginWithGoogle: failed to log in: $e")
+          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+          onFailure(e)
+        },
+      )
     }
   }
 

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -11,51 +11,56 @@ import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
 import io.github.jan.supabase.auth.user.UserInfo
-import kotlinx.coroutines.launch
 import java.security.MessageDigest
+import kotlinx.coroutines.launch
 
 private const val TAG = "AuthenticationViewModel"
 
 private const val PASSWORD_MIN_LENGTH = 8
 private const val PASSWORD_MAX_LENGTH = 128
+private const val EMPTY_EMAIL_ERROR_MESSAGE = "Email cannot be empty"
 private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
 private const val TOO_SHORT_PASSWORD_ERROR_MESSAGE =
-  "Password must be at least $PASSWORD_MIN_LENGTH characters long"
+    "Password must be at least $PASSWORD_MIN_LENGTH characters long"
 private const val TOO_LONG_PASSWORD_ERROR_MESSAGE =
-  "Password must be at most $PASSWORD_MAX_LENGTH characters long"
+    "Password must be at most $PASSWORD_MAX_LENGTH characters long"
 private const val NO_CAPITAL_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one capital letter"
+    "Password must contain at least one capital letter"
 private const val NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one lower case letter"
+    "Password must contain at least one lower case letter"
 private const val NO_NUMBER_PASSWORD_ERROR_MESSAGE = "Password must contain at least one number"
 private const val NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one special character"
+    "Password must contain at least one special character"
 
-private val emailValidators = listOf(Validators.Email(), Validators.Required())
+private val emailValidators =
+    listOf(Validators.Email(), Validators.Required(message = EMPTY_EMAIL_ERROR_MESSAGE))
 private val passwordLoginValidators =
-  listOf(Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE))
+    listOf(
+        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MAX_LENGTH),
+    )
 private val passwordSignupValidators =
-  listOf(
-    Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
-    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
-    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
-    Validators.Custom(
-      message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
-    ),
-  )
+    listOf(
+        Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
+        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MAX_LENGTH),
+        Validators.Custom(
+            message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
+        ),
+        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+    )
 
 /**
  * ViewModel for handling authentication-related operations.
@@ -72,23 +77,24 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
   }
 
   private val _userAuthenticationState =
-    mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
-
-  private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
+      mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
   val userAuthenticationState: State<UserAuthenticationState> = _userAuthenticationState
 
+  private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
   val authUserData: State<AuthenticationUserData?> = _authUserData
 
   val formState =
-    FormState(
-      fields =
-        listOf(
-          TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
-          TextFieldState(name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
-          TextFieldState(name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
-          TextFieldState(name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
-        )
-    )
+      FormState(
+          fields =
+              listOf(
+                  TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
+                  TextFieldState(
+                      name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
+                  TextFieldState(
+                      name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
+                  TextFieldState(
+                      name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
+              ))
 
   /**
    * Registers a new user with the provided email and password.
@@ -99,27 +105,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the registration fails.
    */
   fun signUpWithEmail(
-    userEmail: String,
-    userPassword: String,
-    onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") },
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "signUp failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.register(
-        userEmail = userEmail,
-        userPassword = userPassword,
-        onSuccess = {
-          Log.d(TAG, "signUpWithEmail: registered user successfully")
-          _userAuthenticationState.value =
-            UserAuthenticationState.Success("Registered user successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "signUpWithEmail: failed to register user: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          userEmail = userEmail,
+          userPassword = userPassword,
+          onSuccess = {
+            Log.d(TAG, "signUpWithEmail: registered user successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Registered user successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "signUpWithEmail: failed to register user: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -133,26 +141,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun logInWithEmail(
-    userEmail: String,
-    userPassword: String,
-    onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") },
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "signIn failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.login(
-        userEmail = userEmail,
-        userPassword = userPassword,
-        onSuccess = {
-          Log.d(TAG, "logInWithEmail: logged in successfully")
-          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "logInWithEmail: failed to log in: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          userEmail = userEmail,
+          userPassword = userPassword,
+          onSuccess = {
+            Log.d(TAG, "logInWithEmail: logged in successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged in successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "logInWithEmail: failed to log in: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -164,23 +175,25 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the logout fails.
    */
   fun logOut(
-    onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") },
+      onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "logOut failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.logout(
-        onSuccess = {
-          Log.d(TAG, "logOut: logged out successfully")
-          _userAuthenticationState.value =
-            UserAuthenticationState.Success("Logged out successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "logOut: failed to log out: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "logOut: logged out successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged out successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "logOut: failed to log out: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -192,23 +205,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user is not logged in.
    */
   fun isUserLoggedIn(
-    onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "isUserLoggedIn failure callback: $e")
-    },
+      onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "isUserLoggedIn failure callback: $e")
+      },
   ) {
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
-        onSuccess = {
-          Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
-          _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "isUserLoggedIn: user is not logged in")
-          _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
+            _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "isUserLoggedIn: user is not logged in")
+            _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
+            onFailure(e)
+          },
       )
     }
   }
@@ -220,23 +233,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user data fails to load.
    */
   fun loadAuthenticationUserData(
-    onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
-    },
+      onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
+      },
   ) {
     viewModelScope.launch {
       authenticationModel.currentAuthenticationUser(
-        onSuccess = {
-          Log.d(TAG, "loadAuthUserData: user data successfully loaded")
-          _authUserData.value = it.asAuthenticationUserData()
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "loadAuthUserData: failed to load user data")
-          _authUserData.value = null
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "loadAuthUserData: user data successfully loaded")
+            _authUserData.value = it.asAuthenticationUserData()
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "loadAuthUserData: failed to load user data")
+            _authUserData.value = null
+            onFailure(e)
+          },
       )
     }
   }
@@ -250,28 +263,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun loginWithGoogle(
-    googleIdToken: String,
-    rawNonce: String?,
-    onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "loginWithGoogle failure callback: $e")
-    },
+      googleIdToken: String,
+      rawNonce: String?,
+      onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loginWithGoogle failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.loginGoogle(
-        googleIdToken,
-        rawNonce,
-        onSuccess = {
-          Log.d(TAG, "loginWithGoogle: logged in successfully")
-          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "loginWithGoogle: failed to log in: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          googleIdToken,
+          rawNonce,
+          onSuccess = {
+            Log.d(TAG, "loginWithGoogle: logged in successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged in successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "loginWithGoogle: failed to log in: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt
@@ -11,8 +11,8 @@ import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
 import io.github.jan.supabase.auth.user.UserInfo
-import kotlinx.coroutines.launch
 import java.security.MessageDigest
+import kotlinx.coroutines.launch
 
 private const val TAG = "AuthenticationViewModel"
 
@@ -20,53 +20,53 @@ private const val PASSWORD_MIN_LENGTH = 8
 private const val INPUT_MAX_LENGTH = 128
 private const val EMPTY_EMAIL_ERROR_MESSAGE = "Email cannot be empty"
 private const val TOO_LONG_EMAIL_ERROR_MESSAGE =
-  "Email must be at most $INPUT_MAX_LENGTH characters long"
+    "Email must be at most $INPUT_MAX_LENGTH characters long"
 private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
 private const val TOO_SHORT_PASSWORD_ERROR_MESSAGE =
-  "Password must be at least $PASSWORD_MIN_LENGTH characters long"
+    "Password must be at least $PASSWORD_MIN_LENGTH characters long"
 private const val TOO_LONG_PASSWORD_ERROR_MESSAGE =
-  "Password must be at most $INPUT_MAX_LENGTH characters long"
+    "Password must be at most $INPUT_MAX_LENGTH characters long"
 private const val NO_CAPITAL_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one capital letter"
+    "Password must contain at least one capital letter"
 private const val NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one lower case letter"
+    "Password must contain at least one lower case letter"
 private const val NO_NUMBER_PASSWORD_ERROR_MESSAGE = "Password must contain at least one number"
 private const val NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE =
-  "Password must contain at least one special character"
+    "Password must contain at least one special character"
 
 private val emailValidators =
-  listOf(
-    Validators.Email(),
-    Validators.Required(message = EMPTY_EMAIL_ERROR_MESSAGE),
-    Validators.Max(message = TOO_LONG_EMAIL_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
-  )
+    listOf(
+        Validators.Email(),
+        Validators.Required(message = EMPTY_EMAIL_ERROR_MESSAGE),
+        Validators.Max(message = TOO_LONG_EMAIL_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+    )
 private val passwordLoginValidators =
-  listOf(
-    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
-    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
-  )
+    listOf(
+        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+    )
 private val passwordSignupValidators =
-  listOf(
-    Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
-    Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
-    Validators.Custom(
-      message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
-    ),
-    Validators.Custom(
-      message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
-      function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
-    ),
-    Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
-  )
+    listOf(
+        Validators.Min(message = TOO_SHORT_PASSWORD_ERROR_MESSAGE, limit = PASSWORD_MIN_LENGTH),
+        Validators.Max(message = TOO_LONG_PASSWORD_ERROR_MESSAGE, limit = INPUT_MAX_LENGTH),
+        Validators.Custom(
+            message = NO_CAPITAL_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[A-Z].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[a-z].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_NUMBER_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[0-9].*").containsMatchIn(it as String) },
+        ),
+        Validators.Custom(
+            message = NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE,
+            function = { Regex(".*[!@#\$%^&*(),.?\":{}|<>].*").containsMatchIn(it as String) },
+        ),
+        Validators.Required(message = EMPTY_PASSWORD_ERROR_MESSAGE),
+    )
 
 /**
  * ViewModel for handling authentication-related operations.
@@ -83,22 +83,24 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
   }
 
   private val _userAuthenticationState =
-    mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
+      mutableStateOf<UserAuthenticationState>(UserAuthenticationState.Loading)
   val userAuthenticationState: State<UserAuthenticationState> = _userAuthenticationState
 
   private val _authUserData = mutableStateOf<AuthenticationUserData?>(null)
   val authUserData: State<AuthenticationUserData?> = _authUserData
 
   val formState =
-    FormState(
-      fields =
-        listOf(
-          TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
-          TextFieldState(name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
-          TextFieldState(name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
-          TextFieldState(name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
-        )
-    )
+      FormState(
+          fields =
+              listOf(
+                  TextFieldState(name = EMAIL_STATE_NAME, validators = emailValidators),
+                  TextFieldState(
+                      name = PASSWORD_SIGNUP_STATE_NAME, validators = passwordSignupValidators),
+                  TextFieldState(
+                      name = CONFIRM_PASSWORD_STATE_NAME, validators = passwordSignupValidators),
+                  TextFieldState(
+                      name = PASSWORD_LOGIN_STATE_NAME, validators = passwordLoginValidators),
+              ))
 
   /**
    * Registers a new user with the provided email and password.
@@ -109,27 +111,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the registration fails.
    */
   fun signUpWithEmail(
-    userEmail: String,
-    userPassword: String,
-    onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signUp failure callback: $e") },
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signUp success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "signUp failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.register(
-        userEmail = userEmail,
-        userPassword = userPassword,
-        onSuccess = {
-          Log.d(TAG, "signUpWithEmail: registered user successfully")
-          _userAuthenticationState.value =
-            UserAuthenticationState.Success("Registered user successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "signUpWithEmail: failed to register user: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          userEmail = userEmail,
+          userPassword = userPassword,
+          onSuccess = {
+            Log.d(TAG, "signUpWithEmail: registered user successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Registered user successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "signUpWithEmail: failed to register user: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -143,26 +147,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun logInWithEmail(
-    userEmail: String,
-    userPassword: String,
-    onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "signIn failure callback: $e") },
+      userEmail: String,
+      userPassword: String,
+      onSuccess: () -> Unit = { Log.d(TAG, "signIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "signIn failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.login(
-        userEmail = userEmail,
-        userPassword = userPassword,
-        onSuccess = {
-          Log.d(TAG, "logInWithEmail: logged in successfully")
-          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "logInWithEmail: failed to log in: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          userEmail = userEmail,
+          userPassword = userPassword,
+          onSuccess = {
+            Log.d(TAG, "logInWithEmail: logged in successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged in successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "logInWithEmail: failed to log in: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -174,23 +181,25 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the logout fails.
    */
   fun logOut(
-    onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception -> Log.d(TAG, "logOut failure callback: $e") },
+      onSuccess: () -> Unit = { Log.d(TAG, "logOut success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "logOut failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.logout(
-        onSuccess = {
-          Log.d(TAG, "logOut: logged out successfully")
-          _userAuthenticationState.value =
-            UserAuthenticationState.Success("Logged out successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "logOut: failed to log out: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "logOut: logged out successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged out successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "logOut: failed to log out: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }
@@ -202,23 +211,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user is not logged in.
    */
   fun isUserLoggedIn(
-    onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "isUserLoggedIn failure callback: $e")
-    },
+      onSuccess: () -> Unit = { Log.d(TAG, "isUserLoggedIn success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "isUserLoggedIn failure callback: $e")
+      },
   ) {
     viewModelScope.launch {
       authenticationModel.isUserLoggedIn(
-        onSuccess = {
-          Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
-          _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "isUserLoggedIn: user is not logged in")
-          _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "isUserLoggedIn: user is confirmed logged in")
+            _userAuthenticationState.value = UserAuthenticationState.Success("User is logged in")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "isUserLoggedIn: user is not logged in")
+            _userAuthenticationState.value = UserAuthenticationState.Error("User is not logged in")
+            onFailure(e)
+          },
       )
     }
   }
@@ -230,23 +239,23 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the user data fails to load.
    */
   fun loadAuthenticationUserData(
-    onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
-    },
+      onSuccess: () -> Unit = { Log.d(TAG, "loadAuthenticationUserData success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loadAuthenticationUserData failure callback: $e")
+      },
   ) {
     viewModelScope.launch {
       authenticationModel.currentAuthenticationUser(
-        onSuccess = {
-          Log.d(TAG, "loadAuthUserData: user data successfully loaded")
-          _authUserData.value = it.asAuthenticationUserData()
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "loadAuthUserData: failed to load user data")
-          _authUserData.value = null
-          onFailure(e)
-        },
+          onSuccess = {
+            Log.d(TAG, "loadAuthUserData: user data successfully loaded")
+            _authUserData.value = it.asAuthenticationUserData()
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "loadAuthUserData: failed to load user data")
+            _authUserData.value = null
+            onFailure(e)
+          },
       )
     }
   }
@@ -260,28 +269,29 @@ class AuthenticationViewModel(private val authenticationModel: AuthenticationMod
    * @param onFailure Callback to be invoked when the login fails.
    */
   fun loginWithGoogle(
-    googleIdToken: String,
-    rawNonce: String?,
-    onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
-    onFailure: (Exception) -> Unit = { e: Exception ->
-      Log.d(TAG, "loginWithGoogle failure callback: $e")
-    },
+      googleIdToken: String,
+      rawNonce: String?,
+      onSuccess: () -> Unit = { Log.d(TAG, "loginWithGoogle success callback") },
+      onFailure: (Exception) -> Unit = { e: Exception ->
+        Log.d(TAG, "loginWithGoogle failure callback: $e")
+      },
   ) {
     _userAuthenticationState.value = UserAuthenticationState.Loading
     viewModelScope.launch {
       authenticationModel.loginGoogle(
-        googleIdToken,
-        rawNonce,
-        onSuccess = {
-          Log.d(TAG, "loginWithGoogle: logged in successfully")
-          _userAuthenticationState.value = UserAuthenticationState.Success("Logged in successfully")
-          onSuccess()
-        },
-        onFailure = { e: Exception ->
-          Log.d(TAG, "loginWithGoogle: failed to log in: $e")
-          _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
-          onFailure(e)
-        },
+          googleIdToken,
+          rawNonce,
+          onSuccess = {
+            Log.d(TAG, "loginWithGoogle: logged in successfully")
+            _userAuthenticationState.value =
+                UserAuthenticationState.Success("Logged in successfully")
+            onSuccess()
+          },
+          onFailure = { e: Exception ->
+            Log.d(TAG, "loginWithGoogle: failed to log in: $e")
+            _userAuthenticationState.value = UserAuthenticationState.Error("Error: $e")
+            onFailure(e)
+          },
       )
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -56,9 +56,9 @@ import com.dsc.form_builder.TextFieldState
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.util.UUID
 
 private const val DEFAULT_IS_PASSWORD_VISIBLE = false
 
@@ -81,8 +81,8 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password."
  */
 @Composable
 fun SignInScreen(
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
@@ -90,7 +90,7 @@ fun SignInScreen(
 
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
   var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
@@ -99,88 +99,92 @@ fun SignInScreen(
     GradedBackground()
 
     Column(
-      modifier =
-        Modifier.fillMaxSize()
-          .padding(paddingValues)
-          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
-          .verticalScroll(rememberScrollState()),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.large,
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
-          text = SIGN_IN_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
+            text = SIGN_IN_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-          email = emailState.value,
-          onEmailChange = { emailState.change(it) },
-          emailErrorMessage = emailState.errorMessage,
+            email = emailState.value,
+            onEmailChange = { emailState.change(it) },
+            emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-          password = passwordState.value,
-          onPasswordChange = { passwordState.change(it) },
-          passwordVisible = isPasswordVisible,
-          onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
-          passwordErrorMessage = passwordState.errorMessage,
+            password = passwordState.value,
+            onPasswordChange = { passwordState.change(it) },
+            passwordVisible = isPasswordVisible,
+            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
+            passwordErrorMessage = passwordState.errorMessage,
         )
 
         AuthenticationSubmitButton(
-          text = SIGN_IN_BUTTON_TEXT,
-          onClick = {
-            attemptSignIn(
-              emailState = emailState,
-              passwordState = passwordState,
-              authenticationViewModel = authenticationViewModel,
-              context = context,
-              navigationActions = navigationActions,
-            )
-          },
-          testTag = SignInScreen.SIGN_IN_BUTTON,
+            text = SIGN_IN_BUTTON_TEXT,
+            onClick = {
+              attemptSignIn(
+                  emailState = emailState,
+                  passwordState = passwordState,
+                  authenticationViewModel = authenticationViewModel,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignInScreen.SIGN_IN_BUTTON,
         )
 
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.CONTINUE_WITH_TEXT),
-          text = CONTINUE_WITH_TEXT,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(SignInScreen.CONTINUE_WITH_TEXT),
+            text = CONTINUE_WITH_TEXT,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
       Row(
-        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
       ) {
         Text(
-          modifier = Modifier.wrapContentSize(),
-          text = NO_ACCOUNT_TEXT,
-          color = MaterialTheme.colorScheme.onSecondaryContainer,
-          style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.wrapContentSize(),
+            text = NO_ACCOUNT_TEXT,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodyMedium,
         )
 
         Text(
-          modifier =
-            Modifier.wrapContentSize()
-              .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-              .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-          text = SIGN_UP_TEXT,
-          textDecoration = TextDecoration.Underline,
-          color = MaterialTheme.colorScheme.onSecondaryContainer,
-          style = MaterialTheme.typography.bodyMedium,
+            modifier =
+                Modifier.wrapContentSize()
+                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+            text = SIGN_UP_TEXT,
+            textDecoration = TextDecoration.Underline,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodyMedium,
         )
       }
     }
@@ -196,40 +200,40 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(
-  context: Context,
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
-  modifier: Modifier = Modifier,
+    context: Context,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
+    modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   Button(
-    modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
-    onClick = {
-      attemptAuthenticateWithGoogle(
-        context = context,
-        authenticationViewModel = authenticationViewModel,
-        navigationActions = navigationActions,
-        coroutineScope = coroutineScope,
-      )
-    },
-    colors = getFilledPrimaryContainerButtonColors(),
+      modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
+      onClick = {
+        attemptAuthenticateWithGoogle(
+            context = context,
+            authenticationViewModel = authenticationViewModel,
+            navigationActions = navigationActions,
+            coroutineScope = coroutineScope,
+        )
+      },
+      colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Row(
-      modifier = Modifier.wrapContentSize(),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
+        modifier = Modifier.wrapContentSize(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
     ) {
       Image(
-        painter = painterResource(id = R.drawable.google_logo),
-        contentDescription = "Google Logo",
-        modifier = Modifier.size(MaterialTheme.dimens.iconSize),
+          painter = painterResource(id = R.drawable.google_logo),
+          contentDescription = "Google Logo",
+          modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
       Text(
-        modifier = Modifier.wrapContentSize(),
-        text = SIGN_UP_WITH_GOOGLE,
-        fontWeight = FontWeight.Medium,
-        style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.wrapContentSize(),
+          text = SIGN_UP_WITH_GOOGLE,
+          fontWeight = FontWeight.Medium,
+          style = MaterialTheme.typography.bodyMedium,
       )
     }
   }
@@ -246,11 +250,11 @@ fun AuthenticationGoogleButton(
  * @return A lambda function to be called on button click.
  */
 private fun attemptSignIn(
-  emailState: TextFieldState,
-  passwordState: TextFieldState,
-  authenticationViewModel: AuthenticationViewModel,
-  context: Context,
-  navigationActions: NavigationActions,
+    emailState: TextFieldState,
+    passwordState: TextFieldState,
+    authenticationViewModel: AuthenticationViewModel,
+    context: Context,
+    navigationActions: NavigationActions,
 ) {
   if (!emailState.validate() || !passwordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
@@ -258,19 +262,19 @@ private fun attemptSignIn(
   }
 
   authenticationViewModel.logInWithEmail(
-    userEmail = emailState.value,
-    userPassword = passwordState.value,
-    onSuccess = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-      }
-      navigationActions.navigateTo(Screen.PROFILE)
-    },
-    onFailure = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-      }
-    },
+      userEmail = emailState.value,
+      userPassword = passwordState.value,
+      onSuccess = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
+        navigationActions.navigateTo(Screen.PROFILE)
+      },
+      onFailure = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
+      },
   )
 }
 
@@ -284,10 +288,10 @@ private fun attemptSignIn(
  * @return A lambda function to be called on button click.
  */
 private fun attemptAuthenticateWithGoogle(
-  context: Context,
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
-  coroutineScope: CoroutineScope,
+    context: Context,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
+    coroutineScope: CoroutineScope,
 ) {
   // Create a CredentialManager instance
   val credentialManager = CredentialManager.create(context)
@@ -296,15 +300,15 @@ private fun attemptAuthenticateWithGoogle(
 
   // Configure Google ID option
   val googleIdOption: GetGoogleIdOption =
-    GetGoogleIdOption.Builder()
-      .setFilterByAuthorizedAccounts(false)
-      .setServerClientId(context.getString(R.string.google_client_id))
-      .setNonce(authenticationViewModel.generateHashCode(rawNonce))
-      .build()
+      GetGoogleIdOption.Builder()
+          .setFilterByAuthorizedAccounts(false)
+          .setServerClientId(context.getString(R.string.google_client_id))
+          .setNonce(authenticationViewModel.generateHashCode(rawNonce))
+          .build()
 
   // Create a GetCredentialRequest
   val request: GetCredentialRequest =
-    GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+      GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
 
   // Retrieve the credential
   coroutineScope.launch {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -60,7 +60,7 @@ import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-private const val DEFAULT_PASSWORD_VISIBILITY = false
+private const val DEFAULT_IS_PASSWORD_VISIBLE = false
 
 private const val SIGN_IN_INSTRUCTION = "Sign in to your account"
 private const val SIGN_IN_BUTTON_TEXT = "Sign in"
@@ -89,7 +89,7 @@ fun SignInScreen(
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
       formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
-  var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBILITY) }
+  var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
 
@@ -129,8 +129,8 @@ fun SignInScreen(
         AuthenticationPasswordInput(
             password = passwordState.value,
             onPasswordChange = { passwordState.change(it) },
-            passwordVisible = passwordVisible,
-            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordVisible = isPasswordVisible,
+            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
             passwordErrorMessage = passwordState.errorMessage,
         )
 
@@ -240,10 +240,8 @@ fun AuthenticationGoogleButton(
 /**
  * Attempts to sign in the user with the provided email and password.
  *
- * @param email The email entered by the user.
- * @param setEmailErrorMessage A function to set the error message for the email field.
+ * @param emailState The email entered by the user.
  * @param passwordState The password entered by the user.
- * @param setPasswordErrorMessage A function to set the error message for the password field.
  * @param authenticationViewModel The ViewModel that handles authentication logic.
  * @param context The context used to show Toast messages.
  * @param navigationActions The navigation actions to navigate between screens.

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -52,17 +52,14 @@ import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
+import com.dsc.form_builder.TextFieldState
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
-import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.util.UUID
 
-private const val DEFAULT_PASSWORD = ""
-private const val DEFAULT_EMAIL = ""
-private const val DEFAULT_EMAIL_INVALID_MESSAGE = ""
-private const val DEFAULT_PASSWORD_INVALID_MESSAGE = ""
 private const val DEFAULT_PASSWORD_VISIBILITY = false
 
 private const val SIGN_IN_INSTRUCTION = "Sign in to your account"
@@ -76,10 +73,6 @@ private const val SUCCESSFUL_SIGN_IN_TOAST = "Login Successful"
 private const val FAILED_SIGN_IN_TOAST = "Login Failed"
 private const val INVALID_ATTEMPT_TOAST = "Invalid email or password."
 
-private const val NO_AT_EMAIL_ERROR_MESSAGE = "Email must contain @"
-private const val EMPTY_EMAIL_ERROR_MESSAGE = "Email cannot be empty"
-private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
-
 /**
  * Composable function that displays the Sign In screen.
  *
@@ -88,16 +81,14 @@ private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
  */
 @Composable
 fun SignInScreen(
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
-  var email by remember { mutableStateOf(DEFAULT_EMAIL) }
-  var password by remember { mutableStateOf(DEFAULT_PASSWORD) }
-  val (emailErrorMessage, setEmailErrorMessage) =
-      remember { mutableStateOf(DEFAULT_EMAIL_INVALID_MESSAGE) }
-  val (passwordErrorMessage, setPasswordErrorMessage) =
-      remember { mutableStateOf(DEFAULT_PASSWORD_INVALID_MESSAGE) }
+  val formState = remember { authenticationViewModel.formState }
+  val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
+  val passwordState =
+    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
   var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBILITY) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
@@ -106,94 +97,88 @@ fun SignInScreen(
     GradedBackground()
 
     Column(
-        modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3,
-                )
-                .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+      modifier =
+        Modifier.fillMaxSize()
+          .padding(paddingValues)
+          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
+          .verticalScroll(rememberScrollState()),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-            modifier =
-                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
-            text = SIGN_IN_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
+          text = SIGN_IN_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-            email = email,
-            onEmailChange = { email = it },
-            emailErrorMessage = emailErrorMessage,
+          email = emailState.value,
+          onEmailChange = { emailState.change(it) },
+          emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-            password = password,
-            onPasswordChange = { password = it },
-            passwordVisible = passwordVisible,
-            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-            passwordErrorMessage = passwordErrorMessage,
+          password = passwordState.value,
+          onPasswordChange = { passwordState.change(it) },
+          passwordVisible = passwordVisible,
+          onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+          passwordErrorMessage = passwordState.errorMessage,
         )
 
         AuthenticationSubmitButton(
-            text = SIGN_IN_BUTTON_TEXT,
-            onClick = {
-              attemptSignIn(
-                  email = email,
-                  setEmailErrorMessage = setEmailErrorMessage,
-                  password = password,
-                  setPasswordErrorMessage = setPasswordErrorMessage,
-                  authenticationViewModel = authenticationViewModel,
-                  context = context,
-                  navigationActions = navigationActions,
-              )
-            },
-            testTag = SignInScreen.SIGN_IN_BUTTON,
+          text = SIGN_IN_BUTTON_TEXT,
+          onClick = {
+            attemptSignIn(
+              emailState = emailState,
+              passwordState = passwordState,
+              authenticationViewModel = authenticationViewModel,
+              context = context,
+              navigationActions = navigationActions,
+            )
+          },
+          testTag = SignInScreen.SIGN_IN_BUTTON,
         )
 
         Text(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(SignInScreen.CONTINUE_WITH_TEXT),
-            text = CONTINUE_WITH_TEXT,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.CONTINUE_WITH_TEXT),
+          text = CONTINUE_WITH_TEXT,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
       Row(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          horizontalArrangement = Arrangement.Center,
-          verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
       ) {
         Text(
-            modifier = Modifier.wrapContentSize(),
-            text = NO_ACCOUNT_TEXT,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium)
+          modifier = Modifier.wrapContentSize(),
+          text = NO_ACCOUNT_TEXT,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+          style = MaterialTheme.typography.bodyMedium,
+        )
 
         Text(
-            modifier =
-                Modifier.wrapContentSize()
-                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-            text = SIGN_UP_TEXT,
-            textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium,
+          modifier =
+            Modifier.wrapContentSize()
+              .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+              .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+          text = SIGN_UP_TEXT,
+          textDecoration = TextDecoration.Underline,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+          style = MaterialTheme.typography.bodyMedium,
         )
       }
     }
@@ -209,39 +194,40 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(
-    context: Context,
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
-    modifier: Modifier = Modifier
+  context: Context,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
+  modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   Button(
-      modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
-      onClick = {
-        attemptAuthenticateWithGoogle(
-            context = context,
-            authenticationViewModel = authenticationViewModel,
-            navigationActions = navigationActions,
-            coroutineScope = coroutineScope)
-      },
-      colors = getFilledPrimaryContainerButtonColors(),
+    modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
+    onClick = {
+      attemptAuthenticateWithGoogle(
+        context = context,
+        authenticationViewModel = authenticationViewModel,
+        navigationActions = navigationActions,
+        coroutineScope = coroutineScope,
+      )
+    },
+    colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Row(
-        modifier = Modifier.wrapContentSize(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
+      modifier = Modifier.wrapContentSize(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
     ) {
       Image(
-          painter = painterResource(id = R.drawable.google_logo),
-          contentDescription = "Google Logo",
-          modifier = Modifier.size(MaterialTheme.dimens.iconSize),
+        painter = painterResource(id = R.drawable.google_logo),
+        contentDescription = "Google Logo",
+        modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
       Text(
-          modifier = Modifier.wrapContentSize(),
-          text = SIGN_UP_WITH_GOOGLE,
-          fontWeight = FontWeight.Medium,
-          style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.wrapContentSize(),
+        text = SIGN_UP_WITH_GOOGLE,
+        fontWeight = FontWeight.Medium,
+        style = MaterialTheme.typography.bodyMedium,
       )
     }
   }
@@ -252,7 +238,7 @@ fun AuthenticationGoogleButton(
  *
  * @param email The email entered by the user.
  * @param setEmailErrorMessage A function to set the error message for the email field.
- * @param password The password entered by the user.
+ * @param passwordState The password entered by the user.
  * @param setPasswordErrorMessage A function to set the error message for the password field.
  * @param authenticationViewModel The ViewModel that handles authentication logic.
  * @param context The context used to show Toast messages.
@@ -260,80 +246,32 @@ fun AuthenticationGoogleButton(
  * @return A lambda function to be called on button click.
  */
 private fun attemptSignIn(
-    email: String,
-    setEmailErrorMessage: (String) -> Unit,
-    password: String,
-    setPasswordErrorMessage: (String) -> Unit,
-    authenticationViewModel: AuthenticationViewModel,
-    context: Context,
-    navigationActions: NavigationActions,
+  emailState: TextFieldState,
+  passwordState: TextFieldState,
+  authenticationViewModel: AuthenticationViewModel,
+  context: Context,
+  navigationActions: NavigationActions,
 ) {
-  val isEmailValid = isEmailValid(email, setEmailErrorMessage)
-  val isPasswordValid = isPasswordValid(password, setPasswordErrorMessage)
-
-  if (!isEmailValid || !isPasswordValid) {
+  if (!emailState.validate() || !passwordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
     return
   }
 
   authenticationViewModel.logInWithEmail(
-      userEmail = email,
-      userPassword = password,
-      onSuccess = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-        }
-        navigationActions.navigateTo(Screen.PROFILE)
-      },
-      onFailure = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-        }
-      })
-}
-
-/**
- * Validates the email and returns an error message if the email is invalid.
- *
- * @param email The email to validate.
- * @param setErrorMessage A function to set the error message for the email field.
- * @return True if the email is valid, false otherwise.
- */
-private fun isEmailValid(email: String, setErrorMessage: (String) -> Unit): Boolean {
-  return when {
-    email.isEmpty() -> {
-      setErrorMessage(EMPTY_EMAIL_ERROR_MESSAGE)
-      false
-    }
-    !email.contains("@") -> {
-      setErrorMessage(NO_AT_EMAIL_ERROR_MESSAGE)
-      false
-    }
-    else -> {
-      setErrorMessage(DEFAULT_EMAIL_INVALID_MESSAGE)
-      true
-    }
-  }
-}
-
-/**
- * Validates the password and returns an error message if the password is invalid.
- *
- * @param password The password to validate.
- * @param setErrorMessage A function to set the error message for the password field.
- * @return True if the password is valid, false otherwise.
- */
-private fun isPasswordValid(password: String, setErrorMessage: (String) -> Unit): Boolean {
-  return when {
-    password.isEmpty() -> {
-      setErrorMessage(EMPTY_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    else -> {
-      setErrorMessage(DEFAULT_PASSWORD_INVALID_MESSAGE)
-      true
-    }
-  }
+    userEmail = emailState.value,
+    userPassword = passwordState.value,
+    onSuccess = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+      }
+      navigationActions.navigateTo(Screen.PROFILE)
+    },
+    onFailure = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+      }
+    },
+  )
 }
 
 /**
@@ -346,10 +284,10 @@ private fun isPasswordValid(password: String, setErrorMessage: (String) -> Unit)
  * @return A lambda function to be called on button click.
  */
 private fun attemptAuthenticateWithGoogle(
-    context: Context,
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
-    coroutineScope: CoroutineScope
+  context: Context,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
+  coroutineScope: CoroutineScope,
 ) {
   // Create a CredentialManager instance
   val credentialManager = CredentialManager.create(context)
@@ -358,15 +296,15 @@ private fun attemptAuthenticateWithGoogle(
 
   // Configure Google ID option
   val googleIdOption: GetGoogleIdOption =
-      GetGoogleIdOption.Builder()
-          .setFilterByAuthorizedAccounts(false)
-          .setServerClientId(context.getString(R.string.google_client_id))
-          .setNonce(authenticationViewModel.generateHashCode(rawNonce))
-          .build()
+    GetGoogleIdOption.Builder()
+      .setFilterByAuthorizedAccounts(false)
+      .setServerClientId(context.getString(R.string.google_client_id))
+      .setNonce(authenticationViewModel.generateHashCode(rawNonce))
+      .build()
 
   // Create a GetCredentialRequest
   val request: GetCredentialRequest =
-      GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+    GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
 
   // Retrieve the credential
   coroutineScope.launch {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -56,9 +56,9 @@ import com.dsc.form_builder.TextFieldState
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import java.util.UUID
 
 private const val DEFAULT_PASSWORD_VISIBILITY = false
 
@@ -81,14 +81,14 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password."
  */
 @Composable
 fun SignInScreen(
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
   var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBILITY) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
@@ -97,88 +97,92 @@ fun SignInScreen(
     GradedBackground()
 
     Column(
-      modifier =
-        Modifier.fillMaxSize()
-          .padding(paddingValues)
-          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
-          .verticalScroll(rememberScrollState()),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.large,
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
-          text = SIGN_IN_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
+            text = SIGN_IN_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-          email = emailState.value,
-          onEmailChange = { emailState.change(it) },
-          emailErrorMessage = emailState.errorMessage,
+            email = emailState.value,
+            onEmailChange = { emailState.change(it) },
+            emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-          password = passwordState.value,
-          onPasswordChange = { passwordState.change(it) },
-          passwordVisible = passwordVisible,
-          onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-          passwordErrorMessage = passwordState.errorMessage,
+            password = passwordState.value,
+            onPasswordChange = { passwordState.change(it) },
+            passwordVisible = passwordVisible,
+            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordErrorMessage = passwordState.errorMessage,
         )
 
         AuthenticationSubmitButton(
-          text = SIGN_IN_BUTTON_TEXT,
-          onClick = {
-            attemptSignIn(
-              emailState = emailState,
-              passwordState = passwordState,
-              authenticationViewModel = authenticationViewModel,
-              context = context,
-              navigationActions = navigationActions,
-            )
-          },
-          testTag = SignInScreen.SIGN_IN_BUTTON,
+            text = SIGN_IN_BUTTON_TEXT,
+            onClick = {
+              attemptSignIn(
+                  emailState = emailState,
+                  passwordState = passwordState,
+                  authenticationViewModel = authenticationViewModel,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignInScreen.SIGN_IN_BUTTON,
         )
 
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.CONTINUE_WITH_TEXT),
-          text = CONTINUE_WITH_TEXT,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(SignInScreen.CONTINUE_WITH_TEXT),
+            text = CONTINUE_WITH_TEXT,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
       Row(
-        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+          horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
       ) {
         Text(
-          modifier = Modifier.wrapContentSize(),
-          text = NO_ACCOUNT_TEXT,
-          color = MaterialTheme.colorScheme.onSecondaryContainer,
-          style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.wrapContentSize(),
+            text = NO_ACCOUNT_TEXT,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodyMedium,
         )
 
         Text(
-          modifier =
-            Modifier.wrapContentSize()
-              .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-              .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-          text = SIGN_UP_TEXT,
-          textDecoration = TextDecoration.Underline,
-          color = MaterialTheme.colorScheme.onSecondaryContainer,
-          style = MaterialTheme.typography.bodyMedium,
+            modifier =
+                Modifier.wrapContentSize()
+                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+            text = SIGN_UP_TEXT,
+            textDecoration = TextDecoration.Underline,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            style = MaterialTheme.typography.bodyMedium,
         )
       }
     }
@@ -194,40 +198,40 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(
-  context: Context,
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
-  modifier: Modifier = Modifier,
+    context: Context,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
+    modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   Button(
-    modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
-    onClick = {
-      attemptAuthenticateWithGoogle(
-        context = context,
-        authenticationViewModel = authenticationViewModel,
-        navigationActions = navigationActions,
-        coroutineScope = coroutineScope,
-      )
-    },
-    colors = getFilledPrimaryContainerButtonColors(),
+      modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
+      onClick = {
+        attemptAuthenticateWithGoogle(
+            context = context,
+            authenticationViewModel = authenticationViewModel,
+            navigationActions = navigationActions,
+            coroutineScope = coroutineScope,
+        )
+      },
+      colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Row(
-      modifier = Modifier.wrapContentSize(),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
+        modifier = Modifier.wrapContentSize(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
     ) {
       Image(
-        painter = painterResource(id = R.drawable.google_logo),
-        contentDescription = "Google Logo",
-        modifier = Modifier.size(MaterialTheme.dimens.iconSize),
+          painter = painterResource(id = R.drawable.google_logo),
+          contentDescription = "Google Logo",
+          modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
       Text(
-        modifier = Modifier.wrapContentSize(),
-        text = SIGN_UP_WITH_GOOGLE,
-        fontWeight = FontWeight.Medium,
-        style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.wrapContentSize(),
+          text = SIGN_UP_WITH_GOOGLE,
+          fontWeight = FontWeight.Medium,
+          style = MaterialTheme.typography.bodyMedium,
       )
     }
   }
@@ -246,11 +250,11 @@ fun AuthenticationGoogleButton(
  * @return A lambda function to be called on button click.
  */
 private fun attemptSignIn(
-  emailState: TextFieldState,
-  passwordState: TextFieldState,
-  authenticationViewModel: AuthenticationViewModel,
-  context: Context,
-  navigationActions: NavigationActions,
+    emailState: TextFieldState,
+    passwordState: TextFieldState,
+    authenticationViewModel: AuthenticationViewModel,
+    context: Context,
+    navigationActions: NavigationActions,
 ) {
   if (!emailState.validate() || !passwordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
@@ -258,19 +262,19 @@ private fun attemptSignIn(
   }
 
   authenticationViewModel.logInWithEmail(
-    userEmail = emailState.value,
-    userPassword = passwordState.value,
-    onSuccess = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-      }
-      navigationActions.navigateTo(Screen.PROFILE)
-    },
-    onFailure = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-      }
-    },
+      userEmail = emailState.value,
+      userPassword = passwordState.value,
+      onSuccess = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
+        navigationActions.navigateTo(Screen.PROFILE)
+      },
+      onFailure = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+        }
+      },
   )
 }
 
@@ -284,10 +288,10 @@ private fun attemptSignIn(
  * @return A lambda function to be called on button click.
  */
 private fun attemptAuthenticateWithGoogle(
-  context: Context,
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
-  coroutineScope: CoroutineScope,
+    context: Context,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
+    coroutineScope: CoroutineScope,
 ) {
   // Create a CredentialManager instance
   val credentialManager = CredentialManager.create(context)
@@ -296,15 +300,15 @@ private fun attemptAuthenticateWithGoogle(
 
   // Configure Google ID option
   val googleIdOption: GetGoogleIdOption =
-    GetGoogleIdOption.Builder()
-      .setFilterByAuthorizedAccounts(false)
-      .setServerClientId(context.getString(R.string.google_client_id))
-      .setNonce(authenticationViewModel.generateHashCode(rawNonce))
-      .build()
+      GetGoogleIdOption.Builder()
+          .setFilterByAuthorizedAccounts(false)
+          .setServerClientId(context.getString(R.string.google_client_id))
+          .setNonce(authenticationViewModel.generateHashCode(rawNonce))
+          .build()
 
   // Create a GetCredentialRequest
   val request: GetCredentialRequest =
-    GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+      GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
 
   // Retrieve the credential
   coroutineScope.launch {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -56,9 +56,9 @@ import com.dsc.form_builder.TextFieldState
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
-import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 private const val DEFAULT_IS_PASSWORD_VISIBLE = false
 
@@ -81,14 +81,16 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password."
  */
 @Composable
 fun SignInScreen(
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
+  formState.reset()
+
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
   var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
@@ -97,92 +99,88 @@ fun SignInScreen(
     GradedBackground()
 
     Column(
-        modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3)
-                .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+      modifier =
+        Modifier.fillMaxSize()
+          .padding(paddingValues)
+          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
+          .verticalScroll(rememberScrollState()),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-            modifier =
-                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
-            text = SIGN_IN_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.INSTRUCTION_TEXT),
+          text = SIGN_IN_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-            email = emailState.value,
-            onEmailChange = { emailState.change(it) },
-            emailErrorMessage = emailState.errorMessage,
+          email = emailState.value,
+          onEmailChange = { emailState.change(it) },
+          emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-            password = passwordState.value,
-            onPasswordChange = { passwordState.change(it) },
-            passwordVisible = isPasswordVisible,
-            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
-            passwordErrorMessage = passwordState.errorMessage,
+          password = passwordState.value,
+          onPasswordChange = { passwordState.change(it) },
+          passwordVisible = isPasswordVisible,
+          onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
+          passwordErrorMessage = passwordState.errorMessage,
         )
 
         AuthenticationSubmitButton(
-            text = SIGN_IN_BUTTON_TEXT,
-            onClick = {
-              attemptSignIn(
-                  emailState = emailState,
-                  passwordState = passwordState,
-                  authenticationViewModel = authenticationViewModel,
-                  context = context,
-                  navigationActions = navigationActions,
-              )
-            },
-            testTag = SignInScreen.SIGN_IN_BUTTON,
+          text = SIGN_IN_BUTTON_TEXT,
+          onClick = {
+            attemptSignIn(
+              emailState = emailState,
+              passwordState = passwordState,
+              authenticationViewModel = authenticationViewModel,
+              context = context,
+              navigationActions = navigationActions,
+            )
+          },
+          testTag = SignInScreen.SIGN_IN_BUTTON,
         )
 
         Text(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(SignInScreen.CONTINUE_WITH_TEXT),
-            text = CONTINUE_WITH_TEXT,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignInScreen.CONTINUE_WITH_TEXT),
+          text = CONTINUE_WITH_TEXT,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
       Row(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          horizontalArrangement = Arrangement.Center,
-          verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
       ) {
         Text(
-            modifier = Modifier.wrapContentSize(),
-            text = NO_ACCOUNT_TEXT,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium,
+          modifier = Modifier.wrapContentSize(),
+          text = NO_ACCOUNT_TEXT,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+          style = MaterialTheme.typography.bodyMedium,
         )
 
         Text(
-            modifier =
-                Modifier.wrapContentSize()
-                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-            text = SIGN_UP_TEXT,
-            textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium,
+          modifier =
+            Modifier.wrapContentSize()
+              .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
+              .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
+          text = SIGN_UP_TEXT,
+          textDecoration = TextDecoration.Underline,
+          color = MaterialTheme.colorScheme.onSecondaryContainer,
+          style = MaterialTheme.typography.bodyMedium,
         )
       }
     }
@@ -198,40 +196,40 @@ fun SignInScreen(
  */
 @Composable
 fun AuthenticationGoogleButton(
-    context: Context,
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
-    modifier: Modifier = Modifier,
+  context: Context,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
+  modifier: Modifier = Modifier,
 ) {
   val coroutineScope = rememberCoroutineScope()
   Button(
-      modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
-      onClick = {
-        attemptAuthenticateWithGoogle(
-            context = context,
-            authenticationViewModel = authenticationViewModel,
-            navigationActions = navigationActions,
-            coroutineScope = coroutineScope,
-        )
-      },
-      colors = getFilledPrimaryContainerButtonColors(),
+    modifier = modifier.wrapContentSize().testTag(SignInScreen.GOOGLE_BUTTON),
+    onClick = {
+      attemptAuthenticateWithGoogle(
+        context = context,
+        authenticationViewModel = authenticationViewModel,
+        navigationActions = navigationActions,
+        coroutineScope = coroutineScope,
+      )
+    },
+    colors = getFilledPrimaryContainerButtonColors(),
   ) {
     Row(
-        modifier = Modifier.wrapContentSize(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
+      modifier = Modifier.wrapContentSize(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.small2, Alignment.CenterHorizontally),
     ) {
       Image(
-          painter = painterResource(id = R.drawable.google_logo),
-          contentDescription = "Google Logo",
-          modifier = Modifier.size(MaterialTheme.dimens.iconSize),
+        painter = painterResource(id = R.drawable.google_logo),
+        contentDescription = "Google Logo",
+        modifier = Modifier.size(MaterialTheme.dimens.iconSize),
       )
       Text(
-          modifier = Modifier.wrapContentSize(),
-          text = SIGN_UP_WITH_GOOGLE,
-          fontWeight = FontWeight.Medium,
-          style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.wrapContentSize(),
+        text = SIGN_UP_WITH_GOOGLE,
+        fontWeight = FontWeight.Medium,
+        style = MaterialTheme.typography.bodyMedium,
       )
     }
   }
@@ -248,11 +246,11 @@ fun AuthenticationGoogleButton(
  * @return A lambda function to be called on button click.
  */
 private fun attemptSignIn(
-    emailState: TextFieldState,
-    passwordState: TextFieldState,
-    authenticationViewModel: AuthenticationViewModel,
-    context: Context,
-    navigationActions: NavigationActions,
+  emailState: TextFieldState,
+  passwordState: TextFieldState,
+  authenticationViewModel: AuthenticationViewModel,
+  context: Context,
+  navigationActions: NavigationActions,
 ) {
   if (!emailState.validate() || !passwordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
@@ -260,19 +258,19 @@ private fun attemptSignIn(
   }
 
   authenticationViewModel.logInWithEmail(
-      userEmail = emailState.value,
-      userPassword = passwordState.value,
-      onSuccess = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-        }
-        navigationActions.navigateTo(Screen.PROFILE)
-      },
-      onFailure = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
-        }
-      },
+    userEmail = emailState.value,
+    userPassword = passwordState.value,
+    onSuccess = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+      }
+      navigationActions.navigateTo(Screen.PROFILE)
+    },
+    onFailure = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, FAILED_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
+      }
+    },
   )
 }
 
@@ -286,10 +284,10 @@ private fun attemptSignIn(
  * @return A lambda function to be called on button click.
  */
 private fun attemptAuthenticateWithGoogle(
-    context: Context,
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
-    coroutineScope: CoroutineScope,
+  context: Context,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
+  coroutineScope: CoroutineScope,
 ) {
   // Create a CredentialManager instance
   val credentialManager = CredentialManager.create(context)
@@ -298,15 +296,15 @@ private fun attemptAuthenticateWithGoogle(
 
   // Configure Google ID option
   val googleIdOption: GetGoogleIdOption =
-      GetGoogleIdOption.Builder()
-          .setFilterByAuthorizedAccounts(false)
-          .setServerClientId(context.getString(R.string.google_client_id))
-          .setNonce(authenticationViewModel.generateHashCode(rawNonce))
-          .build()
+    GetGoogleIdOption.Builder()
+      .setFilterByAuthorizedAccounts(false)
+      .setServerClientId(context.getString(R.string.google_client_id))
+      .setNonce(authenticationViewModel.generateHashCode(rawNonce))
+      .build()
 
   // Create a GetCredentialRequest
   val request: GetCredentialRequest =
-      GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
+    GetCredentialRequest.Builder().addCredentialOption(googleIdOption).build()
 
   // Retrieve the credential
   coroutineScope.launch {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -39,8 +39,7 @@ import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
 import com.dsc.form_builder.TextFieldState
 
-private const val DEFAULT_PASSWORD_VISIBLE = false
-private const val DEFAULT_CONFIRMED_PASSWORD_VISIBLE = false
+private const val DEFAULT_IS_PASSWORD_VISIBLE = false
 
 private const val SIGN_UP_INSTRUCTION = "Create your account"
 private const val CONFIRM_PASSWORD_INSTRUCTION = "Confirm your password"
@@ -70,8 +69,8 @@ fun SignUpScreen(
       formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
   val confirmPasswordState =
       formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
-  var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBLE) }
-  var confirmedPasswordVisible by remember { mutableStateOf(DEFAULT_CONFIRMED_PASSWORD_VISIBLE) }
+  var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
+  var isConfirmedPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
   LaunchedEffect(Unit) { authenticationViewModel.isUserLoggedIn() }
 
@@ -111,8 +110,8 @@ fun SignUpScreen(
         AuthenticationPasswordInput(
             password = passwordState.value,
             onPasswordChange = { passwordState.change(it) },
-            passwordVisible = passwordVisible,
-            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordVisible = isPasswordVisible,
+            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
             passwordErrorMessage = passwordState.errorMessage,
         )
 
@@ -130,8 +129,10 @@ fun SignUpScreen(
         AuthenticationPasswordInput(
             password = confirmPasswordState.value,
             onPasswordChange = { confirmPasswordState.change(it) },
-            passwordVisible = confirmedPasswordVisible,
-            onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
+            passwordVisible = isConfirmedPasswordVisible,
+            onPasswordVisibilityChange = {
+              isConfirmedPasswordVisible = !isConfirmedPasswordVisible
+            },
             passwordErrorMessage = confirmPasswordState.errorMessage,
             passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
             testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
@@ -163,10 +164,6 @@ fun SignUpScreen(
  * @param emailState The email entered by the user.
  * @param passwordState The password entered by the user.
  * @param confirmPasswordState The confirmed password entered by the user.
- * @param setEmailErrorMessage A function to set the error message for the email field.
- * @param setPasswordErrorMessage A function to set the error message for the password field.
- * @param setConfirmedPasswordErrorMessage A function to set the error message for the confirmed
- *   password field.
  * @param authenticationViewModel The ViewModel that handles authentication logic.
  * @param context The context used to show Toast messages.
  * @param navigationActions The navigation actions to navigate between screens.

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -59,16 +59,18 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password"
  */
 @Composable
 fun SignUpScreen(
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
+  formState.reset()
+
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
+    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
   val confirmPasswordState =
-      formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
+    formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
   var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
   var isConfirmedPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
@@ -78,80 +80,74 @@ fun SignUpScreen(
     GradedBackground()
 
     Column(
-        modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3)
-                .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+      modifier =
+        Modifier.fillMaxSize()
+          .padding(paddingValues)
+          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
+          .verticalScroll(rememberScrollState()),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-            modifier =
-                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
-            text = SIGN_UP_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
+          text = SIGN_UP_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-            email = emailState.value,
-            onEmailChange = { emailState.change(it) },
-            emailErrorMessage = emailState.errorMessage,
+          email = emailState.value,
+          onEmailChange = { emailState.change(it) },
+          emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-            password = passwordState.value,
-            onPasswordChange = { passwordState.change(it) },
-            passwordVisible = isPasswordVisible,
-            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
-            passwordErrorMessage = passwordState.errorMessage,
+          password = passwordState.value,
+          onPasswordChange = { passwordState.change(it) },
+          passwordVisible = isPasswordVisible,
+          onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
+          passwordErrorMessage = passwordState.errorMessage,
         )
 
         Text(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-            text = CONFIRM_PASSWORD_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+          text = CONFIRM_PASSWORD_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationPasswordInput(
-            password = confirmPasswordState.value,
-            onPasswordChange = { confirmPasswordState.change(it) },
-            passwordVisible = isConfirmedPasswordVisible,
-            onPasswordVisibilityChange = {
-              isConfirmedPasswordVisible = !isConfirmedPasswordVisible
-            },
-            passwordErrorMessage = confirmPasswordState.errorMessage,
-            passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-            testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-            visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+          password = confirmPasswordState.value,
+          onPasswordChange = { confirmPasswordState.change(it) },
+          passwordVisible = isConfirmedPasswordVisible,
+          onPasswordVisibilityChange = { isConfirmedPasswordVisible = !isConfirmedPasswordVisible },
+          passwordErrorMessage = confirmPasswordState.errorMessage,
+          passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+          testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+          visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
         )
 
         AuthenticationSubmitButton(
-            text = SIGN_UP_BUTTON_TEXT,
-            onClick = {
-              attemptSignUp(
-                  emailState = emailState,
-                  passwordState = passwordState,
-                  confirmPasswordState = confirmPasswordState,
-                  authenticationViewModel = authenticationViewModel,
-                  context = context,
-                  navigationActions = navigationActions,
-              )
-            },
-            testTag = SignUpScreen.SIGN_UP_BUTTON,
+          text = SIGN_UP_BUTTON_TEXT,
+          onClick = {
+            attemptSignUp(
+              emailState = emailState,
+              passwordState = passwordState,
+              confirmPasswordState = confirmPasswordState,
+              authenticationViewModel = authenticationViewModel,
+              context = context,
+              navigationActions = navigationActions,
+            )
+          },
+          testTag = SignUpScreen.SIGN_UP_BUTTON,
         )
       }
     }
@@ -169,12 +165,12 @@ fun SignUpScreen(
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSignUp(
-    emailState: TextFieldState,
-    passwordState: TextFieldState,
-    confirmPasswordState: TextFieldState,
-    authenticationViewModel: AuthenticationViewModel,
-    context: Context,
-    navigationActions: NavigationActions,
+  emailState: TextFieldState,
+  passwordState: TextFieldState,
+  confirmPasswordState: TextFieldState,
+  authenticationViewModel: AuthenticationViewModel,
+  context: Context,
+  navigationActions: NavigationActions,
 ) {
   // strange if statements, but necessary to show the proper error messages
   if (!emailState.validate() || !passwordState.validate()) {
@@ -188,18 +184,18 @@ private fun attemptSignUp(
   }
 
   authenticationViewModel.signUpWithEmail(
-      userEmail = emailState.value,
-      userPassword = passwordState.value,
-      onSuccess = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-        }
-        navigationActions.navigateTo(Screen.CREATE_PROFILE)
-      },
-      onFailure = { _: Exception ->
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-        }
-      },
+    userEmail = emailState.value,
+    userPassword = passwordState.value,
+    onSuccess = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+      }
+      navigationActions.navigateTo(Screen.CREATE_PROFILE)
+    },
+    onFailure = { _: Exception ->
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+      }
+    },
   )
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -59,8 +59,8 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password"
  */
 @Composable
 fun SignUpScreen(
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
@@ -68,9 +68,9 @@ fun SignUpScreen(
 
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
   val confirmPasswordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
   var isPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
   var isConfirmedPasswordVisible by remember { mutableStateOf(DEFAULT_IS_PASSWORD_VISIBLE) }
 
@@ -80,74 +80,80 @@ fun SignUpScreen(
     GradedBackground()
 
     Column(
-      modifier =
-        Modifier.fillMaxSize()
-          .padding(paddingValues)
-          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
-          .verticalScroll(rememberScrollState()),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.large,
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
-          text = SIGN_UP_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
+            text = SIGN_UP_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-          email = emailState.value,
-          onEmailChange = { emailState.change(it) },
-          emailErrorMessage = emailState.errorMessage,
+            email = emailState.value,
+            onEmailChange = { emailState.change(it) },
+            emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-          password = passwordState.value,
-          onPasswordChange = { passwordState.change(it) },
-          passwordVisible = isPasswordVisible,
-          onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
-          passwordErrorMessage = passwordState.errorMessage,
+            password = passwordState.value,
+            onPasswordChange = { passwordState.change(it) },
+            passwordVisible = isPasswordVisible,
+            onPasswordVisibilityChange = { isPasswordVisible = !isPasswordVisible },
+            passwordErrorMessage = passwordState.errorMessage,
         )
 
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-          text = CONFIRM_PASSWORD_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+            text = CONFIRM_PASSWORD_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationPasswordInput(
-          password = confirmPasswordState.value,
-          onPasswordChange = { confirmPasswordState.change(it) },
-          passwordVisible = isConfirmedPasswordVisible,
-          onPasswordVisibilityChange = { isConfirmedPasswordVisible = !isConfirmedPasswordVisible },
-          passwordErrorMessage = confirmPasswordState.errorMessage,
-          passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-          testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-          visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+            password = confirmPasswordState.value,
+            onPasswordChange = { confirmPasswordState.change(it) },
+            passwordVisible = isConfirmedPasswordVisible,
+            onPasswordVisibilityChange = {
+              isConfirmedPasswordVisible = !isConfirmedPasswordVisible
+            },
+            passwordErrorMessage = confirmPasswordState.errorMessage,
+            passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+            testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+            visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
         )
 
         AuthenticationSubmitButton(
-          text = SIGN_UP_BUTTON_TEXT,
-          onClick = {
-            attemptSignUp(
-              emailState = emailState,
-              passwordState = passwordState,
-              confirmPasswordState = confirmPasswordState,
-              authenticationViewModel = authenticationViewModel,
-              context = context,
-              navigationActions = navigationActions,
-            )
-          },
-          testTag = SignUpScreen.SIGN_UP_BUTTON,
+            text = SIGN_UP_BUTTON_TEXT,
+            onClick = {
+              attemptSignUp(
+                  emailState = emailState,
+                  passwordState = passwordState,
+                  confirmPasswordState = confirmPasswordState,
+                  authenticationViewModel = authenticationViewModel,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignUpScreen.SIGN_UP_BUTTON,
         )
       }
     }
@@ -165,12 +171,12 @@ fun SignUpScreen(
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSignUp(
-  emailState: TextFieldState,
-  passwordState: TextFieldState,
-  confirmPasswordState: TextFieldState,
-  authenticationViewModel: AuthenticationViewModel,
-  context: Context,
-  navigationActions: NavigationActions,
+    emailState: TextFieldState,
+    passwordState: TextFieldState,
+    confirmPasswordState: TextFieldState,
+    authenticationViewModel: AuthenticationViewModel,
+    context: Context,
+    navigationActions: NavigationActions,
 ) {
   // strange if statements, but necessary to show the proper error messages
   if (!emailState.validate() || !passwordState.validate()) {
@@ -184,18 +190,18 @@ private fun attemptSignUp(
   }
 
   authenticationViewModel.signUpWithEmail(
-    userEmail = emailState.value,
-    userPassword = passwordState.value,
-    onSuccess = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-      }
-      navigationActions.navigateTo(Screen.CREATE_PROFILE)
-    },
-    onFailure = { _: Exception ->
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-      }
-    },
+      userEmail = emailState.value,
+      userPassword = passwordState.value,
+      onSuccess = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
+        navigationActions.navigateTo(Screen.CREATE_PROFILE)
+      },
+      onFailure = { _: Exception ->
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
+      },
   )
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -60,16 +60,16 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password"
  */
 @Composable
 fun SignUpScreen(
-  authenticationViewModel: AuthenticationViewModel,
-  navigationActions: NavigationActions,
+    authenticationViewModel: AuthenticationViewModel,
+    navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
   val formState = remember { authenticationViewModel.formState }
   val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
   val passwordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
   val confirmPasswordState =
-    formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
+      formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
   var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBLE) }
   var confirmedPasswordVisible by remember { mutableStateOf(DEFAULT_CONFIRMED_PASSWORD_VISIBLE) }
 
@@ -79,74 +79,78 @@ fun SignUpScreen(
     GradedBackground()
 
     Column(
-      modifier =
-        Modifier.fillMaxSize()
-          .padding(paddingValues)
-          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
-          .verticalScroll(rememberScrollState()),
-      horizontalAlignment = Alignment.CenterHorizontally,
-      verticalArrangement =
-        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+        modifier =
+            Modifier.fillMaxSize()
+                .padding(paddingValues)
+                .padding(
+                    horizontal = MaterialTheme.dimens.large,
+                    vertical = MaterialTheme.dimens.medium3)
+                .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement =
+            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
-          text = SIGN_UP_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
+            text = SIGN_UP_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-          email = emailState.value,
-          onEmailChange = { emailState.change(it) },
-          emailErrorMessage = emailState.errorMessage,
+            email = emailState.value,
+            onEmailChange = { emailState.change(it) },
+            emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-          password = passwordState.value,
-          onPasswordChange = { passwordState.change(it) },
-          passwordVisible = passwordVisible,
-          onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-          passwordErrorMessage = passwordState.errorMessage,
+            password = passwordState.value,
+            onPasswordChange = { passwordState.change(it) },
+            passwordVisible = passwordVisible,
+            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+            passwordErrorMessage = passwordState.errorMessage,
         )
 
         Text(
-          modifier =
-            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-          text = CONFIRM_PASSWORD_INSTRUCTION,
-          color = MaterialTheme.colorScheme.onSurface,
-          textAlign = TextAlign.Center,
-          style = MaterialTheme.typography.bodyLarge,
+            modifier =
+                Modifier.fillMaxWidth()
+                    .wrapContentHeight()
+                    .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+            text = CONFIRM_PASSWORD_INSTRUCTION,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationPasswordInput(
-          password = confirmPasswordState.value,
-          onPasswordChange = { confirmPasswordState.change(it) },
-          passwordVisible = confirmedPasswordVisible,
-          onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
-          passwordErrorMessage = confirmPasswordState.errorMessage,
-          passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-          testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-          visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+            password = confirmPasswordState.value,
+            onPasswordChange = { confirmPasswordState.change(it) },
+            passwordVisible = confirmedPasswordVisible,
+            onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
+            passwordErrorMessage = confirmPasswordState.errorMessage,
+            passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+            testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+            visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
         )
 
         AuthenticationSubmitButton(
-          text = SIGN_UP_BUTTON_TEXT,
-          onClick = {
-            attemptSignUp(
-              emailState = emailState,
-              passwordState = passwordState,
-              confirmPasswordState = confirmPasswordState,
-              authenticationViewModel = authenticationViewModel,
-              context = context,
-              navigationActions = navigationActions,
-            )
-          },
-          testTag = SignUpScreen.SIGN_UP_BUTTON,
+            text = SIGN_UP_BUTTON_TEXT,
+            onClick = {
+              attemptSignUp(
+                  emailState = emailState,
+                  passwordState = passwordState,
+                  confirmPasswordState = confirmPasswordState,
+                  authenticationViewModel = authenticationViewModel,
+                  context = context,
+                  navigationActions = navigationActions,
+              )
+            },
+            testTag = SignUpScreen.SIGN_UP_BUTTON,
         )
       }
     }
@@ -168,35 +172,37 @@ fun SignUpScreen(
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSignUp(
-  emailState: TextFieldState,
-  passwordState: TextFieldState,
-  confirmPasswordState: TextFieldState,
-  authenticationViewModel: AuthenticationViewModel,
-  context: Context,
-  navigationActions: NavigationActions,
+    emailState: TextFieldState,
+    passwordState: TextFieldState,
+    confirmPasswordState: TextFieldState,
+    authenticationViewModel: AuthenticationViewModel,
+    context: Context,
+    navigationActions: NavigationActions,
 ) {
-  if (!emailState.validate() || !passwordState.validate() || !confirmPasswordState.validate()) {
+  // strange if statements, but necessary to show the proper error messages
+  if (!emailState.validate() || !passwordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
     return
   }
-  if (passwordState.value != confirmPasswordState.value) {
+  if (!confirmPasswordState.validate() || passwordState.value != confirmPasswordState.value) {
     confirmPasswordState.errorMessage = NOT_MATCHING_PASSWORD_ERROR_MESSAGE
+    Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
     return
   }
 
   authenticationViewModel.signUpWithEmail(
-    userEmail = emailState.value,
-    userPassword = passwordState.value,
-    onSuccess = {
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-      }
-      navigationActions.navigateTo(Screen.CREATE_PROFILE)
-    },
-    onFailure = { _: Exception ->
-      Handler(Looper.getMainLooper()).post {
-        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-      }
-    },
+      userEmail = emailState.value,
+      userPassword = passwordState.value,
+      onSuccess = {
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
+        navigationActions.navigateTo(Screen.CREATE_PROFILE)
+      },
+      onFailure = { _: Exception ->
+        Handler(Looper.getMainLooper()).post {
+          Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+        }
+      },
   )
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -37,32 +37,15 @@ import com.android.periodpals.ui.components.GradedBackground
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
+import com.dsc.form_builder.TextFieldState
 
-private const val DEFAULT_EMAIL = ""
-private const val DEFAULT_PASSWORD = ""
-private const val DEFAULT_CONFIRMED_PASSWORD = ""
-private const val DEFAULT_EMAIL_INVALID_MESSAGE = ""
-private const val DEFAULT_PASSWORD_INVALID_MESSAGE = ""
-private const val DEFAULT_CONFIRMED_PASSWORD_INVALID_MESSAGE = ""
 private const val DEFAULT_PASSWORD_VISIBLE = false
 private const val DEFAULT_CONFIRMED_PASSWORD_VISIBLE = false
 
 private const val SIGN_UP_INSTRUCTION = "Create your account"
 private const val CONFIRM_PASSWORD_INSTRUCTION = "Confirm your password"
 private const val SIGN_UP_BUTTON_TEXT = "Sign up"
-private const val MIN_PASSWORD_LENGTH = 8
 
-private const val EMPTY_EMAIL_ERROR_MESSAGE = "Email cannot be empty"
-private const val NO_AT_EMAIL_ERROR_MESSAGE = "Email must contain @"
-private const val EMPTY_PASSWORD_ERROR_MESSAGE = "Password cannot be empty"
-private const val TOO_SHORT_PASSWORD_ERROR_MESSAGE = "Password must be at least 8 characters long"
-private const val NO_CAPITAL_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one capital letter"
-private const val NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one lower case letter"
-private const val NO_NUMBER_PASSWORD_ERROR_MESSAGE = "Password must contain at least one number"
-private const val NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE =
-    "Password must contain at least one special character"
 private const val NOT_MATCHING_PASSWORD_ERROR_MESSAGE = "Passwords do not match"
 
 private const val SUCCESSFUL_SIGN_UP_TOAST = "Account Creation Successful"
@@ -77,20 +60,16 @@ private const val INVALID_ATTEMPT_TOAST = "Invalid email or password"
  */
 @Composable
 fun SignUpScreen(
-    authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions,
+  authenticationViewModel: AuthenticationViewModel,
+  navigationActions: NavigationActions,
 ) {
   val context = LocalContext.current
-
-  var email by remember { mutableStateOf(DEFAULT_EMAIL) }
-  var password by remember { mutableStateOf(DEFAULT_PASSWORD) }
-  var confirmedPassword by remember { mutableStateOf(DEFAULT_CONFIRMED_PASSWORD) }
-  val (emailErrorMessage, setEmailErrorMessage) =
-      remember { mutableStateOf(DEFAULT_EMAIL_INVALID_MESSAGE) }
-  val (passwordErrorMessage, setPasswordErrorMessage) =
-      remember { mutableStateOf(DEFAULT_PASSWORD_INVALID_MESSAGE) }
-  val (confirmedPasswordErrorMessage, setConfirmedPasswordErrorMessage) =
-      remember { mutableStateOf(DEFAULT_CONFIRMED_PASSWORD_INVALID_MESSAGE) }
+  val formState = remember { authenticationViewModel.formState }
+  val emailState = formState.getState<TextFieldState>(AuthenticationViewModel.EMAIL_STATE_NAME)
+  val passwordState =
+    formState.getState<TextFieldState>(AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+  val confirmPasswordState =
+    formState.getState<TextFieldState>(AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
   var passwordVisible by remember { mutableStateOf(DEFAULT_PASSWORD_VISIBLE) }
   var confirmedPasswordVisible by remember { mutableStateOf(DEFAULT_CONFIRMED_PASSWORD_VISIBLE) }
 
@@ -100,82 +79,74 @@ fun SignUpScreen(
     GradedBackground()
 
     Column(
-        modifier =
-            Modifier.fillMaxSize()
-                .padding(paddingValues)
-                .padding(
-                    horizontal = MaterialTheme.dimens.large,
-                    vertical = MaterialTheme.dimens.medium3,
-                )
-                .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement =
-            Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
+      modifier =
+        Modifier.fillMaxSize()
+          .padding(paddingValues)
+          .padding(horizontal = MaterialTheme.dimens.large, vertical = MaterialTheme.dimens.medium3)
+          .verticalScroll(rememberScrollState()),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement =
+        Arrangement.spacedBy(MaterialTheme.dimens.medium1, Alignment.CenterVertically),
     ) {
       AuthenticationWelcomeText()
 
       AuthenticationCard {
         Text(
-            modifier =
-                Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
-            text = SIGN_UP_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.INSTRUCTION_TEXT),
+          text = SIGN_UP_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationEmailInput(
-            email = email,
-            onEmailChange = { email = it },
-            emailErrorMessage = emailErrorMessage,
+          email = emailState.value,
+          onEmailChange = { emailState.change(it) },
+          emailErrorMessage = emailState.errorMessage,
         )
 
         AuthenticationPasswordInput(
-            password = password,
-            onPasswordChange = { password = it },
-            passwordVisible = passwordVisible,
-            onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
-            passwordErrorMessage = passwordErrorMessage,
+          password = passwordState.value,
+          onPasswordChange = { passwordState.change(it) },
+          passwordVisible = passwordVisible,
+          onPasswordVisibilityChange = { passwordVisible = !passwordVisible },
+          passwordErrorMessage = passwordState.errorMessage,
         )
 
         Text(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .wrapContentHeight()
-                    .testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
-            text = CONFIRM_PASSWORD_INSTRUCTION,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodyLarge,
+          modifier =
+            Modifier.fillMaxWidth().wrapContentHeight().testTag(SignUpScreen.CONFIRM_PASSWORD_TEXT),
+          text = CONFIRM_PASSWORD_INSTRUCTION,
+          color = MaterialTheme.colorScheme.onSurface,
+          textAlign = TextAlign.Center,
+          style = MaterialTheme.typography.bodyLarge,
         )
 
         AuthenticationPasswordInput(
-            password = confirmedPassword,
-            onPasswordChange = { confirmedPassword = it },
-            passwordVisible = confirmedPasswordVisible,
-            onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
-            passwordErrorMessage = confirmedPasswordErrorMessage,
-            passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
-            testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
-            visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
+          password = confirmPasswordState.value,
+          onPasswordChange = { confirmPasswordState.change(it) },
+          passwordVisible = confirmedPasswordVisible,
+          onPasswordVisibilityChange = { confirmedPasswordVisible = !confirmedPasswordVisible },
+          passwordErrorMessage = confirmPasswordState.errorMessage,
+          passwordErrorTestTag = SignUpScreen.CONFIRM_PASSWORD_ERROR_TEXT,
+          testTag = SignUpScreen.CONFIRM_PASSWORD_FIELD,
+          visibilityTestTag = SignUpScreen.CONFIRM_PASSWORD_VISIBILITY_BUTTON,
         )
 
         AuthenticationSubmitButton(
-            text = SIGN_UP_BUTTON_TEXT,
-            onClick = {
-              attemptSignUp(
-                  email = email,
-                  password = password,
-                  confirmedPassword = confirmedPassword,
-                  setEmailErrorMessage = setEmailErrorMessage,
-                  setPasswordErrorMessage = setPasswordErrorMessage,
-                  setConfirmedPasswordErrorMessage = setConfirmedPasswordErrorMessage,
-                  authenticationViewModel = authenticationViewModel,
-                  context = context,
-                  navigationActions = navigationActions,
-              )
-            },
-            testTag = SignUpScreen.SIGN_UP_BUTTON,
+          text = SIGN_UP_BUTTON_TEXT,
+          onClick = {
+            attemptSignUp(
+              emailState = emailState,
+              passwordState = passwordState,
+              confirmPasswordState = confirmPasswordState,
+              authenticationViewModel = authenticationViewModel,
+              context = context,
+              navigationActions = navigationActions,
+            )
+          },
+          testTag = SignUpScreen.SIGN_UP_BUTTON,
         )
       }
     }
@@ -185,9 +156,9 @@ fun SignUpScreen(
 /**
  * Attempts to sign up the user with the provided email, password, and confirmed password.
  *
- * @param email The email entered by the user.
- * @param password The password entered by the user.
- * @param confirmedPassword The confirmed password entered by the user.
+ * @param emailState The email entered by the user.
+ * @param passwordState The password entered by the user.
+ * @param confirmPasswordState The confirmed password entered by the user.
  * @param setEmailErrorMessage A function to set the error message for the email field.
  * @param setPasswordErrorMessage A function to set the error message for the password field.
  * @param setConfirmedPasswordErrorMessage A function to set the error message for the confirmed
@@ -197,129 +168,35 @@ fun SignUpScreen(
  * @param navigationActions The navigation actions to navigate between screens.
  */
 private fun attemptSignUp(
-    email: String,
-    password: String,
-    confirmedPassword: String,
-    setEmailErrorMessage: (String) -> Unit,
-    setPasswordErrorMessage: (String) -> Unit,
-    setConfirmedPasswordErrorMessage: (String) -> Unit,
-    authenticationViewModel: AuthenticationViewModel,
-    context: Context,
-    navigationActions: NavigationActions,
+  emailState: TextFieldState,
+  passwordState: TextFieldState,
+  confirmPasswordState: TextFieldState,
+  authenticationViewModel: AuthenticationViewModel,
+  context: Context,
+  navigationActions: NavigationActions,
 ) {
-  val isEmailValid = isEmailValid(email, setEmailErrorMessage)
-  val isPasswordValid = isPasswordValid(password, setPasswordErrorMessage)
-  val isConfirmedPasswordValid =
-      isConfirmedPasswordValid(password, confirmedPassword, setConfirmedPasswordErrorMessage)
-
-  if (!isEmailValid || !isPasswordValid || !isConfirmedPasswordValid) {
+  if (!emailState.validate() || !passwordState.validate() || !confirmPasswordState.validate()) {
     Toast.makeText(context, INVALID_ATTEMPT_TOAST, Toast.LENGTH_SHORT).show()
+    return
+  }
+  if (passwordState.value != confirmPasswordState.value) {
+    confirmPasswordState.errorMessage = NOT_MATCHING_PASSWORD_ERROR_MESSAGE
     return
   }
 
   authenticationViewModel.signUpWithEmail(
-      userEmail = email,
-      userPassword = password,
-      onSuccess = {
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-        }
-        navigationActions.navigateTo(Screen.CREATE_PROFILE)
-      },
-      onFailure = { _: Exception ->
-        Handler(Looper.getMainLooper()).post {
-          Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
-        }
-      })
-}
-
-/**
- * Validates the email and returns an error message if the email is invalid.
- *
- * @param email The email to validate.
- * @param setErrorMessage A function to set the error message for the email field.
- * @return True if the email is valid, false otherwise.
- */
-private fun isEmailValid(email: String, setErrorMessage: (String) -> Unit): Boolean {
-  return when {
-    email.isEmpty() -> {
-      setErrorMessage(EMPTY_EMAIL_ERROR_MESSAGE)
-      false
-    }
-    !email.contains("@") -> {
-      setErrorMessage(NO_AT_EMAIL_ERROR_MESSAGE)
-      false
-    }
-    else -> {
-      setErrorMessage(DEFAULT_EMAIL_INVALID_MESSAGE)
-      true
-    }
-  }
-}
-
-/**
- * Validates the password and returns an error message if the password is invalid.
- *
- * @param password The password to validate.
- * @param setErrorMessage A function to set the error message for the password field.
- * @return True if the password is valid, false otherwise.
- */
-private fun isPasswordValid(password: String, setErrorMessage: (String) -> Unit): Boolean {
-  val capitalLetter = Regex(".*[A-Z].*")
-  val minusculeLetter = Regex(".*[a-z].*")
-  val number = Regex(".*[0-9].*")
-  val specialChar = Regex(".*[!@#\$%^&*(),.?\":{}|<>].*")
-
-  return when {
-    password.isEmpty() -> {
-      setErrorMessage(EMPTY_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    password.length < MIN_PASSWORD_LENGTH -> {
-      setErrorMessage(TOO_SHORT_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    !capitalLetter.containsMatchIn(password) -> {
-      setErrorMessage(NO_CAPITAL_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    !minusculeLetter.containsMatchIn(password) -> {
-      setErrorMessage(NO_LOWER_CASE_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    !number.containsMatchIn(password) -> {
-      setErrorMessage(NO_NUMBER_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    !specialChar.containsMatchIn(password) -> {
-      setErrorMessage(NO_SPECIAL_CHAR_PASSWORD_ERROR_MESSAGE)
-      false
-    }
-    else -> {
-      setErrorMessage(DEFAULT_EMAIL_INVALID_MESSAGE)
-      true
-    }
-  }
-}
-
-/**
- * Validates the confirmed password and returns an error message if the passwords do not match.
- *
- * @param password The original password.
- * @param confirm The confirmed password.
- * @param setErrorMessage A function to set the error message for the confirmed password field.
- * @return True if the confirmed password matches the original password, false otherwise.
- */
-private fun isConfirmedPasswordValid(
-    password: String,
-    confirm: String,
-    setErrorMessage: (String) -> Unit,
-): Boolean {
-  return if (password != confirm) {
-    setErrorMessage(NOT_MATCHING_PASSWORD_ERROR_MESSAGE)
-    false
-  } else {
-    setErrorMessage(DEFAULT_CONFIRMED_PASSWORD_INVALID_MESSAGE)
-    true
-  }
+    userEmail = emailState.value,
+    userPassword = passwordState.value,
+    onSuccess = {
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+      }
+      navigationActions.navigateTo(Screen.CREATE_PROFILE)
+    },
+    onFailure = { _: Exception ->
+      Handler(Looper.getMainLooper()).post {
+        Toast.makeText(context, FAILED_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
+      }
+    },
+  )
 }

--- a/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
@@ -45,133 +45,133 @@ class AuthenticationViewModelTest {
   @Test
   fun `signUpWithEmail success`() = runBlocking {
     doAnswer { inv -> (inv.getArgument<() -> Unit>(2))() }
-        .`when`(authModel)
-        .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.signUpWithEmail(userEmail = email, userPassword = password)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `signUpWithEmail failure`() = runBlocking {
     doAnswer { inv -> (inv.getArgument<(Exception) -> Unit>(3))(Exception("signup failure")) }
-        .`when`(authModel)
-        .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.signUpWithEmail(userEmail = email, userPassword = password)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Error -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Error -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `signInWithEmail success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(2)() }
-        .`when`(authModel)
-        .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logInWithEmail(userEmail = email, userPassword = password)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `signInWithEmail failure`() = runBlocking {
     doAnswer { inv ->
-          val onFailure = inv.getArgument<(Exception) -> Unit>(3)
-          onFailure(Exception("sign in failure"))
-        }
-        .`when`(authModel)
-        .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        val onFailure = inv.getArgument<(Exception) -> Unit>(3)
+        onFailure(Exception("sign in failure"))
+      }
+      .`when`(authModel)
+      .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logInWithEmail(userEmail = email, userPassword = password)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> false
-          is UserAuthenticationState.Error -> true
-          is UserAuthenticationState.Loading -> false
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> false
+        is UserAuthenticationState.Error -> true
+        is UserAuthenticationState.Loading -> false
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `logOut success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(0)() }
-        .`when`(authModel)
-        .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logOut()
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `logOut failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("logout failure")) }
-        .`when`(authModel)
-        .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logOut()
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Error -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Error -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `isUserLoggedIn success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(0)() }
-        .`when`(authModel)
-        .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.isUserLoggedIn()
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `isUserLoggedIn failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("user not logged in")) }
-        .`when`(authModel)
-        .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.isUserLoggedIn()
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Error -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Error -> true
+        else -> false
+      }
     assert(result)
   }
 
@@ -181,8 +181,8 @@ class AuthenticationViewModelTest {
     val expected: AuthenticationUserData = AuthenticationUserData(uid = id, email = email)
 
     doAnswer { inv -> inv.getArgument<(UserInfo) -> Unit>(0)(userInfo) }
-        .`when`(authModel)
-        .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loadAuthenticationUserData()
 
@@ -192,8 +192,8 @@ class AuthenticationViewModelTest {
   @Test
   fun `loadAuthUserData failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("Model Failed")) }
-        .`when`(authModel)
-        .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loadAuthenticationUserData()
 
@@ -203,37 +203,37 @@ class AuthenticationViewModelTest {
   @Test
   fun `signInWithGoogle success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(2)() }
-        .`when`(authModel)
-        .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+      .`when`(authModel)
+      .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loginWithGoogle(googleIdToken, rawNonce)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> true
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> true
+        else -> false
+      }
     assert(result)
   }
 
   @Test
   fun `signInWithGoogle failure`() = runBlocking {
     doAnswer { inv ->
-          val onFailure = inv.getArgument<(Exception) -> Unit>(3)
-          onFailure(Exception("sign in failure"))
-        }
-        .`when`(authModel)
-        .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        val onFailure = inv.getArgument<(Exception) -> Unit>(3)
+        onFailure(Exception("sign in failure"))
+      }
+      .`when`(authModel)
+      .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loginWithGoogle(googleIdToken, rawNonce)
 
     val result =
-        when (authenticationViewModel.userAuthenticationState.value) {
-          is UserAuthenticationState.Success -> false
-          is UserAuthenticationState.Error -> true
-          is UserAuthenticationState.Loading -> false
-          else -> false
-        }
+      when (authenticationViewModel.userAuthenticationState.value) {
+        is UserAuthenticationState.Success -> false
+        is UserAuthenticationState.Error -> true
+        is UserAuthenticationState.Loading -> false
+        else -> false
+      }
     assert(result)
   }
 
@@ -249,8 +249,8 @@ class AuthenticationViewModelTest {
     // Assert that the hash code has the expected length (64 characters for SHA-256)
     val expectedLength = 64
     assertTrue(
-        "Hash code length is not $expectedLength characters",
-        hashCode.length == expectedLength,
+      "Hash code length is not $expectedLength characters",
+      hashCode.length == expectedLength,
     )
   }
 
@@ -260,28 +260,34 @@ class AuthenticationViewModelTest {
     assertEquals(4, formState.fields.size)
     assertTrue(formState.fields.any { it.name == AuthenticationViewModel.EMAIL_STATE_NAME })
     assertTrue(
-        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME })
+      formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME }
+    )
     assertTrue(
-        formState.fields.any { it.name == AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME })
+      formState.fields.any { it.name == AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME }
+    )
     assertTrue(
-        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME })
+      formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME }
+    )
   }
 
   @Test
   fun emailFieldHasCorrectValidators() {
     val emailField =
-        authenticationViewModel.formState.getState<TextFieldState>(
-            AuthenticationViewModel.EMAIL_STATE_NAME)
-    assertEquals(2, emailField.validators.size)
+      authenticationViewModel.formState.getState<TextFieldState>(
+        AuthenticationViewModel.EMAIL_STATE_NAME
+      )
+    assertEquals(3, emailField.validators.size)
     assertTrue(emailField.validators.any { it is Validators.Email })
     assertTrue(emailField.validators.any { it is Validators.Required })
+    assertTrue(emailField.validators.any { it is Validators.Max })
   }
 
   @Test
   fun passwordSignupFieldHasCorrectValidators() {
     val passwordSignupField =
-        authenticationViewModel.formState.getState<TextFieldState>(
-            AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
+      authenticationViewModel.formState.getState<TextFieldState>(
+        AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME
+      )
     assertEquals(7, passwordSignupField.validators.size)
     assertTrue(passwordSignupField.validators.any { it is Validators.Min })
     assertTrue(passwordSignupField.validators.any { it is Validators.Max })
@@ -292,8 +298,9 @@ class AuthenticationViewModelTest {
   @Test
   fun confirmPasswordFieldHasCorrectValidators() {
     val confirmPasswordField =
-        authenticationViewModel.formState.getState<TextFieldState>(
-            AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
+      authenticationViewModel.formState.getState<TextFieldState>(
+        AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME
+      )
     assertEquals(7, confirmPasswordField.validators.size)
     assertTrue(confirmPasswordField.validators.any { it is Validators.Min })
     assertTrue(confirmPasswordField.validators.any { it is Validators.Max })
@@ -304,8 +311,9 @@ class AuthenticationViewModelTest {
   @Test
   fun passwordLoginFieldHasCorrectValidators() {
     val passwordLoginField =
-        authenticationViewModel.formState.getState<TextFieldState>(
-            AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+      authenticationViewModel.formState.getState<TextFieldState>(
+        AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME
+      )
     assertEquals(2, passwordLoginField.validators.size)
     assertTrue(passwordLoginField.validators.any { it is Validators.Required })
     assertTrue(passwordLoginField.validators.any { it is Validators.Max })

--- a/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
@@ -45,133 +45,133 @@ class AuthenticationViewModelTest {
   @Test
   fun `signUpWithEmail success`() = runBlocking {
     doAnswer { inv -> (inv.getArgument<() -> Unit>(2))() }
-      .`when`(authModel)
-      .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.signUpWithEmail(userEmail = email, userPassword = password)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `signUpWithEmail failure`() = runBlocking {
     doAnswer { inv -> (inv.getArgument<(Exception) -> Unit>(3))(Exception("signup failure")) }
-      .`when`(authModel)
-      .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .register(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.signUpWithEmail(userEmail = email, userPassword = password)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Error -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Error -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `signInWithEmail success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(2)() }
-      .`when`(authModel)
-      .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logInWithEmail(userEmail = email, userPassword = password)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `signInWithEmail failure`() = runBlocking {
     doAnswer { inv ->
-        val onFailure = inv.getArgument<(Exception) -> Unit>(3)
-        onFailure(Exception("sign in failure"))
-      }
-      .`when`(authModel)
-      .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+          val onFailure = inv.getArgument<(Exception) -> Unit>(3)
+          onFailure(Exception("sign in failure"))
+        }
+        .`when`(authModel)
+        .login(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logInWithEmail(userEmail = email, userPassword = password)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> false
-        is UserAuthenticationState.Error -> true
-        is UserAuthenticationState.Loading -> false
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> false
+          is UserAuthenticationState.Error -> true
+          is UserAuthenticationState.Loading -> false
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `logOut success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(0)() }
-      .`when`(authModel)
-      .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logOut()
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `logOut failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("logout failure")) }
-      .`when`(authModel)
-      .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .logout(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.logOut()
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Error -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Error -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `isUserLoggedIn success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(0)() }
-      .`when`(authModel)
-      .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.isUserLoggedIn()
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `isUserLoggedIn failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("user not logged in")) }
-      .`when`(authModel)
-      .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .isUserLoggedIn(any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.isUserLoggedIn()
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Error -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Error -> true
+          else -> false
+        }
     assert(result)
   }
 
@@ -181,8 +181,8 @@ class AuthenticationViewModelTest {
     val expected: AuthenticationUserData = AuthenticationUserData(uid = id, email = email)
 
     doAnswer { inv -> inv.getArgument<(UserInfo) -> Unit>(0)(userInfo) }
-      .`when`(authModel)
-      .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loadAuthenticationUserData()
 
@@ -192,8 +192,8 @@ class AuthenticationViewModelTest {
   @Test
   fun `loadAuthUserData failure`() = runBlocking {
     doAnswer { inv -> inv.getArgument<(Exception) -> Unit>(1)(Exception("Model Failed")) }
-      .`when`(authModel)
-      .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .currentAuthenticationUser(any<(UserInfo) -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loadAuthenticationUserData()
 
@@ -203,37 +203,37 @@ class AuthenticationViewModelTest {
   @Test
   fun `signInWithGoogle success`() = runBlocking {
     doAnswer { inv -> inv.getArgument<() -> Unit>(2)() }
-      .`when`(authModel)
-      .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+        .`when`(authModel)
+        .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loginWithGoogle(googleIdToken, rawNonce)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> true
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> true
+          else -> false
+        }
     assert(result)
   }
 
   @Test
   fun `signInWithGoogle failure`() = runBlocking {
     doAnswer { inv ->
-        val onFailure = inv.getArgument<(Exception) -> Unit>(3)
-        onFailure(Exception("sign in failure"))
-      }
-      .`when`(authModel)
-      .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
+          val onFailure = inv.getArgument<(Exception) -> Unit>(3)
+          onFailure(Exception("sign in failure"))
+        }
+        .`when`(authModel)
+        .loginGoogle(any<String>(), any<String>(), any<() -> Unit>(), any<(Exception) -> Unit>())
 
     authenticationViewModel.loginWithGoogle(googleIdToken, rawNonce)
 
     val result =
-      when (authenticationViewModel.userAuthenticationState.value) {
-        is UserAuthenticationState.Success -> false
-        is UserAuthenticationState.Error -> true
-        is UserAuthenticationState.Loading -> false
-        else -> false
-      }
+        when (authenticationViewModel.userAuthenticationState.value) {
+          is UserAuthenticationState.Success -> false
+          is UserAuthenticationState.Error -> true
+          is UserAuthenticationState.Loading -> false
+          else -> false
+        }
     assert(result)
   }
 
@@ -249,8 +249,8 @@ class AuthenticationViewModelTest {
     // Assert that the hash code has the expected length (64 characters for SHA-256)
     val expectedLength = 64
     assertTrue(
-      "Hash code length is not $expectedLength characters",
-      hashCode.length == expectedLength,
+        "Hash code length is not $expectedLength characters",
+        hashCode.length == expectedLength,
     )
   }
 
@@ -260,22 +260,18 @@ class AuthenticationViewModelTest {
     assertEquals(4, formState.fields.size)
     assertTrue(formState.fields.any { it.name == AuthenticationViewModel.EMAIL_STATE_NAME })
     assertTrue(
-      formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME }
-    )
+        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME })
     assertTrue(
-      formState.fields.any { it.name == AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME }
-    )
+        formState.fields.any { it.name == AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME })
     assertTrue(
-      formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME }
-    )
+        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME })
   }
 
   @Test
   fun emailFieldHasCorrectValidators() {
     val emailField =
-      authenticationViewModel.formState.getState<TextFieldState>(
-        AuthenticationViewModel.EMAIL_STATE_NAME
-      )
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.EMAIL_STATE_NAME)
     assertEquals(3, emailField.validators.size)
     assertTrue(emailField.validators.any { it is Validators.Email })
     assertTrue(emailField.validators.any { it is Validators.Required })
@@ -285,9 +281,8 @@ class AuthenticationViewModelTest {
   @Test
   fun passwordSignupFieldHasCorrectValidators() {
     val passwordSignupField =
-      authenticationViewModel.formState.getState<TextFieldState>(
-        AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME
-      )
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
     assertEquals(7, passwordSignupField.validators.size)
     assertTrue(passwordSignupField.validators.any { it is Validators.Min })
     assertTrue(passwordSignupField.validators.any { it is Validators.Max })
@@ -298,9 +293,8 @@ class AuthenticationViewModelTest {
   @Test
   fun confirmPasswordFieldHasCorrectValidators() {
     val confirmPasswordField =
-      authenticationViewModel.formState.getState<TextFieldState>(
-        AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME
-      )
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
     assertEquals(7, confirmPasswordField.validators.size)
     assertTrue(confirmPasswordField.validators.any { it is Validators.Min })
     assertTrue(confirmPasswordField.validators.any { it is Validators.Max })
@@ -311,9 +305,8 @@ class AuthenticationViewModelTest {
   @Test
   fun passwordLoginFieldHasCorrectValidators() {
     val passwordLoginField =
-      authenticationViewModel.formState.getState<TextFieldState>(
-        AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME
-      )
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
     assertEquals(2, passwordLoginField.validators.size)
     assertTrue(passwordLoginField.validators.any { it is Validators.Required })
     assertTrue(passwordLoginField.validators.any { it is Validators.Max })

--- a/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt
@@ -3,6 +3,8 @@ package com.android.periodpals.model.authentication
 import com.android.periodpals.MainCoroutineRule
 import com.android.periodpals.model.user.AuthenticationUserData
 import com.android.periodpals.model.user.UserAuthenticationState
+import com.dsc.form_builder.TextFieldState
+import com.dsc.form_builder.Validators
 import io.github.jan.supabase.auth.user.UserInfo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -247,6 +249,65 @@ class AuthenticationViewModelTest {
     // Assert that the hash code has the expected length (64 characters for SHA-256)
     val expectedLength = 64
     assertTrue(
-        "Hash code length is not $expectedLength characters", hashCode.length == expectedLength)
+        "Hash code length is not $expectedLength characters",
+        hashCode.length == expectedLength,
+    )
+  }
+
+  @Test
+  fun formStateContainsCorrectFields() {
+    val formState = authenticationViewModel.formState
+    assertEquals(4, formState.fields.size)
+    assertTrue(formState.fields.any { it.name == AuthenticationViewModel.EMAIL_STATE_NAME })
+    assertTrue(
+        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME })
+    assertTrue(
+        formState.fields.any { it.name == AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME })
+    assertTrue(
+        formState.fields.any { it.name == AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME })
+  }
+
+  @Test
+  fun emailFieldHasCorrectValidators() {
+    val emailField =
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.EMAIL_STATE_NAME)
+    assertEquals(2, emailField.validators.size)
+    assertTrue(emailField.validators.any { it is Validators.Email })
+    assertTrue(emailField.validators.any { it is Validators.Required })
+  }
+
+  @Test
+  fun passwordSignupFieldHasCorrectValidators() {
+    val passwordSignupField =
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.PASSWORD_SIGNUP_STATE_NAME)
+    assertEquals(7, passwordSignupField.validators.size)
+    assertTrue(passwordSignupField.validators.any { it is Validators.Min })
+    assertTrue(passwordSignupField.validators.any { it is Validators.Max })
+    assertTrue(passwordSignupField.validators.any { it is Validators.Required })
+    assertTrue(passwordSignupField.validators.any { it is Validators.Custom })
+  }
+
+  @Test
+  fun confirmPasswordFieldHasCorrectValidators() {
+    val confirmPasswordField =
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.CONFIRM_PASSWORD_STATE_NAME)
+    assertEquals(7, confirmPasswordField.validators.size)
+    assertTrue(confirmPasswordField.validators.any { it is Validators.Min })
+    assertTrue(confirmPasswordField.validators.any { it is Validators.Max })
+    assertTrue(confirmPasswordField.validators.any { it is Validators.Required })
+    assertTrue(confirmPasswordField.validators.any { it is Validators.Custom })
+  }
+
+  @Test
+  fun passwordLoginFieldHasCorrectValidators() {
+    val passwordLoginField =
+        authenticationViewModel.formState.getState<TextFieldState>(
+            AuthenticationViewModel.PASSWORD_LOGIN_STATE_NAME)
+    assertEquals(2, passwordLoginField.validators.size)
+    assertTrue(passwordLoginField.validators.any { it is Validators.Required })
+    assertTrue(passwordLoginField.validators.any { it is Validators.Max })
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidxNavigationCompose = "2.5.3"
 bomVersion = "3.0.0"
 compose = "1.0.0-beta01"
 firebaseBom = "33.6.0"
+formBuilder = "1.0.7"
 fragmentKtxVersion = "1.8.4"
 dexmakerMockitoInline = "2.28.4"
 imagepicker = "2.1"
@@ -112,6 +113,7 @@ compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose
 core-ktx = { module = "com.google.android.play:core-ktx", version.ref = "coreKtxVersion" }
 dexmaker-mockito-inline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmakerMockitoInline" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+form-builder = { module = "com.github.jkuatdsc:form-builder", version.ref = "formBuilder" }
 github-postgrest-kt = { module = "io.github.jan-tennert.supabase:postgrest-kt" }
 imagepicker = { module = "com.github.dhaval2404:imagepicker", version.ref = "imagepicker" }
 json = { module = "org.json:json", version.ref = "json" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,24 +1,26 @@
 pluginManagement {
-    repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
+  repositories {
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
     }
+    mavenCentral()
+    gradlePluginPortal()
+    maven { url = uri("https://jitpack.io") }
+  }
 }
+
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+    maven { url = uri("https://jitpack.io") }
+  }
 }
 
 rootProject.name = "PeriodPals"
 include(":app")
- 


### PR DESCRIPTION
# Integrate form validation library into authentication screens

## Description
This PR integrate a new library [FromBuilder](https://github.com/jkuatdsc/form-builder) to do form validation in our authentication screens. This library is made to work with Jetpack Compose. This tremendously cleans up our screens since the validation logic is handled elsewhere, and better separates the duties MVVM-wise.
This PR closes issue #262 and part of #261.

## Changes
**Explanation of the library:**
FormBuilder (docs [here](https://jkuatdsc.github.io/form-builder/form-builder/com.dsc.form_builder/index.html)) provides us with a `FormState`, which is a `State` to represent a form. Here, we only use fields, but it also provides support for checkboxes, radio buttons, etc. 

The `FormState` has a list of `TextFieldState`s passed as arguments on initialization, to represent each one of the fields (here, email, password and password confirmation). 

Each `TextFieldState` has an identifying name and a list of `Validator`s, that provide "rules" that the field input has to follow to be considered valid. 

These `Validator`s are either provided by the library (like `Required` or `Min` for example) or custom (built using the `Custom` validator). Each of them have an error message.

Using the `getState` function, we can extract the `TextFieldState` by name. Using the `change` function, we can trigger a recompose with the new value. Using `validate`, we can evaluate whether or not the value of the input is valid (follows the rules defined by the associated `Validator`s) or not. We can access the error message with `errorMessage`.

**Actual changes:**
I set up the validation logic in the `AuthenticationViewModel`: the `FormState` is accessible as an attribute of the class and is associated with the corresponding `TextFieldState`s and `Validator`s.
In the screens, I replaced the existing states with the `formState` and offshoots `emailState`, `passwordState` etc. I also replaced the validation logic with calls to `validate` and the `onChange` logic with calls to `change`. The error messages are also better handled using the `errorMessage` function.

Seeing the feedback from M2, I added a check for the length of the inputs. FormBuilder also implements proper checks for the email so just having a `@` is not sufficient anymore. The email needs to be of the form `<smth>@<smth>.<smth>`.

## Files 

#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/model/authentication/AuthenticationViewModel.kt`: implemented the validation logic
- `app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt` and `app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt`: integrated the library into the screens
- `app/src/test/java/com/android/periodpals/model/authentication/AuthenticationViewModelTest.kt`, `app/src/test/java/com/android/periodpals/ui/authentication/SignInTest.kt` and `app/src/test/java/com/android/periodpals/ui/authentication/SignUpTest.kt`: update tests
- `app/build.gradle.kts`, `settings.gradle.kts` and `gradle/libs.versions.toml`: added FormBuilder dependency

#### Removed
None

## Dependencies Added
- `com.github.jkuatdsc:form-builder`: FormBuilder dependency

## Testing
I updated the tests to take into account this new library: in `AuthenticationViewModelTest`, I implemented new checks that verify the `FormState` attribute values, and in `SignInTest` and `SignUpTest`, I provided the `FormState` as part of the `AuthenticationViewModel` mock.
