### PR TITLE
Feat/alert/location filtering

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/alert/Alert.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/Alert.kt
@@ -28,8 +28,7 @@ data class Alert(
     val urgency: Urgency,
     val createdAt: String = LocalDateTime.now().toString(),
     val location: String,
-    val locationGIS: String? =
-        parseLocationGIS(location), // TODO: remove nullable type after cleaning repo
+    val locationGIS: String = parseLocationGIS(location),
     val message: String,
     val status: Status
 ) {

--- a/app/src/main/java/com/android/periodpals/model/alert/Alert.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/Alert.kt
@@ -1,6 +1,8 @@
 package com.android.periodpals.model.alert
 
 import com.android.periodpals.R
+import com.android.periodpals.model.location.LocationGIS
+import com.android.periodpals.model.location.parseLocationGIS
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -28,34 +30,10 @@ data class Alert(
     val urgency: Urgency,
     val createdAt: String = LocalDateTime.now().toString(),
     val location: String,
-    val locationGIS: String = parseLocationGIS(location),
+    val locationGIS: LocationGIS = parseLocationGIS(location),
     val message: String,
     val status: Status
-) {
-  companion object {
-    /**
-     * Parses a location string in "latitude,longitude,name" format into a PostGIS-compatible POINT.
-     *
-     * @param location The location string to be parsed.
-     * @return A PostGIS-compatible POINT string (e.g., "POINT(longitude latitude)").
-     */
-    fun parseLocationGIS(location: String): String {
-      val parts = location.split(",")
-      if (parts.size < 2) {
-        throw IllegalArgumentException(
-            "Invalid location format. Expected 'latitude,longitude,name'.")
-      }
-
-      val latitude =
-          parts[0].toDoubleOrNull() ?: throw IllegalArgumentException("Invalid latitude value.")
-      val longitude =
-          parts[1].toDoubleOrNull() ?: throw IllegalArgumentException("Invalid longitude value.")
-
-      // Return the location in PostGIS-compatible POINT format
-      return "POINT($longitude $latitude)"
-    }
-  }
-}
+)
 
 /** Enum class representing the product requested with the alert. */
 enum class Product {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -46,7 +46,7 @@ data class AlertDto(
       urgency = alert.urgency,
       createdAt = alert.createdAt,
       location = alert.location,
-      locationGIS = alert.locationGIS?.let { parseLocationGIS(it) },
+      locationGIS = parseLocationGIS(alert.locationGIS),
       message = alert.message,
       status = alert.status)
 
@@ -57,10 +57,9 @@ data class AlertDto(
    */
   fun toAlert(): Alert {
     val gisString =
-        locationGIS?.let {
-          "POINT(${it.coordinates[0]} ${it.coordinates[1]})" // Convert JSON to PostGIS-compatible
-          // string
-        }
+        "POINT(${locationGIS!!.coordinates[0]} ${locationGIS.coordinates[1]})" // Convert JSON to
+                                                                               // PostGIS-compatible
+    // string
     return Alert(
         id = id,
         uid = uid,

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.Serializable
  * @property createdAt The date and time when the alert was created, generated when alert is created
  *   in [Alert].
  * @property location The location of the alert.
+ * @property locationGIS The location of the alert in PostGIS-compatible POINT format.
  * @property message The message associated with the alert.
  * @property status The current status of the alert.
  */
@@ -26,6 +27,8 @@ data class AlertDto(
     @SerialName("urgency") val urgency: Urgency,
     @SerialName("createdAt") val createdAt: String,
     @SerialName("location") val location: String,
+    @SerialName("locationGIS")
+    val locationGIS: String? = null, // TODO: remove null and nullable type after cleaning repo
     @SerialName("message") val message: String,
     @SerialName("status") val status: Status
 ) {
@@ -44,6 +47,7 @@ data class AlertDto(
       urgency = alert.urgency,
       createdAt = alert.createdAt,
       location = alert.location,
+      locationGIS = alert.locationGIS,
       message = alert.message,
       status = alert.status)
 
@@ -61,6 +65,7 @@ data class AlertDto(
         urgency = urgency,
         createdAt = createdAt,
         location = location,
+        locationGIS = locationGIS,
         message = message,
         status = status)
   }

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -28,7 +28,7 @@ data class AlertDto(
     @SerialName("createdAt") val createdAt: String,
     @SerialName("location") val location: String,
     @SerialName("locationGIS")
-    val locationGIS: LocationGIS? = null, // Handle JSON object for locationGIS
+    val locationGIS: LocationGIS?,
     @SerialName("message") val message: String,
     @SerialName("status") val status: Status
 ) {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -27,8 +27,7 @@ data class AlertDto(
     @SerialName("urgency") val urgency: Urgency,
     @SerialName("createdAt") val createdAt: String,
     @SerialName("location") val location: String,
-    @SerialName("locationGIS")
-    val locationGIS: LocationGIS?,
+    @SerialName("locationGIS") val locationGIS: LocationGIS?,
     @SerialName("message") val message: String,
     @SerialName("status") val status: Status
 ) {
@@ -60,7 +59,7 @@ data class AlertDto(
     val gisString =
         locationGIS?.let {
           "POINT(${it.coordinates[0]} ${it.coordinates[1]})" // Convert JSON to PostGIS-compatible
-                                                             // string
+          // string
         }
     return Alert(
         id = id,

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -58,7 +58,7 @@ data class AlertDto(
   fun toAlert(): Alert {
     val gisString =
         "POINT(${locationGIS!!.coordinates[0]} ${locationGIS.coordinates[1]})" // Convert JSON to
-                                                                               // PostGIS-compatible
+    // PostGIS-compatible
     // string
     return Alert(
         id = id,

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.model.alert
 
+import com.android.periodpals.model.location.LocationGIS
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -27,7 +28,7 @@ data class AlertDto(
     @SerialName("urgency") val urgency: Urgency,
     @SerialName("createdAt") val createdAt: String,
     @SerialName("location") val location: String,
-    @SerialName("locationGIS") val locationGIS: LocationGIS?,
+    @SerialName("locationGIS") val locationGIS: LocationGIS,
     @SerialName("message") val message: String,
     @SerialName("status") val status: Status
 ) {
@@ -46,7 +47,7 @@ data class AlertDto(
       urgency = alert.urgency,
       createdAt = alert.createdAt,
       location = alert.location,
-      locationGIS = parseLocationGIS(alert.locationGIS),
+      locationGIS = alert.locationGIS,
       message = alert.message,
       status = alert.status)
 
@@ -56,10 +57,6 @@ data class AlertDto(
    * @return The `Alert` object created from this `AlertDto`.
    */
   fun toAlert(): Alert {
-    val gisString =
-        "POINT(${locationGIS!!.coordinates[0]} ${locationGIS.coordinates[1]})" // Convert JSON to
-    // PostGIS-compatible
-    // string
     return Alert(
         id = id,
         uid = uid,
@@ -68,32 +65,8 @@ data class AlertDto(
         urgency = urgency,
         createdAt = createdAt,
         location = location,
-        locationGIS = gisString, // Use PostGIS-compatible string
+        locationGIS = locationGIS,
         message = message,
         status = status)
   }
-
-  companion object {
-    fun parseLocationGIS(gisString: String): LocationGIS {
-      val regex = """POINT\((\S+)\s+(\S+)\)""".toRegex()
-      val matchResult =
-          regex.matchEntire(gisString)
-              ?: throw IllegalArgumentException("Invalid POINT format: $gisString")
-      val (longitude, latitude) = matchResult.destructured
-      return LocationGIS("Point", listOf(longitude.toDouble(), latitude.toDouble()))
-    }
-  }
 }
-
-/**
- * Data class representing the GIS location.
- *
- * @property type The type of the GIS object, typically "Point".
- * @property coordinates The coordinates of the GIS object, where the first element is longitude and
- *   the second is latitude.
- */
-@Serializable
-data class LocationGIS(
-    val type: String,
-    val coordinates: List<Double> // Handles JSON structure returned by the database
-)

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertModel.kt
@@ -47,15 +47,16 @@ interface AlertModel {
       onFailure: (Exception) -> Unit
   )
 
-    /**
-     * Retrieves alerts within a specified radius from a given location.
-     *
-     * @param latitude The latitude of the center point.
-     * @param longitude The longitude of the center point.
-     * @param radius The radius within which to search for alerts, in kilometers.
-     * @param onSuccess Callback function to be called on successful retrieval, with the list of alerts as a parameter.
-     * @param onFailure Callback function to be called on failure, with the exception as a parameter.
-     */
+  /**
+   * Retrieves alerts within a specified radius from a given location.
+   *
+   * @param latitude The latitude of the center point.
+   * @param longitude The longitude of the center point.
+   * @param radius The radius within which to search for alerts, in kilometers.
+   * @param onSuccess Callback function to be called on successful retrieval, with the list of
+   *   alerts as a parameter.
+   * @param onFailure Callback function to be called on failure, with the exception as a parameter.
+   */
   suspend fun getAlertsWithinRadius(
       latitude: Double,
       longitude: Double,

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertModel.kt
@@ -47,6 +47,23 @@ interface AlertModel {
       onFailure: (Exception) -> Unit
   )
 
+    /**
+     * Retrieves alerts within a specified radius from a given location.
+     *
+     * @param latitude The latitude of the center point.
+     * @param longitude The longitude of the center point.
+     * @param radius The radius within which to search for alerts, in kilometers.
+     * @param onSuccess Callback function to be called on successful retrieval, with the list of alerts as a parameter.
+     * @param onFailure Callback function to be called on failure, with the exception as a parameter.
+     */
+  suspend fun getAlertsWithinRadius(
+      latitude: Double,
+      longitude: Double,
+      radius: Double,
+      onSuccess: (List<Alert>) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   /**
    * Updates an existing alert (edited).
    *

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
@@ -6,6 +6,8 @@ import io.github.jan.supabase.postgrest.postgrest
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 private const val TAG = "AlertRepositorySupabase"
 private const val ALERTS = "alerts"
@@ -111,6 +113,40 @@ class AlertModelSupabase(
       onSuccess(result.map { it.toAlert() })
     } catch (e: Exception) {
       Log.e(TAG, "getMyAlerts: fail to retrieve alerts: ${e.message}")
+      onFailure(e)
+    }
+  }
+
+    /**
+     * Retrieves alerts within a specified radius from a given location.
+     *
+     * @param latitude The latitude of the center point.
+     * @param longitude The longitude of the center point.
+     * @param radius The radius within which to search for alerts, in meters.
+     * @param onSuccess Callback function to be called on successful retrieval, with the list of alerts as a parameter.
+     * @param onFailure Callback function to be called on failure, with the exception as a parameter.
+     */
+  override suspend fun getAlertsWithinRadius(
+    latitude: Double,
+    longitude: Double,
+    radius: Double, //in meters
+    onSuccess: (List<Alert>) -> Unit,
+    onFailure: (Exception) -> Unit
+  ) {
+    try {
+      // Build the JSON object for parameters
+      val params = buildJsonObject {
+        put("p_latitude", latitude)
+        put("p_longitude", longitude)
+        put("p_radius", radius)
+      }
+      // Call the RPC function
+      val result = supabase.postgrest.rpc("get_alerts_within_radius", params)
+        .decodeList<AlertDto>()
+      Log.d(TAG, "getAlertsWithinRadius: Success")
+      onSuccess(result.map { it.toAlert() })
+    } catch (e: Exception) {
+        Log.e(TAG, "getAlertsWithinRadius: fail to retrieve alerts: ${e.message}")
       onFailure(e)
     }
   }

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
@@ -135,6 +135,7 @@ class AlertModelSupabase(
           set("product", alertDto.product)
           set("urgency", alertDto.urgency)
           set("location", alertDto.location)
+          set("locationGIS", alertDto.locationGIS)
           set("message", alertDto.message)
           set("status", alertDto.status)
         }) {

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt
@@ -117,21 +117,22 @@ class AlertModelSupabase(
     }
   }
 
-    /**
-     * Retrieves alerts within a specified radius from a given location.
-     *
-     * @param latitude The latitude of the center point.
-     * @param longitude The longitude of the center point.
-     * @param radius The radius within which to search for alerts, in meters.
-     * @param onSuccess Callback function to be called on successful retrieval, with the list of alerts as a parameter.
-     * @param onFailure Callback function to be called on failure, with the exception as a parameter.
-     */
+  /**
+   * Retrieves alerts within a specified radius from a given location.
+   *
+   * @param latitude The latitude of the center point.
+   * @param longitude The longitude of the center point.
+   * @param radius The radius within which to search for alerts, in meters.
+   * @param onSuccess Callback function to be called on successful retrieval, with the list of
+   *   alerts as a parameter.
+   * @param onFailure Callback function to be called on failure, with the exception as a parameter.
+   */
   override suspend fun getAlertsWithinRadius(
-    latitude: Double,
-    longitude: Double,
-    radius: Double, //in meters
-    onSuccess: (List<Alert>) -> Unit,
-    onFailure: (Exception) -> Unit
+      latitude: Double,
+      longitude: Double,
+      radius: Double, // in meters
+      onSuccess: (List<Alert>) -> Unit,
+      onFailure: (Exception) -> Unit
   ) {
     try {
       // Build the JSON object for parameters
@@ -141,12 +142,11 @@ class AlertModelSupabase(
         put("p_radius", radius)
       }
       // Call the RPC function
-      val result = supabase.postgrest.rpc("get_alerts_within_radius", params)
-        .decodeList<AlertDto>()
+      val result = supabase.postgrest.rpc("get_alerts_within_radius", params).decodeList<AlertDto>()
       Log.d(TAG, "getAlertsWithinRadius: Success")
       onSuccess(result.map { it.toAlert() })
     } catch (e: Exception) {
-        Log.e(TAG, "getAlertsWithinRadius: fail to retrieve alerts: ${e.message}")
+      Log.e(TAG, "getAlertsWithinRadius: fail to retrieve alerts: ${e.message}")
       onFailure(e)
     }
   }

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -20,8 +20,10 @@ private const val TAG = "AlertViewModel"
  * @property alerts Public state exposing the list of all alerts.
  * @property _myAlerts Mutable state holding the list of current users alerts.
  * @property myAlerts Public state exposing the list of current users alerts.
- * @property _alertsWithinRadius Mutable state holding the ordered list of all alerts within a specified radius.
- * @property alertsWithinRadius Public state exposing the ordered list of all alerts within a specified radius.
+ * @property _alertsWithinRadius Mutable state holding the ordered list of all alerts within a
+ *   specified radius.
+ * @property alertsWithinRadius Public state exposing the ordered list of all alerts within a
+ *   specified radius.
  * @property _palAlerts Mutable state holding the list of other users alerts, within radius.
  * @property palAlerts Public state exposing the list of other users alerts, within radius.
  * @property alertFilter Mutable state holding a filter for `filterAlerts`.
@@ -42,7 +44,7 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
   val myAlerts: State<List<Alert>> = _myAlerts
 
   private var _alertsWithinRadius = mutableStateOf<List<Alert>>(listOf())
-    val alertsWithinRadius: State<List<Alert>> = _alertsWithinRadius
+  val alertsWithinRadius: State<List<Alert>> = _alertsWithinRadius
 
   private var _palAlerts =
       derivedStateOf<List<Alert>> { _alertsWithinRadius.value.filter { it.uid != userId.value } }
@@ -164,37 +166,36 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
     }
   }
 
-    /**
-     * Retrieves alerts within a specified radius from a given location.
-     *
-     * @param location The location from which to search for alerts.
-     * @param radius The radius within which to search for alerts, in kilometers.
-     * @param onSuccess Callback function to be called on successful retrieval.
-     * @param onFailure Callback function to be called on failure.
-     */
-    fun fetchAlertsWithinRadius(
-        location: Location,
-        radius: Double,
-        onSuccess: () -> Unit,
-        onFailure: (Exception) -> Unit
-    ) {
-        viewModelScope.launch {
-            alertModelSupabase.getAlertsWithinRadius(
-                latitude = location.latitude,
-                longitude = location.longitude,
-                radius = radius,
-                onSuccess = {
-                    Log.d(TAG, "getAlertsWithinRadius: Success")
-                    _alertsWithinRadius.value = it
-                    onSuccess()
-                },
-                onFailure = { e ->
-                    Log.e(TAG, "getAlertsWithinRadius: fail to get alerts: ${e.message}")
-                    onFailure(e)
-                }
-            )
-        }
+  /**
+   * Retrieves alerts within a specified radius from a given location.
+   *
+   * @param location The location from which to search for alerts.
+   * @param radius The radius within which to search for alerts, in kilometers.
+   * @param onSuccess Callback function to be called on successful retrieval.
+   * @param onFailure Callback function to be called on failure.
+   */
+  fun fetchAlertsWithinRadius(
+      location: Location,
+      radius: Double,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    viewModelScope.launch {
+      alertModelSupabase.getAlertsWithinRadius(
+          latitude = location.latitude,
+          longitude = location.longitude,
+          radius = radius,
+          onSuccess = {
+            Log.d(TAG, "getAlertsWithinRadius: Success")
+            _alertsWithinRadius.value = it
+            onSuccess()
+          },
+          onFailure = { e ->
+            Log.e(TAG, "getAlertsWithinRadius: fail to get alerts: ${e.message}")
+            onFailure(e)
+          })
     }
+  }
 
   /**
    * Sets the filter for the `filterAlerts` list. Some filter examples could be:

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -24,8 +24,8 @@ private const val TAG = "AlertViewModel"
  *   specified radius.
  * @property alertsWithinRadius Public state exposing the ordered list of all alerts within a
  *   specified radius.
- * @property _palAlerts Mutable state holding the list of other users alerts, within radius.
- * @property palAlerts Public state exposing the list of other users alerts, within radius.
+ * @property _palAlerts Mutable state holding the list of other users alerts.
+ * @property palAlerts Public state exposing the list of other users alerts.
  * @property alertFilter Mutable state holding a filter for `filterAlerts`.
  * @property _filterAlerts Mutable state holding the list of alerts filtered by `alertFilter`.
  * @property filterAlerts Public state exposing the list of alerts filtered y `alertFilter`.
@@ -47,7 +47,7 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
   val alertsWithinRadius: State<List<Alert>> = _alertsWithinRadius
 
   private var _palAlerts =
-      derivedStateOf<List<Alert>> { _alertsWithinRadius.value.filter { it.uid != userId.value } }
+      derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid != userId.value } }
   val palAlerts: State<List<Alert>> = _palAlerts
 
   private var alertFilter = mutableStateOf<(Alert) -> Boolean>({ false })

--- a/app/src/main/java/com/android/periodpals/model/location/LocationGIS.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationGIS.kt
@@ -1,0 +1,27 @@
+package com.android.periodpals.model.location
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Data class representing a geographic location in GeoJSON format (needed to send to the database).
+ *
+ * @property type The type of the GeoJSON object, typically "Point".
+ * @property coordinates A list containing the longitude and latitude of the location.
+ */
+@Serializable
+data class LocationGIS(
+    val type: String,
+    val coordinates: List<Double> // Handles JSON structure returned by the database
+)
+
+/**
+ * Parses a location string (parameter location from an Alert) in "latitude,longitude,name" format
+ * into a PostGIS-compatible POINT.
+ *
+ * @param location The location string to be parsed.
+ * @return A PostGIS-compatible POINT string (e.g., "POINT(longitude latitude)").
+ */
+fun parseLocationGIS(location: String): LocationGIS {
+  val locationValue = Location.fromString(location)
+  return LocationGIS("Point", listOf(locationValue.longitude, locationValue.latitude))
+}

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertModelSupabaseTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertModelSupabaseTest.kt
@@ -1,10 +1,10 @@
 import com.android.periodpals.model.alert.Alert
 import com.android.periodpals.model.alert.AlertDto
 import com.android.periodpals.model.alert.AlertModelSupabase
-import com.android.periodpals.model.alert.LocationGIS
 import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
 import com.android.periodpals.model.alert.Urgency
+import com.android.periodpals.model.location.LocationGIS
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
 import io.ktor.client.engine.mock.MockEngine
@@ -45,7 +45,7 @@ class AlertModelSupabaseTest {
           urgency = urgency,
           createdAt = createdAt,
           location = location,
-          locationGIS = "POINT(${locationGIS.coordinates[0]} ${locationGIS.coordinates[1]})",
+          locationGIS = locationGIS,
           message = message,
           status = status)
 
@@ -194,8 +194,7 @@ class AlertModelSupabaseTest {
         defaultAlert.copy(
             id = "idOutside",
             location = "47.3769,8.5417,Zürich",
-            locationGIS =
-                "POINT(${outsideLocationGIS.coordinates[0]} ${outsideLocationGIS.coordinates[1]})",
+            locationGIS = outsideLocationGIS,
             message = "Outside radius message")
 
     val allAlerts = listOf(AlertDto(defaultAlert), AlertDto(outsideRadiusAlert))
@@ -210,20 +209,16 @@ class AlertModelSupabaseTest {
                 // Simulate filtering based on the radius
                 val filteredAlerts =
                     allAlerts.filter { alertDto ->
-                      val alertCoordinates = alertDto.locationGIS?.coordinates
-                      if (alertCoordinates != null) {
-                        val alertLatitude = alertCoordinates[1]
-                        val alertLongitude = alertCoordinates[0]
-                        val distance =
-                            calculateDistance(
-                                testLatitude,
-                                testLongitude,
-                                alertLatitude,
-                                alertLongitude) // helper function
-                        distance <= testRadius
-                      } else {
-                        false
-                      }
+                      val alertCoordinates = alertDto.locationGIS.coordinates
+                      val alertLatitude = alertCoordinates[1]
+                      val alertLongitude = alertCoordinates[0]
+                      val distance =
+                          calculateDistance(
+                              testLatitude,
+                              testLongitude,
+                              alertLatitude,
+                              alertLongitude) // helper function
+                      distance <= testRadius
                     }
 
                 // Return filtered alerts as JSON

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertModelSupabaseTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertModelSupabaseTest.kt
@@ -1,5 +1,7 @@
 import com.android.periodpals.model.alert.Alert
+import com.android.periodpals.model.alert.AlertDto
 import com.android.periodpals.model.alert.AlertModelSupabase
+import com.android.periodpals.model.alert.LocationGIS
 import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
 import com.android.periodpals.model.alert.Urgency
@@ -12,6 +14,7 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDateTime
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +30,8 @@ class AlertModelSupabaseTest {
     val product = Product.PAD
     val urgency = Urgency.LOW
     val createdAt = LocalDateTime(2022, 1, 1, 0, 0).toString()
-    val location = "test_location"
+    val location = "46.9481,7.4474,Bern"
+    val locationGIS = LocationGIS(type = "Point", coordinates = listOf(7.4474, 46.9481))
     val message = "test_message"
     val status = Status.CREATED
   }
@@ -41,6 +45,7 @@ class AlertModelSupabaseTest {
           urgency = urgency,
           createdAt = createdAt,
           location = location,
+          locationGIS = "POINT(${locationGIS.coordinates[0]} ${locationGIS.coordinates[1]})",
           message = message,
           status = status)
 
@@ -61,6 +66,7 @@ class AlertModelSupabaseTest {
                       "\"urgency\":\"${defaultAlert.urgency}\"," +
                       "\"createdAt\":\"${defaultAlert.createdAt}\"," +
                       "\"location\":\"${defaultAlert.location}\"," +
+                      "\"locationGIS\":{\"type\":\"Point\",\"coordinates\":[${locationGIS.coordinates[0]}, ${locationGIS.coordinates[1]}]}," +
                       "\"message\":\"${defaultAlert.message}\"," +
                       "\"status\":\"${defaultAlert.status}\"}" +
                       "]",
@@ -177,6 +183,110 @@ class AlertModelSupabaseTest {
   }
 
   @Test
+  fun getAlertsWithinRadiusSuccess() = runBlocking {
+    val testLatitude = 46.9481
+    val testLongitude = 7.4474
+    val testRadius = 1000.0 // 1 km
+
+    // Second alert outside the radius
+    val outsideLocationGIS = LocationGIS(type = "Point", coordinates = listOf(8.5417, 47.3769))
+    val outsideRadiusAlert =
+        defaultAlert.copy(
+            id = "idOutside",
+            location = "47.3769,8.5417,Zürich",
+            locationGIS =
+                "POINT(${outsideLocationGIS.coordinates[0]} ${outsideLocationGIS.coordinates[1]})",
+            message = "Outside radius message")
+
+    val allAlerts = listOf(AlertDto(defaultAlert), AlertDto(outsideRadiusAlert))
+
+    // Mock Supabase response to filter alerts dynamically based on the radius
+    alertModelSupabase =
+        AlertModelSupabase(
+            createSupabaseClient("", "") {
+              httpEngine = MockEngine { request ->
+                println("Received request: ${request.url}")
+
+                // Simulate filtering based on the radius
+                val filteredAlerts =
+                    allAlerts.filter { alertDto ->
+                      val alertCoordinates = alertDto.locationGIS?.coordinates
+                      if (alertCoordinates != null) {
+                        val alertLatitude = alertCoordinates[1]
+                        val alertLongitude = alertCoordinates[0]
+                        val distance =
+                            calculateDistance(
+                                testLatitude,
+                                testLongitude,
+                                alertLatitude,
+                                alertLongitude) // helper function
+                        distance <= testRadius
+                      } else {
+                        false
+                      }
+                    }
+
+                // Return filtered alerts as JSON
+                respond(
+                    content =
+                        filteredAlerts.joinToString(prefix = "[", postfix = "]") {
+                          """
+                        {
+                            "id": "${it.id}",
+                            "uid": "${it.uid}",
+                            "name": "${it.name}",
+                            "product": "${it.product}",
+                            "urgency": "${it.urgency}",
+                            "createdAt": "${it.createdAt}",
+                            "location": "${it.location}",
+                            "locationGIS": {"type": "Point", "coordinates": [${it.locationGIS!!.coordinates[0]}, ${it.locationGIS!!.coordinates[1]}]},
+                            "message": "${it.message}",
+                            "status": "${it.status}"
+                        }
+                        """
+                              .trimIndent()
+                        },
+                    status = HttpStatusCode.OK)
+              }
+              install(Postgrest)
+            })
+
+    var result: List<Alert>? = null
+
+    alertModelSupabase.getAlertsWithinRadius(
+        latitude = testLatitude,
+        longitude = testLongitude,
+        radius = testRadius,
+        onSuccess = { result = it },
+        onFailure = { fail("should not call onFailure") })
+
+    assertNotNull(result)
+    println(result)
+    assertEquals(1, result!!.size)
+    assertEquals(defaultAlert.id, result!![0].id) // defaultAlert is the only one within the radius
+  }
+
+  @Test
+  fun getAlertsWithinRadiusFailure() = runBlocking {
+    // Switch to the failure client
+    alertModelSupabase = AlertModelSupabase(supabaseClientFailure)
+
+    var onFailureCalled = false
+
+    // Call the function with mock failure client
+    alertModelSupabase.getAlertsWithinRadius(
+        latitude = 46.9481,
+        longitude = 7.4474,
+        radius = 10000.0, // 10 km
+        onSuccess = { fail("should not call onSuccess") },
+        onFailure = { onFailureCalled = true } // Track failure callback
+        )
+
+    // Assert that the failure callback was invoked
+    assert(onFailureCalled)
+  }
+
+  @Test
   fun updateAlertSuccess() = runBlocking {
     var updateResult = false
     var retrievedAlert: Alert? = null
@@ -242,4 +352,20 @@ class AlertModelSupabaseTest {
 
     assert(onFailureCalled)
   }
+}
+
+// Haversine formula
+/* Helper function for getAlertsWithinRadiusSuccess() test */
+private fun calculateDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+  val radius = 6371000.0 // Earth's radius in meters
+  val dLat = Math.toRadians(lat2 - lat1)
+  val dLon = Math.toRadians(lon2 - lon1)
+  val a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+          Math.cos(Math.toRadians(lat1)) *
+              Math.cos(Math.toRadians(lat2)) *
+              Math.sin(dLon / 2) *
+              Math.sin(dLon / 2)
+  val c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return radius * c
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertTests.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertTests.kt
@@ -34,10 +34,4 @@ class AlertTests {
     assertEquals(LIST_OF_URGENCIES[1], urgencyToPeriodPalsIcon(Urgency.MEDIUM))
     assertEquals(LIST_OF_URGENCIES[2], urgencyToPeriodPalsIcon(Urgency.LOW))
   }
-
-  @Test
-  fun testParseLocationGIS() {
-    assertEquals("POINT(12.34 56.78)", Alert.parseLocationGIS("56.78,12.34,Some Place"))
-    assertEquals("POINT(-123.45 67.89)", Alert.parseLocationGIS("67.89,-123.45,Another Place"))
-  }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertTests.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertTests.kt
@@ -34,4 +34,10 @@ class AlertTests {
     assertEquals(LIST_OF_URGENCIES[1], urgencyToPeriodPalsIcon(Urgency.MEDIUM))
     assertEquals(LIST_OF_URGENCIES[2], urgencyToPeriodPalsIcon(Urgency.LOW))
   }
+
+  @Test
+  fun testParseLocationGIS() {
+    assertEquals("POINT(12.34 56.78)", Alert.parseLocationGIS("56.78,12.34,Some Place"))
+    assertEquals("POINT(-123.45 67.89)", Alert.parseLocationGIS("67.89,-123.45,Another Place"))
+  }
 }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -2,6 +2,7 @@ package com.android.periodpals.model.alert
 
 import com.android.periodpals.MainCoroutineRule
 import com.android.periodpals.model.location.Location
+import com.android.periodpals.model.location.LocationGIS
 import kotlin.random.Random
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
@@ -50,8 +51,8 @@ class AlertViewModelTest {
         }
     val locationGIS =
         List(EXAMPLES) {
-          "POINT(7.4474 46.9481)"
-          "POINT(8.5417 47.3769)"
+          LocationGIS("Point", listOf(7.4474, 46.9481))
+          LocationGIS("Point", listOf(8.5417, 47.3769))
         }
     val message = tagList("message")
     val status = List(EXAMPLES) { Status.entries[Random.nextInt(Status.entries.size)] }
@@ -394,8 +395,8 @@ class AlertViewModelTest {
             product = Product.TAMPON,
             urgency = Urgency.LOW,
             createdAt = "createdAt",
-            location = "location",
-            locationGIS = "locationGIS",
+            location = "46.9481,7.4474,Bern",
+            locationGIS = LocationGIS("Point", listOf(7.4474, 46.9481)),
             message = "message",
             status = Status.CREATED)
     viewModel.selectAlert(alert)

--- a/app/src/test/java/com/android/periodpals/model/location/LocationGISDataClassTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/LocationGISDataClassTest.kt
@@ -1,0 +1,26 @@
+package com.android.periodpals.model.location
+
+import org.junit.Test
+
+class LocationGISDataClassTest {
+  @Test
+  fun testLocationGISInitialization() {
+    val location = LocationGIS("Point", listOf(-122.4194, 37.7749))
+    assert(location.type == "Point")
+    assert(location.coordinates[0] == -122.4194)
+    assert(location.coordinates[1] == 37.7749)
+  }
+
+  @Test
+  fun testParseLocationGIS() {
+    val location = parseLocationGIS("-122.4194,37.7749,San Francisco")
+    assert(location.type == "Point")
+    assert(location.coordinates[0] == 37.7749)
+    assert(location.coordinates[1] == -122.4194)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun testParseLocationGISInvalidFormat() {
+    parseLocationGIS("invalid_format")
+  }
+}


### PR DESCRIPTION
# Location Filtering: backend modifications
## Description
This PR introduces closes issue #273  by applying the necessary changes to `Alert`/`AlertDto`, `AlertModelSupabase` and `AlertViewModel` to add a function that fetches alerts within a certain radius. 

As described in the issue #272, beforehand, I created a new column in the alerts table in Supabase, that contains the location of the alert as a geometry point (a data type of the PostGIS extension, which allows more efficient location-based calculations). 

To add the value of this column to each alert, I wanted to directly do it in Supabase using a trigger function, sadly I didn’t manage to do it so I had to add a parameter in the `Alert` and `AlertDto` data classes. Also I had to create a data class `LocationGIs` and parsing function to ensure correct format of this parameter, which is very particular. 

I also created a postgres function, in the Supabase repository (using SQL queries), which filters the alerts in the table : `get_alerts_within_radius()` 

The function I added to the model, calls the remote function in the repository and gets the filtered Alerts.
Then the view model calls the model, as you know. And there we fill a mutable state that I added called `alertsWithinRadius`, obtaining the desired sublist of alerts. 

(for more information about how this process see [this documentation](https://www.restack.io/docs/supabase-knowledge-supabase-rpc-guide)). 

## Changes
- Added new data class `LocationGIS`, which represents a location in GeoJSON format, format needed to add this value in the database. And parsing function. 
- Modifications to `Alert` and `AlertDto` data classes: added a `locationGIS` parameter, filled by default by parsing`location` parameter.
- Added one function to get the alerts within a radius to `AlertModelSupabase` and `AlertViewModel` (also added a new mutable state list of alerts to store the alerts within radius to the VM)
## Files 
#### Added
- `app/src/main/java/com/android/periodpals/model/location/LocationGIS.kt`

#### Modified
Data classes :
- `app/src/main/java/com/android/periodpals/model/alert/Alert.kt`
- `app/src/main/java/com/android/periodpals/model/alert/AlertDto.kt`

Add functions for location-filtering :
- `app/src/main/java/com/android/periodpals/model/alert/AlertModel.kt`
- `app/src/main/java/com/android/periodpals/model/alert/AlertModelSupabase.kt`
- `app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt`


#### Removed
None. 

## Dependencies Added
None. 

## Testing
- `LocationGIS`: 
Test initialisation of an instance of the data class and the functionality of the parsing function. 

- `AlertModelSupabaseTests`: 
Testing was the most difficult part of this task because the function added to the model calls a remote function that filters the alerts, as previously explained. This postgres function was tested (with SQL queries in Supabase) to ensure its functionality is correct. This doesn’t have to be tested from the model side. 
It is very hard to mock the response of the repository, in this case the output of the function, while being consistent with the other tests of the class and the other view model tests. 
I looked into the possibility of [using test containers](https://foojay.io/today/unit-testing-supabase-in-kotlin/), but it would require adding dependencies and probably changing all the other view model’s tests, which I considered was not worth it for **one test**. 
So, I’m sticking to encapsulating the Supabase client (which is what’s done for the other tests), i.e indication what the output should be for this specific test, for this I used a helper function that computes the distance of the two mock alerts in the test class, and the mocked supabase client returns only the one inside the radius. I added comments to this test 

- `AlertViewModelTests`: 
Added corresponding tests for the `fetchAlertsWithinRadius()` function