### PR TITLE
Feat/misc/notifications/integrate-user-vm : Integrate profile VM to notification interface

### DIFF
--- a/app/src/main/java/com/android/periodpals/MainActivity.kt
+++ b/app/src/main/java/com/android/periodpals/MainActivity.kt
@@ -73,10 +73,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
 
     gpsService = GPSServiceImpl(this)
-    pushNotificationsService = PushNotificationsServiceImpl(this)
-
-    // create new token for device
-    pushNotificationsService.createDeviceToken()
+    pushNotificationsService = PushNotificationsServiceImpl(this, userViewModel)
 
     // Initialize osmdroid configuration getSharedPreferences(this)
     Configuration.getInstance().load(this, getSharedPreferences("osmdroid", Context.MODE_PRIVATE))
@@ -93,7 +90,8 @@ class MainActivity : ComponentActivity() {
               pushNotificationsService,
               authenticationViewModel,
               userViewModel,
-              alertViewModel)
+              alertViewModel,
+          )
         }
       }
     }
@@ -121,7 +119,7 @@ fun PeriodPalsApp(
     pushNotificationsService: PushNotificationsService,
     authenticationViewModel: AuthenticationViewModel,
     userViewModel: UserViewModel,
-    alertViewModel: AlertViewModel
+    alertViewModel: AlertViewModel,
 ) {
   val navController = rememberNavController()
   val navigationActions = NavigationActions(navController)
@@ -145,7 +143,8 @@ fun PeriodPalsApp(
             alertViewModel,
             authenticationViewModel,
             userViewModel,
-            navigationActions)
+            navigationActions,
+        )
       }
     }
 

--- a/app/src/main/java/com/android/periodpals/model/user/User.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/User.kt
@@ -8,9 +8,20 @@ package com.android.periodpals.model.user
  * @property description A brief description of the user.
  * @property dob The date of birth of the user.
  */
-data class User(val name: String, val imageUrl: String, val description: String, val dob: String) {
+data class User(
+    val name: String,
+    val imageUrl: String,
+    val description: String,
+    val dob: String,
+    val fcmToken: String? = null,
+) {
   inline fun asUserDto(): UserDto {
     return UserDto(
-        name = this.name, imageUrl = this.imageUrl, description = this.description, dob = this.dob)
+        name = this.name,
+        imageUrl = this.imageUrl,
+        description = this.description,
+        dob = this.dob,
+        fcm_token = this.fcmToken,
+    )
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/user/User.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/User.kt
@@ -7,6 +7,7 @@ package com.android.periodpals.model.user
  * @property imageUrl The URL of the user's profile image.
  * @property description A brief description of the user.
  * @property dob The date of birth of the user.
+ * @property fcmToken The Firebase Cloud Messaging token for the user (optional).
  */
 data class User(
     val name: String,

--- a/app/src/main/java/com/android/periodpals/model/user/UserDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserDto.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
  * @property imageUrl The URL of the user's profile image.
  * @property description A brief description of the user.
  * @property dob The age of the user.
+ * @property fcm_token The Firebase Cloud Messaging token for the user (optional).
  */
 @Serializable
 data class UserDto(

--- a/app/src/main/java/com/android/periodpals/model/user/UserDto.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserDto.kt
@@ -15,10 +15,16 @@ data class UserDto(
     val name: String,
     val imageUrl: String,
     val description: String,
-    val dob: String
+    val dob: String,
+    val fcm_token: String? = null,
 ) {
   inline fun asUser(): User {
     return User(
-        name = this.name, imageUrl = this.imageUrl, description = this.description, dob = this.dob)
+        name = this.name,
+        imageUrl = this.imageUrl,
+        description = this.description,
+        dob = this.dob,
+        fcmToken = this.fcm_token,
+    )
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/user/UserModelSupabase.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserModelSupabase.kt
@@ -18,7 +18,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
 
   override suspend fun loadUserProfile(
       onSuccess: (UserDto) -> Unit,
-      onFailure: (Exception) -> Unit
+      onFailure: (Exception) -> Unit,
   ) {
     try {
       val result =
@@ -38,7 +38,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
   override suspend fun createUserProfile(
       user: User,
       onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
+      onFailure: (Exception) -> Unit,
   ) {
     try {
       withContext(Dispatchers.Main) {
@@ -47,7 +47,9 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
                 name = user.name,
                 imageUrl = user.imageUrl,
                 description = user.description,
-                dob = user.dob)
+                dob = user.dob,
+                fcm_token = user.fcmToken,
+            )
         supabase.postgrest[USERS].insert(userDto)
       }
       Log.d(TAG, "createUserProfile: Success")
@@ -61,7 +63,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
   override suspend fun upsertUserProfile(
       userDto: UserDto,
       onSuccess: (UserDto) -> Unit,
-      onFailure: (Exception) -> Unit
+      onFailure: (Exception) -> Unit,
   ) {
     try {
       withContext(Dispatchers.Main) {
@@ -78,7 +80,7 @@ class UserRepositorySupabase(private val supabase: SupabaseClient) : UserReposit
   override suspend fun deleteUserProfile(
       idUser: String,
       onSuccess: () -> Unit,
-      onFailure: (Exception) -> Unit
+      onFailure: (Exception) -> Unit,
   ) {
     try {
       withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -43,6 +43,7 @@ import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignInScreen
 import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
+import com.android.periodpals.services.PushNotificationsServiceImpl
 import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
 import com.android.periodpals.ui.components.AuthenticationPasswordInput
@@ -268,6 +269,7 @@ private fun attemptSignIn(
         Handler(Looper.getMainLooper()).post {
           Toast.makeText(context, SUCCESSFUL_SIGN_IN_TOAST, Toast.LENGTH_SHORT).show()
         }
+        PushNotificationsServiceImpl().createDeviceToken()
         navigationActions.navigateTo(Screen.PROFILE)
       },
       onFailure = {

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens.SignUpScreen
+import com.android.periodpals.services.PushNotificationsServiceImpl
 import com.android.periodpals.ui.components.AuthenticationCard
 import com.android.periodpals.ui.components.AuthenticationEmailInput
 import com.android.periodpals.ui.components.AuthenticationPasswordInput
@@ -196,6 +197,7 @@ private fun attemptSignUp(
         Handler(Looper.getMainLooper()).post {
           Toast.makeText(context, SUCCESSFUL_SIGN_UP_TOAST, Toast.LENGTH_SHORT).show()
         }
+        PushNotificationsServiceImpl().createDeviceToken()
         navigationActions.navigateTo(Screen.CREATE_PROFILE)
       },
       onFailure = { _: Exception ->

--- a/app/src/test/java/com/android/periodpals/model/user/UserModelSupabaseTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/user/UserModelSupabaseTest.kt
@@ -28,10 +28,11 @@ class UserRepositorySupabaseTest {
     val description = "test_description"
     val dob = "test_dob"
     val id = "test_id"
+    val fcmToken = "test_fcm_token"
   }
 
-  private val defaultUserDto: UserDto = UserDto(name, imageUrl, description, dob)
-  private val defaultUser: User = User(name, imageUrl, description, dob)
+  private val defaultUserDto: UserDto = UserDto(name, imageUrl, description, dob, fcmToken)
+  private val defaultUser: User = User(name, imageUrl, description, dob, fcmToken)
 
   private val supabaseClientSuccess =
       createSupabaseClient("", "") {
@@ -41,8 +42,9 @@ class UserRepositorySupabaseTest {
                   "[" +
                       "{\"name\":\"${name}\"," +
                       "\"imageUrl\":\"${imageUrl}\"," +
-                      "\"description\":\"${description}\"" +
-                      ",\"dob\":\"${dob}\"}" +
+                      "\"description\":\"${description}\"," +
+                      "\"dob\":\"${dob}\"," +
+                      "\"fcm_token\":\"${fcmToken}\"}" +
                       "]")
         }
         install(Postgrest)
@@ -99,7 +101,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientSuccess)
       userRepositorySupabase.createUserProfile(
-          defaultUser, { result = true }, { fail("should not call onFailure") })
+          defaultUser,
+          { result = true },
+          { fail("should not call onFailure") },
+      )
       assert(result)
     }
   }
@@ -111,7 +116,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientFailure)
       userRepositorySupabase.createUserProfile(
-          defaultUser, { fail("should not call onSuccess") }, { result = true })
+          defaultUser,
+          { fail("should not call onSuccess") },
+          { result = true },
+      )
       assert(result)
     }
   }
@@ -123,7 +131,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientSuccess)
       userRepositorySupabase.upsertUserProfile(
-          defaultUserDto, { result = it }, { fail("should not call onFailure") })
+          defaultUserDto,
+          { result = it },
+          { fail("should not call onFailure") },
+      )
       assertEquals(defaultUserDto, result)
     }
   }
@@ -135,7 +146,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientFailure)
       userRepositorySupabase.upsertUserProfile(
-          defaultUserDto, { fail("should not call onSuccess") }, { result = true })
+          defaultUserDto,
+          { fail("should not call onSuccess") },
+          { result = true },
+      )
       assert(result)
     }
   }
@@ -147,7 +161,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientSuccess)
       userRepositorySupabase.deleteUserProfile(
-          id, { result = true }, { fail("should not call onFailure") })
+          id,
+          { result = true },
+          { fail("should not call onFailure") },
+      )
       assert(result)
     }
   }
@@ -159,7 +176,10 @@ class UserRepositorySupabaseTest {
     runTest {
       val userRepositorySupabase = UserRepositorySupabase(supabaseClientFailure)
       userRepositorySupabase.deleteUserProfile(
-          id, { fail("should not call onSuccess") }, { result = true })
+          id,
+          { fail("should not call onSuccess") },
+          { result = true },
+      )
       assert(result)
     }
   }

--- a/app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt
@@ -31,7 +31,7 @@ class UserViewModelTest {
 
   @Test
   fun loadUserIsSuccessful() = runTest {
-    val user = UserDto("test", "test", "test", "test")
+    val user = UserDto("test", "test", "test", "test", "fcmToken")
     val expected = user.asUser()
 
     doAnswer { it.getArgument<(UserDto) -> Unit>(0)(user) }
@@ -56,7 +56,7 @@ class UserViewModelTest {
 
   @Test
   fun saveUserIsSuccessful() = runTest {
-    val expected = UserDto("test", "test", "test", "test").asUser()
+    val expected = UserDto("test", "test", "test", "test", "fcmToken").asUser()
 
     doAnswer { it.getArgument<(UserDto) -> Unit>(1)(expected.asUserDto()) }
         .`when`(userModel)
@@ -69,7 +69,7 @@ class UserViewModelTest {
 
   @Test
   fun saveUserHasFailed() = runTest {
-    val test = UserDto("test", "test", "test", "test").asUser()
+    val test = UserDto("test", "test", "test", "test", "fcmToken").asUser()
 
     doAnswer { it.getArgument<(Exception) -> Unit>(2)(Exception("failed")) }
         .`when`(userModel)


### PR DESCRIPTION
# Integrate profile VM to notification interface

## Description
This PR integrated the user VM into the push notification interface, so that we now can push FCM tokens to our repository. It closes issue #267 and part of #232.

## Changes
This essentially adds a `UserViewModel` parameter to the `PushNotificationsServiceImpl` class and implements a method `uploadToken` to push said token to the profile of the user. To do that, I had to add an attribute `fcmToken`/`fcm_token` to the data classes `User` and `UserDto`, and update the user model to take this new attribute into account when manipulating a profile.

I also updated the authentication screens `SignIn` and `SignUp` to create an FCM token upon login/signing up.

This was all very complicated since the constructors of `PushNotificationsServiceImpl` are restricted by the manifest (see [here](https://github.com/PeriodPals/periodpals/pull/234#discussion_r1855455693) for more explanations) and I was unable to create a user VM factory. This solution is the best I could come up with.

## Files 

#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/services/PushNotificationsServiceImpl.kt`: integrated user VM and implemented method to push FCM token to repository
- `app/src/main/java/com/android/periodpals/model/user/User.kt` and `app/src/main/java/com/android/periodpals/model/user/UserDto.kt`: updated data classes to have FCM token attribute
- `app/src/main/java/com/android/periodpals/MainActivity.kt`: called `PushNotificationsServiceImpl` with proper parameters
- `app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt` and `app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt`: updated to create an FCM token upon login/signing up
- `app/src/test/java/com/android/periodpals/services/PushNotificationsServiceImplTest.kt`: added tests for uploading token to repository
- `app/src/test/java/com/android/periodpals/model/user/UserModelSupabaseTest.kt` and `app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt`: updated tests to take into account new FCM token attribute in user
#### Removed
None

## Dependencies Added
None

## Testing
Testing this was very complicated as well but in I ended up managing to test `onNewToken` and `createDeviceToken` properly.
I also updated the user model and view model tests to take the new FCM token attribute into account.