### PR TITLE
Feat/alert/product urgency filters

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -42,7 +42,7 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
       derivedStateOf<List<Alert>> { _alerts.value.filter { it.uid == userId.value } }
   val myAlerts: State<List<Alert>> = _myAlerts
 
-  private var _alertsWithinRadius = mutableStateOf<List<Alert>>(alerts.value)
+  private var _alertsWithinRadius = mutableStateOf<List<Alert>>(listOf())
   val alertsWithinRadius: State<List<Alert>> = _alertsWithinRadius
   private var alertFilter = mutableStateOf<(Alert) -> Boolean>({ true })
   private var _filterAlerts = derivedStateOf {
@@ -56,6 +56,14 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
 
   private var _selectedAlert = mutableStateOf<Alert?>(null)
   val selectedAlert: State<Alert?> = _selectedAlert
+
+  /**
+   * Initializes the `alertsWithinRadius` list to the `alerts` list, no location filter at the
+   * beginning.
+   */
+  init {
+    _alertsWithinRadius.value = _alerts.value
+  }
 
   /**
    * Creates a new alert.

--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -48,7 +48,7 @@ class AlertViewModel(private val alertModelSupabase: AlertModelSupabase) : ViewM
   private var _filterAlerts = derivedStateOf {
     _alertsWithinRadius.value.filter { alertFilter.value(it) }
   }
-  private var filterAlerts: State<List<Alert>> = _filterAlerts
+  val filterAlerts: State<List<Alert>> = _filterAlerts
 
   private var _palAlerts =
       derivedStateOf<List<Alert>> { _filterAlerts.value.filter { it.uid != userId.value } }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -50,8 +50,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.android.periodpals.model.alert.Alert
 import com.android.periodpals.model.alert.AlertViewModel
+import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
+import com.android.periodpals.model.alert.Urgency
 import com.android.periodpals.model.alert.productToPeriodPalsIcon
+import com.android.periodpals.model.alert.stringToProduct
+import com.android.periodpals.model.alert.stringToUrgency
 import com.android.periodpals.model.alert.urgencyToPeriodPalsIcon
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.location.Location
@@ -88,6 +92,7 @@ private val INPUT_DATE_FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 private val OUTPUT_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm")
 private const val TAG = "AlertListsScreen"
 private const val DEFAULT_RADIUS = 100.0
+private const val URGENCY_FILTER_DEFAULT_VALUE = "No Preference"
 
 /** Enum class representing the tabs in the AlertLists screen. */
 private enum class AlertListsTab {
@@ -119,6 +124,8 @@ fun AlertListsScreen(
   var isFilterApplied by remember { mutableStateOf(false) }
   var selectedLocation by remember { mutableStateOf<Location?>(null) }
   var radiusInMeters by remember { mutableDoubleStateOf(100.0) }
+  var productFilter by remember { mutableStateOf<Product?>(Product.NO_PREFERENCE) }
+  var urgencyFilter by remember { mutableStateOf<Urgency?>(null) }
 
   authenticationViewModel.loadAuthenticationUserData(
       onFailure = {
@@ -135,7 +142,7 @@ fun AlertListsScreen(
   alertViewModel.fetchAlerts(
       onSuccess = {
         alertViewModel.alerts.value
-        alertViewModel.removeLocationFilter()
+        alertViewModel.removeFilters()
       },
       onFailure = { e -> Log.d(TAG, "Error fetching alerts: $e") })
 
@@ -205,28 +212,43 @@ fun AlertListsScreen(
       FilterDialog(
           context = context,
           currentRadius = radiusInMeters,
+          location = selectedLocation,
+          product = productToPeriodPalsIcon(productFilter!!).textId,
+          urgency =
+              if (urgencyFilter == null) URGENCY_FILTER_DEFAULT_VALUE
+              else urgencyToPeriodPalsIcon(urgencyFilter!!).textId,
           onDismiss = { showFilterDialog = false },
           onLocationSelected = { selectedLocation = it },
-          onProductSelected = {},
-          onUrgencySelected = {},
-          onSave = {
-            radiusInMeters = it
+          onSave = { radius, product, urgency ->
+            radiusInMeters = radius
+            productFilter = stringToProduct(product)
+            urgencyFilter = stringToUrgency(urgency)
             isFilterApplied = true
-            alertViewModel.fetchAlertsWithinRadius(
-                selectedLocation!!,
-                radiusInMeters,
-                onSuccess = {
-                  palsAlertsList = alertViewModel.palAlerts
-                  Log.d(TAG, "Alerts within radius: $palsAlertsList")
-                },
-                onFailure = { e -> Log.d(TAG, "Error fetching alerts within radius: $e") })
+            if (selectedLocation != null) {
+              alertViewModel.fetchAlertsWithinRadius(
+                  selectedLocation!!,
+                  radiusInMeters,
+                  onSuccess = {
+                    palsAlertsList = alertViewModel.palAlerts
+                    Log.d(TAG, "Alerts within radius: $palsAlertsList")
+                  },
+                  onFailure = { e -> Log.d(TAG, "Error fetching alerts within radius: $e") })
+            }
+
+            alertViewModel.setFilter {
+              (productFilter == Product.NO_PREFERENCE ||
+                  (it.product == (productFilter) || it.product == Product.NO_PREFERENCE)) &&
+                  (urgencyFilter == null || it.urgency == urgencyFilter)
+            }
           },
           onReset = {
             radiusInMeters = DEFAULT_RADIUS
+            selectedLocation = null
             isFilterApplied = false
-            alertViewModel.removeLocationFilter()
+            alertViewModel.removeFilters()
+            productFilter = Product.NO_PREFERENCE
+            urgencyFilter = null
           },
-          location = selectedLocation,
           locationViewModel = locationViewModel,
           gpsService = gpsService)
     }

--- a/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
+++ b/app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt
@@ -207,6 +207,8 @@ fun AlertListsScreen(
           currentRadius = radiusInMeters,
           onDismiss = { showFilterDialog = false },
           onLocationSelected = { selectedLocation = it },
+          onProductSelected = {},
+          onUrgencySelected = {},
           onSave = {
             radiusInMeters = it
             isFilterApplied = true

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -403,7 +403,7 @@ class AlertViewModelTest {
     assertEquals(1, viewModel.alertsWithinRadius.value.size)
     assertEquals(listOf(alerts[0]), viewModel.alertsWithinRadius.value)
 
-    viewModel.removeLocationFilter()
+    viewModel.removeFilters()
     assertEquals(2, viewModel.alertsWithinRadius.value.size)
     assertEquals(alerts, viewModel.alertsWithinRadius.value)
   }

--- a/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/alert/AlertViewModelTest.kt
@@ -355,8 +355,6 @@ class AlertViewModelTest {
         .getAlertsWithinRadius(
             any(), any(), any(), any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
 
-    assert(viewModel.alertsWithinRadius.value.isEmpty())
-
     viewModel.fetchAlertsWithinRadius(
         userLocation, radius, {}, { fail("Should not call `onFailure`") })
 
@@ -386,6 +384,31 @@ class AlertViewModelTest {
   }
 
   @Test
+  fun setFilterSuccess() = runBlocking {
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(alerts) }
+        .`when`(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+
+    viewModel.fetchAlerts()
+    assert(viewModel.alerts.value.isNotEmpty())
+    assert(viewModel.alertsWithinRadius.value.isNotEmpty())
+
+    val filter = { alert: Alert -> alert.product == Product.TAMPON && alert.urgency == Urgency.LOW }
+    viewModel.setFilter(filter)
+
+    alerts.forEach { alert ->
+      if (alert.product != Product.TAMPON || alert.urgency != Urgency.LOW) {
+        assert(viewModel.filterAlerts.value.isEmpty())
+      } else {
+        assert(
+            viewModel.filterAlerts.value.all {
+              it.product == Product.TAMPON && it.urgency == Urgency.LOW
+            })
+      }
+    }
+  }
+
+  @Test
   fun removeLocationFilterSuccess() = runBlocking {
     doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(alerts) }
         .`when`(alertModelSupabase)
@@ -397,6 +420,7 @@ class AlertViewModelTest {
 
     viewModel.fetchAlerts()
     assert(viewModel.alerts.value.isNotEmpty())
+    assert(viewModel.alertsWithinRadius.value.isNotEmpty())
 
     viewModel.fetchAlertsWithinRadius(
         userLocation, radius, {}, { fail("Should not call `onFailure`") })
@@ -406,6 +430,54 @@ class AlertViewModelTest {
     viewModel.removeFilters()
     assertEquals(2, viewModel.alertsWithinRadius.value.size)
     assertEquals(alerts, viewModel.alertsWithinRadius.value)
+  }
+
+  @Test
+  fun removeProductUrgencyFiltersSuccess() = runBlocking {
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(alerts) }
+        .`when`(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+
+    viewModel.fetchAlerts()
+    assert(viewModel.alerts.value.isNotEmpty())
+    assert(viewModel.alertsWithinRadius.value.isNotEmpty())
+
+    val filter = { alert: Alert -> alert.product == Product.PAD && alert.urgency == Urgency.HIGH }
+    viewModel.setFilter(filter)
+    assert(
+        viewModel.filterAlerts.value.isEmpty() ||
+            viewModel.filterAlerts.value.all {
+              it.product == Product.PAD && it.urgency == Urgency.HIGH
+            })
+
+    viewModel.removeFilters()
+    assertEquals(alerts, viewModel.filterAlerts.value)
+  }
+
+  @Test
+  fun removeLocationAndOtherFilters() = runBlocking {
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(0)(alerts) }
+        .`when`(alertModelSupabase)
+        .getAllAlerts(any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    doAnswer { it.getArgument<(List<Alert>) -> Unit>(3)(listOf(alerts[0])) }
+        .`when`(alertModelSupabase)
+        .getAlertsWithinRadius(
+            any(), any(), any(), any<(List<Alert>) -> Unit>(), any<(Exception) -> Unit>())
+    viewModel.fetchAlerts(onSuccess = { viewModel.alertsWithinRadius.value })
+    assert(viewModel.alerts.value.isNotEmpty())
+    assert(viewModel.alertsWithinRadius.value.isNotEmpty())
+
+    viewModel.fetchAlertsWithinRadius(
+        userLocation, radius, {}, { fail("Should not call `onFailure`") })
+    assertEquals(1, viewModel.alertsWithinRadius.value.size)
+
+    viewModel.setFilter { it.product == Product.PAD }
+    assert(
+        viewModel.filterAlerts.value.isEmpty() ||
+            viewModel.filterAlerts.value.all { it.product == Product.PAD })
+
+    viewModel.removeFilters()
+    assertEquals(alerts, viewModel.filterAlerts.value)
   }
 
   @Test

--- a/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
@@ -546,7 +546,7 @@ class AlertListsScreenTest {
         .assertIsSelected()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_FAB).performClick()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_RESET_BUTTON).performClick()
-    verify(alertViewModel).removeLocationFilter()
+    verify(alertViewModel).removeFilters()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_FAB_BUBBLE).assertIsNotDisplayed()
     assert(alertViewModel.palAlerts.value == PALS_ALERTS_LIST)
   }

--- a/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/AlertListsScreenTest.kt
@@ -11,12 +11,15 @@ import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import com.android.periodpals.model.alert.Alert
 import com.android.periodpals.model.alert.AlertViewModel
+import com.android.periodpals.model.alert.LIST_OF_PRODUCTS
+import com.android.periodpals.model.alert.LIST_OF_URGENCIES
 import com.android.periodpals.model.alert.Product
 import com.android.periodpals.model.alert.Status
 import com.android.periodpals.model.alert.Urgency
@@ -47,6 +50,8 @@ import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
 private const val LOCATION = "Bern"
+private val PRODUCT = LIST_OF_PRODUCTS[0].textId // Tampon
+private val URGENCY = LIST_OF_URGENCIES[0].textId // High
 
 @RunWith(RobolectricTestRunner::class)
 class AlertListsScreenTest {
@@ -499,6 +504,8 @@ class AlertListsScreenTest {
     composeTestRule.onNodeWithTag(AlertInputs.LOCATION_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_RADIUS_TEXT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_RADIUS_SLIDER).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(AlertInputs.PRODUCT_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(AlertInputs.URGENCY_FIELD).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_APPLY_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_RESET_BUTTON).assertIsDisplayed()
   }
@@ -522,14 +529,16 @@ class AlertListsScreenTest {
         SemanticsActions.SetProgress) {
           it(200.0f)
         }
+    composeTestRule.onNodeWithTag(AlertInputs.PRODUCT_FIELD).performClick()
+    composeTestRule.onNodeWithText(PRODUCT).performScrollTo().performClick()
+    composeTestRule.onNodeWithTag(AlertInputs.URGENCY_FIELD).performClick()
+    composeTestRule.onNodeWithText(URGENCY).performScrollTo().performClick()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_APPLY_BUTTON).performClick()
+
     verify(alertViewModel)
         .fetchAlertsWithinRadius(eq(Location.DEFAULT_LOCATION), eq(200.0), any(), any())
+    verify(alertViewModel).setFilter(any())
 
-    `when`(alertViewModel.palAlerts).thenReturn(mutableStateOf(listOf(PALS_ALERTS_LIST[0])))
-    composeTestRule.runOnIdle {
-      assert(alertViewModel.palAlerts.value == listOf(PALS_ALERTS_LIST[0]))
-    }
     composeTestRule.onNodeWithTag(AlertListsScreen.SCREEN).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AlertListsScreen.FILTER_FAB_BUBBLE).assertIsDisplayed()
   }


### PR DESCRIPTION
# Add Filters for Product and Urgency to palsAlerts list
## Description
This PR introduces new filters for product and urgency in the Filter dialog, to filter pal's alerts lists (in `AlertsLists` for the moment, and same component will be used for `Map`). 

## Changes
- Added UI and to filter dialog for new filters, that work as such:  
    - If a user selects a product to filter by, for example Tampon, then only the alerts that listed "Tampon" or "No Preference" as product needed will be displayed. 
    - For the urgency filter, the user can select a level of urgency, and only alerts with that level will be displayed. 

This filters are applied **on top of the location filter**, literally. The changes I made in the view model are such that we have the following mutable state lists (and others): 
- `alerts`: contains **all** the alerts 
- `alertsWithinRadius`: initialised (in init) as the same as alerts (such that if location filter has not yet been applied, the alerts are simply not filtered), it's given a value when call on `fetchAlertsWithinRadius(location, radius, ...)`. Also this can be changed in the future, we can initialise this list by directly calling `fetchAlertsWithinRadius` if we have a user defined location and radius. But for the moment this is the best option. 
- `filteredAlerts`: which takes `alertsWithinRadius` and applies a filter, by default this filter is `true`, i.e no filter, later we apply the input the user gives in `FilterDialog`. 
- `palsAlerts`: which takes `filteredAlerts` and removes the ones of the current user, i.e living only pals' alerts ;)

## VERY IMPORTANT SIDE NOTE (reason why this is draft)
for the moment filters work great (yey). HOWEVER, they do not persist within screen changes. i.e the user changes screens then comes back to `AlertsLists`, then the filter they had previously indicated are gone. they would have to put them again. 
UX- wise this is not ideal, but to make them persistent filters would have to be stored somewhere (Alert VM possibly), and getting into saving them would require a lot more modifications, I estimate. Which I'm not sure if we want to do, and if this PR is the best one to do it. TBD

## Files 

#### Added
None.
#### Modified
- `app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt`
- `app/src/main/java/com/android/periodpals/ui/alert/AlertLists.kt`
- `app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt`

#### Removed
None.

## Dependencies Added
None.

## Testing
Added test for `setFilter()` in `AlertViewModelTest` as well as tests for `removeFilters()`. 
For `AlertListstScreenTest` I modified the preexisting Filter tests to adapt them to the added filters, but I encountered a problem with verifying the correct call to the `setFilters()` function, I couldn't get it to verify that it was called with the right parameters, so I had to use `any()` as parameter, I had some conflicts with the parameter being a lambda function. But manually tested, it works just fine at least.  

## Screenshots (if applicable)
<img width="378" alt="Screenshot 2024-12-10 at 16 27 51" src="https://github.com/user-attachments/assets/01ddfef9-8703-46bf-bd84-a2dfa05551cc">
