### PR TITLE
Feat/authentication/back to sign in

### DIFF
--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -84,7 +84,7 @@ object C {
         const val SIGN_IN_BUTTON = "signInButton"
         const val CONTINUE_WITH_TEXT = "continueWith"
         const val GOOGLE_BUTTON = "googleButton"
-        const val NOT_REGISTERED_BUTTON = "notRegisteredButton"
+        const val NOT_REGISTERED_NAV_LINK = "notRegisteredButton"
       }
 
       /** Constants for tagging UI components in the SignUpScreen. */
@@ -96,7 +96,7 @@ object C {
         const val CONFIRM_PASSWORD_VISIBILITY_BUTTON = "confirmPasswordVisibilityButton"
         const val CONFIRM_PASSWORD_ERROR_TEXT = "confirmPasswordErrorText"
         const val SIGN_UP_BUTTON = "signUpButton"
-        const val ALREADY_REGISTERED_BUTTON = "alreadyRegisteredButton"
+        const val ALREADY_REGISTERED_NAV_LINK = "alreadyRegisteredButton"
       }
 
       // shared authentication components

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -96,6 +96,7 @@ object C {
         const val CONFIRM_PASSWORD_VISIBILITY_BUTTON = "confirmPasswordVisibilityButton"
         const val CONFIRM_PASSWORD_ERROR_TEXT = "confirmPasswordErrorText"
         const val SIGN_UP_BUTTON = "signUpButton"
+        const val ALREADY_REGISTERED_BUTTON = "alreadyRegisteredButton"
       }
 
       // shared authentication components

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -48,7 +48,7 @@ import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
 import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
-import com.android.periodpals.ui.components.navigateBetweenAuthScreens
+import com.android.periodpals.ui.components.NavigateBetweenAuthScreens
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
@@ -164,11 +164,11 @@ fun SignInScreen(
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
-      navigateBetweenAuthScreens(
+      NavigateBetweenAuthScreens(
           NO_ACCOUNT_TEXT,
           SIGN_UP_TEXT,
           Screen.SIGN_UP,
-          SignInScreen.NOT_REGISTERED_BUTTON,
+          SignInScreen.NOT_REGISTERED_NAV_LINK,
           navigationActions)
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignIn.kt
@@ -5,7 +5,6 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,7 +34,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialException
@@ -50,6 +48,7 @@ import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
 import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
+import com.android.periodpals.ui.components.navigateBetweenAuthScreens
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
@@ -165,29 +164,12 @@ fun SignInScreen(
         AuthenticationGoogleButton(context, authenticationViewModel, navigationActions)
       }
 
-      Row(
-          modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-          horizontalArrangement = Arrangement.Center,
-          verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Text(
-            modifier = Modifier.wrapContentSize(),
-            text = NO_ACCOUNT_TEXT,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-
-        Text(
-            modifier =
-                Modifier.wrapContentSize()
-                    .clickable { navigationActions.navigateTo(Screen.SIGN_UP) }
-                    .testTag(SignInScreen.NOT_REGISTERED_BUTTON),
-            text = SIGN_UP_TEXT,
-            textDecoration = TextDecoration.Underline,
-            color = MaterialTheme.colorScheme.onSecondaryContainer,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-      }
+      navigateBetweenAuthScreens(
+          NO_ACCOUNT_TEXT,
+          SIGN_UP_TEXT,
+          Screen.SIGN_UP,
+          SignInScreen.NOT_REGISTERED_BUTTON,
+          navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -35,7 +35,7 @@ import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
 import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
-import com.android.periodpals.ui.components.navigateBetweenAuthScreens
+import com.android.periodpals.ui.components.NavigateBetweenAuthScreens
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
@@ -161,11 +161,11 @@ fun SignUpScreen(
         )
       }
 
-      navigateBetweenAuthScreens(
+      NavigateBetweenAuthScreens(
           ALREADY_ACCOUNT_TEXT,
           SIGN_IN_TEXT,
           Screen.SIGN_IN,
-          SignUpScreen.ALREADY_REGISTERED_BUTTON,
+          SignUpScreen.ALREADY_REGISTERED_NAV_LINK,
           navigationActions)
     }
   }

--- a/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/android/periodpals/ui/authentication/SignUp.kt
@@ -35,6 +35,7 @@ import com.android.periodpals.ui.components.AuthenticationPasswordInput
 import com.android.periodpals.ui.components.AuthenticationSubmitButton
 import com.android.periodpals.ui.components.AuthenticationWelcomeText
 import com.android.periodpals.ui.components.GradedBackground
+import com.android.periodpals.ui.components.navigateBetweenAuthScreens
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.theme.dimens
@@ -47,6 +48,8 @@ private const val CONFIRM_PASSWORD_INSTRUCTION = "Confirm your password"
 private const val SIGN_UP_BUTTON_TEXT = "Sign up"
 
 private const val NOT_MATCHING_PASSWORD_ERROR_MESSAGE = "Passwords do not match"
+private const val ALREADY_ACCOUNT_TEXT = "Already registered ? "
+private const val SIGN_IN_TEXT = "Sign in!"
 
 private const val SUCCESSFUL_SIGN_UP_TOAST = "Account Creation Successful"
 private const val FAILED_SIGN_UP_TOAST = "Account Creation Failed"
@@ -157,6 +160,13 @@ fun SignUpScreen(
             testTag = SignUpScreen.SIGN_UP_BUTTON,
         )
       }
+
+      navigateBetweenAuthScreens(
+          ALREADY_ACCOUNT_TEXT,
+          SIGN_IN_TEXT,
+          Screen.SIGN_IN,
+          SignUpScreen.ALREADY_REGISTERED_BUTTON,
+          navigationActions)
     }
   }
 }

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -275,7 +275,7 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
  * @param navigationActions The navigation actions to handle screen navigation.
  */
 @Composable
-fun navigateBetweenAuthScreens(
+fun NavigateBetweenAuthScreens(
     questionText: String,
     navigateToText: String,
     screen: String,

--- a/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AuthenticationComponents.kt
@@ -2,9 +2,11 @@ package com.android.periodpals.ui.components
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -39,9 +41,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import com.android.periodpals.resources.C.Tag.AuthenticationScreens
 import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
+import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.theme.dimens
 
 /**
@@ -256,6 +260,48 @@ fun AuthenticationSubmitButton(text: String, onClick: () -> Unit, testTag: Strin
     Text(
         text = text,
         modifier = Modifier.wrapContentSize(),
+        style = MaterialTheme.typography.bodyMedium,
+    )
+  }
+}
+
+/**
+ * A composable function that displays a navigation row between authentication screens.
+ *
+ * @param questionText The question text to display.
+ * @param navigateToText The text for the navigation link.
+ * @param screen The screen to navigate to when the link is clicked.
+ * @param testTag The test tag for the navigation link.
+ * @param navigationActions The navigation actions to handle screen navigation.
+ */
+@Composable
+fun navigateBetweenAuthScreens(
+    questionText: String,
+    navigateToText: String,
+    screen: String,
+    testTag: String,
+    navigationActions: NavigationActions
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth().wrapContentHeight(),
+      horizontalArrangement = Arrangement.Center,
+      verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+        modifier = Modifier.wrapContentSize(),
+        text = questionText,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+
+    Text(
+        modifier =
+            Modifier.wrapContentSize()
+                .clickable { navigationActions.navigateTo(screen) }
+                .testTag(testTag),
+        text = navigateToText,
+        textDecoration = TextDecoration.Underline,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
         style = MaterialTheme.typography.bodyMedium,
     )
   }

--- a/app/src/test/java/com/android/periodpals/ui/authentication/SignInTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/authentication/SignInTest.kt
@@ -130,7 +130,7 @@ class SignInScreenTest {
         .assertIsDisplayed()
     composeTestRule.onNodeWithTag(SignInScreen.GOOGLE_BUTTON).performScrollTo().assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON)
+        .onNodeWithTag(SignInScreen.NOT_REGISTERED_NAV_LINK)
         .performScrollTo()
         .assertIsDisplayed()
   }
@@ -229,7 +229,7 @@ class SignInScreenTest {
   @Test
   fun signUpHereNavigatesToSignUpScreen() {
     composeTestRule
-        .onNodeWithTag(SignInScreen.NOT_REGISTERED_BUTTON)
+        .onNodeWithTag(SignInScreen.NOT_REGISTERED_NAV_LINK)
         .performScrollTo()
         .performClick()
 

--- a/app/src/test/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -173,6 +173,10 @@ class SignUpScreenTest {
         .performScrollTo()
         .assertIsDisplayed()
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_BUTTON)
+        .performScrollTo()
+        .assertIsDisplayed()
   }
 
   @Test
@@ -520,7 +524,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(PASSWORD)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     verify(navigationActions).navigateTo(Screen.CREATE_PROFILE)
   }
 
@@ -529,7 +533,17 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag(AuthenticationScreens.EMAIL_FIELD).performTextInput(EMAIL)
     composeTestRule.onNodeWithTag(AuthenticationScreens.PASSWORD_FIELD).performTextInput(PASSWORD)
     composeTestRule.onNodeWithTag(SignUpScreen.CONFIRM_PASSWORD_FIELD).performTextInput(PASSWORD)
-    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performClick()
+    composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().performClick()
     verify(authViewModel).signUpWithEmail(eq(EMAIL), eq(PASSWORD), any(), any())
+  }
+
+  @Test
+  fun signInNavigatesToSignUpScreen() {
+    composeTestRule
+        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_BUTTON)
+        .performScrollTo()
+        .performClick()
+
+    verify(navigationActions).navigateTo(Screen.SIGN_IN)
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/authentication/SignUpTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/authentication/SignUpTest.kt
@@ -174,7 +174,7 @@ class SignUpScreenTest {
         .assertIsDisplayed()
     composeTestRule.onNodeWithTag(SignUpScreen.SIGN_UP_BUTTON).performScrollTo().assertIsDisplayed()
     composeTestRule
-        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_BUTTON)
+        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_NAV_LINK)
         .performScrollTo()
         .assertIsDisplayed()
   }
@@ -540,7 +540,7 @@ class SignUpScreenTest {
   @Test
   fun signInNavigatesToSignUpScreen() {
     composeTestRule
-        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_BUTTON)
+        .onNodeWithTag(SignUpScreen.ALREADY_REGISTERED_NAV_LINK)
         .performScrollTo()
         .performClick()
 


### PR DESCRIPTION
# Sign-Up can go back to Sign-In

## Description
This PR introduces a new composable function for consistent navigation between authentication screens and updates related UI components and tests. It closes issue #300

## Changes

### UI Component Enhancements:
- Added a new constant `ALREADY_REGISTERED_BUTTON` in `C.kt` to handle the "Already Registered" button.
- Created a new composable function `navigateBetweenAuthScreens` in `AuthenticationComponents.kt` to streamline navigation between authentication screens.

#### Modified
- Replaced the inline navigation row in `SignIn.kt` and added in `SignUp.kt` with the new `navigateBetweenAuthScreens` function to reduce code duplication.

### Testing
- Updated `SignUpScreenTest.kt` to include tests for the new "Already Registered" button and ensure proper navigation.

## Files 
#### Added
- None

#### Modified
- `SignIn.kt` (replaced inline navigation row with `navigateBetweenAuthScreens` function)
- `SignUp.kt` (added inline navigation row with `navigateBetweenAuthScreens` function)
- `C.kt` (added `ALREADY_REGISTERED_BUTTON` constant)
- `AuthenticationComponents.kt` (added `navigateBetweenAuthScreens` composable function)
- `SignUpScreenTest.kt` (updated tests for the new button and navigation)

#### Removed
- None

## Dependencies Added
- None

## Testing
- Added UI and navigation tests to ensure the "Already Registered" button appears correctly and navigates users to the Sign-In screen as expected.

## Screenshots 
<img src="https://github.com/user-attachments/assets/aa6ae419-619b-42ec-abb0-fbea3c4e9d31" width="300" />