### PR TITLE
Feat/timer/notifications/timer-edge-function : Push notifications for timer

### DIFF
--- a/supabase/functions/push_timer/index.ts
+++ b/supabase/functions/push_timer/index.ts
@@ -1,0 +1,118 @@
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { JWT } from 'npm:google-auth-library@9';
+import serviceAccount from '../service-account.json' with { type: 'json' };
+
+
+/**
+ * Represents a timer with a unique identifier, a unique identifier for the user it belongs to,
+ * and a message to be sent.
+ *
+ * @interface Timer
+ * @property {string} id - The unique identifier for the timer.
+ * @property {string} user_id - The unique identifier for the owner of the timer.
+ * @property {string} instructionText - The message content of the timer.
+ */
+interface Timer {
+  id: string;
+  user_id: string;
+  instructionText: string;
+}
+
+/**
+ * Represents the payload sent to a webhook when a timer is updated.
+ *
+ * @interface WebhookPayload
+ * @property {"INSERT"} type - The type of operation that triggered the webhook. Always "UPDATE" for timers.
+ * @property {string} table - The name of the table where the timers are updated.
+ * @property {Alert} record - The timer record or the updated version.
+ * @property {"public"} schema - The schema of the table where the timer was updated. Always "public".
+ */
+interface WebhookPayload {
+  type: "UPDATE";
+  table: string;
+  record: Timer;
+  schema: 'public';
+}
+
+
+// supabase client with service account access (admin access)
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL')!,
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+);
+
+// create a server to listen for new alerts
+Deno.serve(async (req) => {
+  // get the webhook payload
+  const payload: WebhookPayload = await req.json();
+
+  // check if the instructionText is null
+  if (payload.record.instructionText === null) {
+    console.log(`No notification to send for timer ${payload.record.id}`);
+    return new Response('No notification to send', { status: 200 });
+  }
+
+  // get the fcm token for the user owner of the timer using database function
+  const { data: fcmToken, error } = await supabase
+    .rpc("get_user_token_from_timer", { timer_id: payload.record.id });
+  if (error || !fcmToken) {
+    console.log(`No FCM token found for timer ${payload.record.id}`);
+    return new Response('Error fetching FCM token', { status: 500 });
+  }
+
+  // get access token for sending notifications
+  const accessToken = await getAccessToken({
+    clientEmail: serviceAccount.client_email,
+    privateKey: serviceAccount.private_key,
+  });
+
+  // send notification to the user
+  const res = await fetch(
+    `https://fcm.googleapis.com/v1/projects/${serviceAccount.project_id}/messages:send`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({
+        message: {
+          token: fcmToken[0]["fcm_token"],
+          notification: {
+            title: `Your Timer`,
+            body: payload.record.instructionText,
+          },
+        },
+      }),
+    }
+  );
+
+  const resData = await res.json();
+  if (res.status < 200 || 299 < res.status) {
+    console.error(`No notification sent: ${JSON.stringify(resData)}`);
+    return new Response('No notification sent', { status: 500 });
+  }
+
+  return new Response('Notification sent', { status: 200 });
+})
+
+const getAccessToken = ({ clientEmail, privateKey }: {
+  clientEmail: string;
+  privateKey: string;
+}): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const jwtClient = new JWT({
+      email: clientEmail,
+      key: privateKey,
+      scopes: ['https://www.googleapis.com/auth/firebase.messaging'],
+    });
+    jwtClient.authorize((err, tokens) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(tokens!.access_token!);
+    });
+  });
+};
+

--- a/supabase/functions/push_timer/index.ts
+++ b/supabase/functions/push_timer/index.ts
@@ -34,7 +34,6 @@ interface WebhookPayload {
   schema: 'public';
 }
 
-
 // supabase client with service account access (admin access)
 const supabase = createClient(
   Deno.env.get('SUPABASE_URL')!,
@@ -55,7 +54,7 @@ Deno.serve(async (req) => {
   // get the fcm token for the user owner of the timer using database function
   const { data: fcmToken, error } = await supabase
     .rpc("get_user_token_from_timer", { timer_id: payload.record.id });
-  if (error || !fcmToken) {
+  if (error || fcmToken === null) {
     console.log(`No FCM token found for timer ${payload.record.id}`);
     return new Response('Error fetching FCM token', { status: 500 });
   }

--- a/supabase/tests/push_timer.test.ts
+++ b/supabase/tests/push_timer.test.ts
@@ -1,0 +1,161 @@
+import { assertEquals } from 'https://deno.land/std@0.110.0/testing/asserts.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import { JWT } from 'npm:google-auth-library@9';
+import serviceAccount from '../functions/service-account.json' with { type: 'json' };
+
+/**
+ * Handler representing the `push_timer` function. Used only for testing purposes.
+ * //TODO: This should always be up-to-date with how the function is implemented.
+ */
+async function handler(
+  req: Request,
+  data: any,
+  dataError: Error | null,
+  res: { status: number },
+): Promise<Response> {
+  const { type, table, record, schema } = await req.json();
+
+  if (type !== "UPDATE" || table !== "timers" || schema !== "public") {
+    return new Response("Invalid payload", { status: 400 });
+  }
+
+  if (record.instructionText === null) {
+    return new Response('No notification to send', { status: 200 });
+  }
+  if (dataError || data === null) {
+    return new Response('Error fetching FCM token', { status: 500 });
+  }
+  if (res.status < 200 || 299 < res.status) {
+    return new Response('No notification sent', { status: 500 });
+  }
+  return new Response('Notification sent', { status: 200 });
+}
+
+Deno.test('push_timer does not send notification when instructionText is null', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'UPDATE',
+      table: 'timers',
+      record: {
+        id: 'timer1',
+        user_id: 'user1',
+        instructionText: null,
+      },
+      schema: 'public',
+    }),
+  });
+  const data = [{ fcm_token: 'fcm token' }];
+  const error = null;
+  const res = { status: 200 };
+
+  const expected = new Response('No notification to send', { status: 200 });
+  const actual = await handler(req, data, error, res);
+  assertEquals(actual.status, expected.status);
+  assertEquals(await actual.text(), await expected.text());
+});
+
+Deno.test('push_timer sends notification when instructionText is not null', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'UPDATE',
+      table: 'timers',
+      record: {
+        id: 'timer1',
+        user_id: 'user1',
+        instructionText: 'Test notification',
+      },
+      schema: 'public',
+    }),
+  });
+  const data = [{ fcm_token: 'fcm token' }];
+  const error = null;
+  const res = { status: 200 };
+
+  const expected = new Response('Notification sent', { status: 200 });
+  const actual = await handler(req, data, error, res);
+  assertEquals(actual.status, expected.status);
+  assertEquals(await actual.text(), await expected.text());
+});
+
+Deno.test('push_timer returns error when FCM token is not found', async () => {
+  const req1 = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'UPDATE',
+      table: 'timers',
+      record: {
+        id: 'timer1',
+        user_id: 'user1',
+        instructionText: 'Test notification',
+      },
+      schema: 'public',
+    }),
+  });
+  const req2 = req1.clone();
+  const data1: any = null;
+  const error1 = null;
+  const res = { status: 200 };
+
+  const expected1 = new Response('Error fetching FCM token', { status: 500 });
+  const expected2 = expected1.clone();
+  const actual1 = await handler(req1, data1, error1, res);
+  assertEquals(actual1.status, expected1.status);
+  assertEquals(await actual1.text(), await expected1.text());
+
+  const data2 = [{ fcm_token: 'fcm token' }];
+  const error2 = new Error('Failed to fetch FCM token');
+
+  const actual2 = await handler(req2, data2, error2, res);
+  assertEquals(actual2.status, expected2.status);
+  assertEquals(await actual2.text(), await expected2.text());
+});
+
+Deno.test('push_timer returns error when notification fails to send', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'UPDATE',
+      table: 'timers',
+      record: {
+        id: 'timer1',
+        user_id: 'user1',
+        instructionText: 'Test notification',
+      },
+      schema: 'public',
+    }),
+  });
+  const data = [{ fcm_token: 'fcm token' }];
+  const error = null;
+  const res = { status: 500 };
+
+  const expected = new Response('No notification sent', { status: 500 });
+  const actual = await handler(req, data, error, res);
+  assertEquals(actual.status, expected.status);
+  assertEquals(await actual.text(), await expected.text());
+});
+
+Deno.test('push_timer returns error when payload is invalid', async () => {
+  const req = new Request('http://localhost', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'UPDATE',
+      table: 'timers',
+      record: {
+        id: 'timer1',
+        user_id: 'user1',
+        instructionText: 'Test notification',
+      },
+      schema: 'invalid',
+    }),
+  });
+  const data = [{ fcm_token: 'fcm token' }];
+  const error = null;
+  const res = { status: 200 };
+
+  const expected = new Response('Invalid payload', { status: 400 });
+  const actual = await handler(req, data, error, res);
+  assertEquals(actual.status, expected.status);
+  assertEquals(await actual.text(), await expected.text());
+});


### PR DESCRIPTION
# Push notifications for timer

## Description
This PR introduces a new edge function to push the timer notifications. This makes it so that a user will receive a notification when their timer is nearly ended, and when it ends. The title is "Your Timer" and the body is the `instructionText` of the timer in the Supabase `public.timers`.  

It closes issue #299. 

## Changes
See #285 for details on how edge functions work.

For this feature, I created a function `push_timer` and an associated webhook with the same name.
Here, the webhook triggers the edge function when a row is updated (not when it's created) in the `public.timers` table in Supabase. 
The edge function then sends an HTTP request to Firebase, who's in charge of actually sending the notifications. 

## Files 

#### Added
- `supabase/functions/push_timer/index.ts`: the `push_timer` edge notification
- `supabase/tests/push_timer.test.ts`: tests for the `push_timer` function
#### Modified
None
#### Removed
None
## Dependencies Added
None

## Testing
Tested in the `push_timer.test.ts` file. All pass.
