### PR TITLE
fix/alert/location-input-length : Fix alert location input length

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 private const val TAG = "AlertViewModel"
 
-private const val MAX_LOCATION_LENGTH = 128
+private const val MAX_LOCATION_LENGTH = 512
 private const val MAX_MESSAGE_LENGTH = 512
 
 private const val ERROR_INVALID_PRODUCT = "Please select a product"

--- a/app/src/test/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
@@ -79,7 +79,7 @@ class CreateAlertScreenTest {
     private const val NUM_ITEMS_WHEN_SUGGESTION = 4
     private const val NUM_ITEMS_WHEN_NO_SUGGESTION = 1
 
-    private const val MAX_LOCATION_LENGTH = 128
+    private const val MAX_LOCATION_LENGTH = 512
     private const val MAX_MESSAGE_LENGTH = 512
 
     private const val ERROR_INVALID_PRODUCT = "Please select a product"
@@ -127,7 +127,8 @@ class CreateAlertScreenTest {
               imageUrl = imageUrl,
               description = description,
               dob = dob,
-              preferredDistance = preferredDistance))
+              preferredDistance = preferredDistance,
+          ))
 
   private val uid = "12345"
   private val email = "john.doe@example.com"

--- a/app/src/test/java/com/android/periodpals/ui/alert/EditAlertScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/EditAlertScreenTest.kt
@@ -77,7 +77,7 @@ class EditAlertScreenTest {
     private const val SAVE_BUTTON_TEXT = "Save"
     private const val RESOLVE_BUTTON_TEXT = "Resolve"
 
-    private const val MAX_LOCATION_LENGTH = 128
+    private const val MAX_LOCATION_LENGTH = 512
     private const val MAX_MESSAGE_LENGTH = 512
 
     private const val ERROR_INVALID_PRODUCT = "Please select a product"
@@ -125,7 +125,8 @@ class EditAlertScreenTest {
               imageUrl = imageUrl,
               description = description,
               dob = dob,
-              preferredDistance))
+              preferredDistance,
+          ))
 
   private val uid = "12345"
   private val email = "john.doe@example.com"


### PR DESCRIPTION
# Fix alert location input length

## Description
This PR increases the character limit on the location input field in CreateAlert and EditAlert screens. It closes issue #312.

## Changes
Changed the `MAX_LOCATION_LENGTH` from 128 to 512 in `AlertViewModel` and propagated the changes to the tests.

## Files 

#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/model/alert/AlertViewModel.kt`, `app/src/test/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt` and `app/src/test/java/com/android/periodpals/ui/alert/EditAlertScreenTest.kt`: modified the `MAX_LOCATION_LENGTH` value
#### Removed
None
## Dependencies Added
None
## Testing
Adapted to new value. The behavior of the form builder is still not tested since it's an external library.