### PR TITLE
Feat/profile/age verification : Age verification in CreateProfile and EditProfile screens

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
@@ -9,6 +9,8 @@ import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
 import java.text.DateFormat
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlinx.coroutines.launch
 
@@ -16,13 +18,15 @@ private const val TAG = "UserViewModel"
 
 private const val MAX_NAME_LENGTH = 128
 private const val MAX_DESCRIPTION_LENGTH = 512
+const val MAX_AGE = 16L
 
 private const val ERROR_INVALID_NAME = "Please enter a name"
 private const val ERROR_NAME_TOO_LONG = "Name must be less than $MAX_NAME_LENGTH characters"
 private const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
 private const val ERROR_DESCRIPTION_TOO_LONG =
     "Description must be less than $MAX_DESCRIPTION_LENGTH characters"
-private const val ERROR_INVALID_DOB = "Invalid date"
+private const val ERROR_INVALID_DOB = "Please enter a valid date"
+private const val ERROR_TOO_YOUNG = "You must be at least $MAX_AGE years old"
 
 private val nameValidators =
     listOf(
@@ -38,6 +42,7 @@ private val dobValidators =
     listOf(
         Validators.Required(message = ERROR_INVALID_DOB),
         Validators.Custom(message = ERROR_INVALID_DOB, function = { validateDate(it as String) }),
+        Validators.Custom(message = ERROR_TOO_YOUNG, function = { isOldEnough(it as String) }),
     )
 private val profileImageValidators =
     emptyList<Validators>() // TODO: add validators when profile image is implemented
@@ -90,10 +95,12 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
             downloadFile(
                 it.imageUrl,
                 onSuccess = { onSuccess() },
-                onFailure = { e: Exception -> onFailure(Exception(e)) })
+                onFailure = { e: Exception -> onFailure(Exception(e)) },
+            )
           }
         },
-        onFailure = { e: Exception -> onFailure(Exception(e)) })
+        onFailure = { e: Exception -> onFailure(Exception(e)) },
+    )
   }
 
   /**
@@ -201,7 +208,7 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
       onSuccess: () -> Unit = { Log.d(TAG, "uploadFile success callback") },
       onFailure: (Exception) -> Unit = { e: Exception ->
         Log.d(TAG, "uploadFile failure callback: ${e.message}")
-      }
+      },
   ) {
     viewModelScope.launch {
       userRepository.uploadFile(
@@ -214,7 +221,8 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
           onFailure = { e: Exception ->
             Log.d(TAG, "uploadFile: fail to upload file: ${e.message}")
             onFailure(e)
-          })
+          },
+      )
     }
   }
 
@@ -230,7 +238,7 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
       onSuccess: () -> Unit = { Log.d(TAG, "downloadFile success callback") },
       onFailure: (Exception) -> Unit = { e: Exception ->
         Log.d(TAG, "downloadFile failure callback: ${e.message}")
-      }
+      },
   ) {
     viewModelScope.launch {
       userRepository.downloadFile(
@@ -243,7 +251,8 @@ class UserViewModel(private val userRepository: UserRepositorySupabase) : ViewMo
           onFailure = { e: Exception ->
             Log.d(TAG, "downloadFile: fail to download file: ${e.message}")
             onFailure(e)
-          })
+          },
+      )
     }
   }
 }
@@ -260,6 +269,21 @@ fun validateDate(date: String): Boolean {
   return try {
     dateFormat.parse(date)
     true
+  } catch (e: Exception) {
+    false
+  }
+}
+
+/**
+ * Validates the user is at least 16 years old.
+ *
+ * @param date The date string to validate.
+ * @return True if the user is at least 16 years old, otherwise false.
+ */
+fun isOldEnough(date: String): Boolean {
+  return try {
+    LocalDate.parse(date, DateTimeFormatter.ofPattern("dd/MM/yyyy"))
+        .isBefore(LocalDate.now().minusYears(MAX_AGE))
   } catch (e: Exception) {
     false
   }

--- a/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt
@@ -18,7 +18,7 @@ private const val TAG = "UserViewModel"
 
 private const val MAX_NAME_LENGTH = 128
 private const val MAX_DESCRIPTION_LENGTH = 512
-const val MAX_AGE = 16L
+const val MIN_AGE = 16L
 
 private const val ERROR_INVALID_NAME = "Please enter a name"
 private const val ERROR_NAME_TOO_LONG = "Name must be less than $MAX_NAME_LENGTH characters"
@@ -26,7 +26,7 @@ private const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
 private const val ERROR_DESCRIPTION_TOO_LONG =
     "Description must be less than $MAX_DESCRIPTION_LENGTH characters"
 private const val ERROR_INVALID_DOB = "Please enter a valid date"
-private const val ERROR_TOO_YOUNG = "You must be at least $MAX_AGE years old"
+private const val ERROR_TOO_YOUNG = "You must be at least $MIN_AGE years old"
 
 private val nameValidators =
     listOf(
@@ -283,7 +283,7 @@ fun validateDate(date: String): Boolean {
 fun isOldEnough(date: String): Boolean {
   return try {
     LocalDate.parse(date, DateTimeFormatter.ofPattern("dd/MM/yyyy"))
-        .isBefore(LocalDate.now().minusYears(MAX_AGE))
+        .isBefore(LocalDate.now().minusYears(MIN_AGE))
   } catch (e: Exception) {
     false
   }

--- a/app/src/main/java/com/android/periodpals/resources/C.kt
+++ b/app/src/main/java/com/android/periodpals/resources/C.kt
@@ -166,6 +166,7 @@ object C {
       const val YOUR_PROFILE_SECTION = "yourProfileSection"
       const val NAME_INPUT_FIELD = "nameInputField"
       const val DOB_INPUT_FIELD = "dobInputField"
+      const val DOB_MIN_AGE_TEXT = "dobMinAgeText"
       const val DESCRIPTION_INPUT_FIELD = "descriptionInputField"
       const val SAVE_BUTTON = "saveButton"
     }

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
-import com.android.periodpals.model.user.MAX_AGE
+import com.android.periodpals.model.user.MIN_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
@@ -51,7 +51,7 @@ private const val DOB_PLACEHOLDER = "DD/MM/YYYY"
 const val PROFILE_TEXT = "Your Profile"
 private const val DESCRIPTION_LABEL = "Description"
 private const val DESCRIPTION_PLACEHOLDER = "Describe yourself"
-private const val MINIMUM_AGE_TEXT = "You have to be at least $MAX_AGE years old to use this app."
+private const val MINIMUM_AGE_TEXT = "You have to be at least $MIN_AGE years old to use this app."
 private const val SAVE_BUTTON_TEXT = "Save"
 const val LOG_TAG = "CreateProfileScreen"
 const val LOG_FAILURE = "Failed to save profile"

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -28,9 +28,11 @@ import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import com.android.periodpals.model.user.MAX_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.ProfileScreens
+import com.android.periodpals.resources.C.Tag.ProfileScreens.DOB_MIN_AGE_TEXT
 import com.android.periodpals.resources.ComponentColor.getFilledPrimaryContainerButtonColors
 import com.android.periodpals.resources.ComponentColor.getOutlinedTextFieldColors
 import com.android.periodpals.ui.navigation.NavigationActions
@@ -49,6 +51,7 @@ private const val DOB_PLACEHOLDER = "DD/MM/YYYY"
 const val PROFILE_TEXT = "Your Profile"
 private const val DESCRIPTION_LABEL = "Description"
 private const val DESCRIPTION_PLACEHOLDER = "Describe yourself"
+private const val MINIMUM_AGE_TEXT = "You have to be at least $MAX_AGE years old to use this app."
 private const val SAVE_BUTTON_TEXT = "Save"
 const val LOG_TAG = "CreateProfileScreen"
 const val LOG_FAILURE = "Failed to save profile"
@@ -126,7 +129,8 @@ fun ProfileInputName(name: String, onValueChange: (String) -> Unit) {
 }
 
 /**
- * A composable function that displays an outlined text field for the date of birth input.
+ * A composable function that displays an outlined text field for the date of birth input, as well
+ * as a text to explain the minimum age requirement.
  *
  * @param dob The current value of the date of birth input.
  * @param onValueChange A lambda function to handle changes to the date of birth input.
@@ -152,6 +156,16 @@ fun ProfileInputDob(dob: String, onValueChange: (String) -> Unit) {
         )
       },
       placeholder = { Text(text = DOB_PLACEHOLDER, style = MaterialTheme.typography.labelLarge) },
+  )
+  Text(
+      text = MINIMUM_AGE_TEXT,
+      style = MaterialTheme.typography.labelSmall,
+      modifier =
+          Modifier.wrapContentHeight()
+              .fillMaxWidth()
+              .testTag(DOB_MIN_AGE_TEXT)
+              .padding(top = MaterialTheme.dimens.small2),
+      textAlign = TextAlign.Center,
   )
 }
 
@@ -259,7 +273,8 @@ fun ProfileSaveButton(
                             Toast.makeText(context, TOAST_FAILURE, Toast.LENGTH_SHORT).show()
                           }
                       Log.d(LOG_TAG, LOG_FAILURE)
-                    })
+                    },
+                )
               }
             },
             onFailure = {

--- a/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt
@@ -231,8 +231,8 @@ fun ProfileSaveButton(
       onClick = {
         val errorMessage =
             when {
-              !dobState.validate() -> dobState.errorMessage
               !nameState.validate() -> nameState.errorMessage
+              !dobState.validate() -> dobState.errorMessage
               !descriptionState.validate() -> descriptionState.errorMessage
               else -> null
             }

--- a/app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt
@@ -70,16 +70,7 @@ class UserViewModelTest {
 
   @Test
   fun initHasSucceeded() = runTest {
-    val user =
-        UserDto(
-            name,
-            imageUrl,
-            description,
-            dob,
-            preferredDistance,
-            fcmToken,
-            locationGIS,
-        )
+    val user = UserDto(name, imageUrl, description, dob, preferredDistance, fcmToken, locationGIS)
     val expected = user.asUser()
 
     doAnswer { it.getArgument<(UserDto) -> Unit>(0)(user) }
@@ -108,16 +99,7 @@ class UserViewModelTest {
 
   @Test
   fun initDownLoadHasFailed() = runTest {
-    val user =
-        UserDto(
-            name,
-            imageUrl,
-            description,
-            dob,
-            preferredDistance,
-            fcmToken,
-            locationGIS,
-        )
+    val user = UserDto(name, imageUrl, description, dob, preferredDistance, fcmToken, locationGIS)
     doAnswer { it.getArgument<(UserDto) -> Unit>(0)(user) }
         .`when`(userModel)
         .loadUserProfile(any<(UserDto) -> Unit>(), any<(Exception) -> Unit>())
@@ -133,16 +115,7 @@ class UserViewModelTest {
 
   @Test
   fun loadUserIsSuccessful() = runTest {
-    val user =
-        UserDto(
-            name,
-            imageUrl,
-            description,
-            dob,
-            preferredDistance,
-            fcmToken,
-            locationGIS,
-        )
+    val user = UserDto(name, imageUrl, description, dob, preferredDistance, fcmToken, locationGIS)
     val expected = user.asUser()
 
     doAnswer { it.getArgument<(UserDto) -> Unit>(0)(user) }
@@ -168,16 +141,7 @@ class UserViewModelTest {
   @Test
   fun saveUserIsSuccessful() = runTest {
     val expected =
-        UserDto(
-                name,
-                imageUrl,
-                description,
-                dob,
-                preferredDistance,
-                fcmToken,
-                locationGIS,
-            )
-            .asUser()
+        UserDto(name, imageUrl, description, dob, preferredDistance, fcmToken, locationGIS).asUser()
 
     doAnswer { it.getArgument<(UserDto) -> Unit>(1)(expected.asUserDto()) }
         .`when`(userModel)
@@ -191,16 +155,7 @@ class UserViewModelTest {
   @Test
   fun saveUserHasFailed() = runTest {
     val test =
-        UserDto(
-                name,
-                imageUrl,
-                description,
-                dob,
-                preferredDistance,
-                fcmToken,
-                locationGIS,
-            )
-            .asUser()
+        UserDto(name, imageUrl, description, dob, preferredDistance, fcmToken, locationGIS).asUser()
 
     doAnswer { it.getArgument<(Exception) -> Unit>(2)(Exception("failed")) }
         .`when`(userModel)
@@ -311,7 +266,7 @@ class UserViewModelTest {
   @Test
   fun dobFieldHasCorrectValidators() {
     val dobField = userViewModel.formState.getState<TextFieldState>(UserViewModel.DOB_STATE_NAME)
-    assertEquals(2, dobField.validators.size)
+    assertEquals(3, dobField.validators.size)
     assert(dobField.validators.any { it is Validators.Required })
     assert(dobField.validators.any { it is Validators.Custom })
   }
@@ -345,5 +300,30 @@ class UserViewModelTest {
     assert(!validateDate("01/13/2000"))
     // invalid day
     assert(!validateDate("32/01/2000"))
+  }
+
+  @Test
+  fun isOldEnoughReturnsTrueForValidDate() {
+    assert(isOldEnough("01/01/2000"))
+  }
+
+  @Test
+  fun isOldEnoughReturnsFalseForRecentDate() {
+    assert(!isOldEnough("01/01/2010"))
+  }
+
+  @Test
+  fun isOldEnoughReturnsFalseForFutureDate() {
+    assert(!isOldEnough("01/01/2030"))
+  }
+
+  @Test
+  fun isOldEnoughReturnsFalseForInvalidDate() {
+    assert(!isOldEnough("invalid_date"))
+  }
+
+  @Test
+  fun isOldEnoughReturnsFalseForEmptyDate() {
+    assert(!isOldEnough(""))
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -10,12 +10,14 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import com.android.periodpals.model.user.MAX_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.model.user.UserViewModel.Companion.DESCRIPTION_STATE_NAME
 import com.android.periodpals.model.user.UserViewModel.Companion.DOB_STATE_NAME
 import com.android.periodpals.model.user.UserViewModel.Companion.NAME_STATE_NAME
 import com.android.periodpals.model.user.UserViewModel.Companion.PROFILE_IMAGE_STATE_NAME
+import com.android.periodpals.model.user.isOldEnough
 import com.android.periodpals.model.user.validateDate
 import com.android.periodpals.resources.C.Tag.AlertListsScreen
 import com.android.periodpals.resources.C.Tag.BottomNavigationMenu
@@ -28,6 +30,8 @@ import com.android.periodpals.ui.navigation.TopLevelDestination
 import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
@@ -61,7 +65,8 @@ class CreateProfileTest {
                 imageUrl = imageUrl,
                 description = description,
                 dob = dob,
-                preferredDistance = preferredDistance))
+                preferredDistance = preferredDistance,
+            ))
 
     private const val MAX_NAME_LENGTH = 128
     private const val MAX_DESCRIPTION_LENGTH = 512
@@ -71,7 +76,8 @@ class CreateProfileTest {
     private const val ERROR_INVALID_DESCRIPTION = "Please enter a description"
     private const val ERROR_DESCRIPTION_TOO_LONG =
         "Description must be less than $MAX_DESCRIPTION_LENGTH characters"
-    private const val ERROR_INVALID_DOB = "Invalid date"
+    private const val ERROR_INVALID_DOB = "Please enter a valid date"
+    private const val ERROR_TOO_YOUNG = "You must be at least $MAX_AGE years old"
 
     private val nameValidators =
         listOf(
@@ -88,6 +94,7 @@ class CreateProfileTest {
             Validators.Required(message = ERROR_INVALID_DOB),
             Validators.Custom(
                 message = ERROR_INVALID_DOB, function = { validateDate(it as String) }),
+            Validators.Custom(message = ERROR_TOO_YOUNG, function = { isOldEnough(it as String) }),
         )
     private val profileImageValidators = emptyList<Validators>()
   }
@@ -144,6 +151,10 @@ class CreateProfileTest {
         .assertIsDisplayed()
     composeTestRule
         .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_MIN_AGE_TEXT)
         .performScrollTo()
         .assertIsDisplayed()
     composeTestRule
@@ -212,6 +223,33 @@ class CreateProfileTest {
         .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
         .performScrollTo()
         .performTextInput(dob)
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(description)
+    composeTestRule.onNodeWithTag(ProfileScreens.SAVE_BUTTON).performScrollTo().performClick()
+
+    verify(userViewModel, never()).saveUser(any(), any(), any())
+
+    verify(navigationActions, never()).navigateTo(any<TopLevelDestination>())
+    verify(navigationActions, never()).navigateTo(any<String>())
+  }
+
+  @Test
+  fun createInvalidProfileTooYoung() {
+    `when`(userViewModel.user).thenReturn(userState)
+    composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
+
+    val tooYoungDate = LocalDate.now().minusYears(MAX_AGE).plusDays(1)
+
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(tooYoungDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")))
+    composeTestRule
+        .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)
+        .performScrollTo()
+        .performTextInput(name)
     composeTestRule
         .onNodeWithTag(ProfileScreens.DESCRIPTION_INPUT_FIELD)
         .performScrollTo()

--- a/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
-import com.android.periodpals.model.user.MAX_AGE
+import com.android.periodpals.model.user.MIN_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.model.user.UserViewModel.Companion.DESCRIPTION_STATE_NAME
@@ -77,7 +77,7 @@ class CreateProfileTest {
     private const val ERROR_DESCRIPTION_TOO_LONG =
         "Description must be less than $MAX_DESCRIPTION_LENGTH characters"
     private const val ERROR_INVALID_DOB = "Please enter a valid date"
-    private const val ERROR_TOO_YOUNG = "You must be at least $MAX_AGE years old"
+    private const val ERROR_TOO_YOUNG = "You must be at least $MIN_AGE years old"
 
     private val nameValidators =
         listOf(
@@ -240,7 +240,7 @@ class CreateProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { CreateProfileScreen(userViewModel, navigationActions) }
 
-    val tooYoungDate = LocalDate.now().minusYears(MAX_AGE).plusDays(1)
+    val tooYoungDate = LocalDate.now().minusYears(MIN_AGE).plusDays(1)
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.DOB_INPUT_FIELD)

--- a/app/src/test/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import com.android.periodpals.model.user.MAX_AGE
+import com.android.periodpals.model.user.MIN_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.model.user.UserViewModel.Companion.DESCRIPTION_STATE_NAME
@@ -76,7 +76,7 @@ class EditProfileTest {
     private const val ERROR_DESCRIPTION_TOO_LONG =
         "Description must be less than $MAX_DESCRIPTION_LENGTH characters"
     private const val ERROR_INVALID_DOB = "Please enter a valid date"
-    private const val ERROR_TOO_YOUNG = "You must be at least $MAX_AGE years old"
+    private const val ERROR_TOO_YOUNG = "You must be at least $MIN_AGE years old"
 
     private val nameValidators =
         listOf(
@@ -309,7 +309,7 @@ class EditProfileTest {
     `when`(userViewModel.user).thenReturn(userState)
     composeTestRule.setContent { EditProfileScreen(userViewModel, navigationActions) }
 
-    val tooYoungDate = LocalDate.now().minusYears(MAX_AGE).plusDays(1)
+    val tooYoungDate = LocalDate.now().minusYears(MIN_AGE).plusDays(1)
 
     composeTestRule
         .onNodeWithTag(ProfileScreens.NAME_INPUT_FIELD)


### PR DESCRIPTION
# Age verification in CreateProfile and EditProfile screens

## Description
This PR introduces age verification in the CreateProfile and EditProfile screens. It closes issue #314.

## Changes
I added an age condition in `UserViewModel`'s `dobValidators` list of validators. The minimum age is set to 16 and can be changed via the `MIN_AGE` constant. I added the corresponding error message and adapted the old all-encompassing one to be more precise for a malformatted date.

One the UI side, I added a simple text to the date of birth field to explain the restriction to users.

## Files 

#### Added
None
#### Modified
- `app/src/main/java/com/android/periodpals/model/user/UserViewModel.kt`: added age validation logic and modified error messages
- `app/src/main/java/com/android/periodpals/ui/components/ProfileComponents.kt`: added explanatory text to date of birth field and changed the checks order to show proper error message
- `app/src/main/java/com/android/periodpals/resources/C.kt`: added test tag for explanatory text
- `app/src/test/java/com/android/periodpals/model/user/UserViewModelTest.kt`, `app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt` and `app/src/test/java/com/android/periodpals/ui/profile/EditProfileTest.kt`: adapted and added tests
#### Removed
None

## Dependencies Added
None

## Testing
Adapted existing tests and added to check for the age validation components and behaviour.

## Screenshots
![invalid date](https://github.com/user-attachments/assets/00fb22db-fdfd-45fd-b6bf-ca2dceec22ee)

![too young](https://github.com/user-attachments/assets/36c6a3f1-6d96-4680-8394-b0e2434c0e37)

