### PR TITLE
feat/authentication/delete-users : Delete user from `auth.users` upon delete from `public.users`

### DIFF
--- a/supabase/functions/delete_auth_users/index.ts
+++ b/supabase/functions/delete_auth_users/index.ts
@@ -1,0 +1,58 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { JWT } from "npm:google-auth-library@9";
+import serviceAccount from "../service-account.json" with { type: "json" };
+
+/**
+ * Represents a user with a unique identifier.
+ *
+ * @interface User
+ * @property {string} user_id - The unique identifier for the user from the `public.users` table.
+ */
+interface User {
+  user_id: string;
+}
+
+/**
+ * Represents the payload sent to a webhook when a user is deleted.
+ *
+ * @interface WebhookPayload
+ * @property {"DELETE"} type - The type of operation that triggered the webhook. Always "DELETE" for user deletions.
+ * @property {string} table - The name of the table where the user was deleted.
+ * @property {User} old_record - The previous record that was deleted.
+ * @property {"public"} schema - The schema of the table where the user was deleted. Always "public".
+ */
+interface WebhookPayload {
+  type: "DELETE";
+  table: string;
+  old_record: User;
+  schema: "public";
+}
+
+// supabase client with service account access (admin access)
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+);
+
+// create a server to listen for new alerts
+Deno.serve(async (req) => {
+  // get the webhook payload
+  const payload: WebhookPayload = await req.json();
+
+  // check if payload.old_record is not null or undefined
+  if (!payload.old_record || !payload.old_record.user_id) {
+    console.error("Invalid payload:", payload);
+    return new Response('Invalid payload', { status: 400 });
+  }
+
+  // delete user from `auth.users` using database function
+  const { data, error } = await supabase
+    .rpc("delete_auth_user_with_uid", { input_id: payload.old_record.user_id });
+
+  if (error) {
+    console.error("Error deleting user:", error);
+    return new Response('Error deleting user', { status: 500 });
+  }
+  return new Response('User deleted', { status: 200 });
+});
+


### PR DESCRIPTION
# Delete user from `auth.users` upon delete from `public.users`

## Description
This PR introduces a new edge function that enables us to delete a user from the authentication table (`auth.users`) when deleting them from the profile table (`public.users`). It closes issue #320 and part of #319. It also fixes the problem of giving the user the possibility of deleting their account: we can now just delete the `public.users` user and everything associated to that user is deleted.

## Changes
Explanations about edge functions and webhooks [here](https://github.com/PeriodPals/periodpals/pull/285).

I wrote a new edge function `delete_auth_users` and created an associated webhook of the same name, so that a deletion in the `auth.users` table triggers the execution of the `delete_auth_users` edge function. 

I also wrote a helper database function that has the access rights to delete rows from that very protected table. This function is an SQL function that runs server-side with admin access. You can find it [here](https://supabase.com/dashboard/project/bhhjdcvdcfrxczbudraf/database/functions?schema=public), along with the other database functions of our project.

I also modified every public table's settings so that once a user is deleted, everything associated to that user (user profile, location, alerts, timers) is also deleted (cascade for the delete action on the authentication uid foreign key).

## Files 

#### Added
- `supabase/functions/delete_auth_users/index.ts`: new `delete_auth_users` edge function
#### Modified
None
#### Removed
None
## Dependencies Added
None

## Testing
Tested server-side.