### PR TITLE
Add search from coordinates to address

### DIFF
--- a/app/src/main/java/com/android/periodpals/model/location/Location.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/Location.kt
@@ -1,6 +1,5 @@
 package com.android.periodpals.model.location
 
-import android.util.Log
 import org.osmdroid.util.GeoPoint
 
 private const val PARTS_ERROR_MESSAGE = "Invalid format. Expected 'latitude,longitude,name'."

--- a/app/src/main/java/com/android/periodpals/model/location/Location.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/Location.kt
@@ -1,5 +1,6 @@
 package com.android.periodpals.model.location
 
+import android.util.Log
 import org.osmdroid.util.GeoPoint
 
 private const val PARTS_ERROR_MESSAGE = "Invalid format. Expected 'latitude,longitude,name'."

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
@@ -30,7 +30,7 @@ interface LocationModel {
    * @param onSuccess A callback function to handle the succesful retrieval of the address.
    * @param onFailure A callback function to handle any errors or exceptions encountered during the search.
    */
-  fun addressFromCoordinates(
+  fun reverseSearch(
     gpsCoordinates: Location,
     onSuccess: (String) -> Unit,
     onFailure: (Exception) -> Unit

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
@@ -23,17 +23,19 @@ interface LocationModel {
   /**
    * Performs a "reverse location search".
    *
-   * In other words, the function returns the closest address to the specified latitude and longitude.
+   * In other words, the function returns the closest address to the specified latitude and
+   * longitude.
    *
    * @param lat Latitude of the location.
    * @param lon Longitude of the location.
    * @param onSuccess Callback function to handle the succesful retrieval of the address.
-   * @param onFailure Callback function to handle any errors or exceptions encountered during the search.
+   * @param onFailure Callback function to handle any errors or exceptions encountered during the
+   *   search.
    */
   fun reverseSearch(
-    lat: Double,
-    lon: Double,
-    onSuccess: (String) -> Unit,
-    onFailure: (Exception) -> Unit
+      lat: Double,
+      lon: Double,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
   )
 }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
@@ -19,4 +19,20 @@ interface LocationModel {
    *   search. It takes an [Exception] as its parameter.
    */
   fun search(query: String, onSuccess: (List<Location>) -> Unit, onFailure: (Exception) -> Unit)
+
+  /**
+   * Performs a "reverse location search".
+   *
+   * In other words, the function returns the closest address to the latitude and longitude of the
+   * [Location] parameter.
+   *
+   * @param gpsCoordinates The location object containing the latitude and longitude.
+   * @param onSuccess A callback function to handle the succesful retrieval of the address.
+   * @param onFailure A callback function to handle any errors or exceptions encountered during the search.
+   */
+  fun addressFromCoordinates(
+    gpsCoordinates: Location,
+    onSuccess: (String) -> Unit,
+    onFailure: (Exception) -> Unit
+  )
 }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
@@ -23,13 +23,12 @@ interface LocationModel {
   /**
    * Performs a "reverse location search".
    *
-   * In other words, the function returns the closest address to the latitude and longitude of the
-   * [Location] parameter.
+   * In other words, the function returns the closest address to the specified latitude and longitude.
    *
-   * @param lat The latitude of the location.
-   * @param lon The longitude of the location.
-   * @param onSuccess A callback function to handle the succesful retrieval of the address.
-   * @param onFailure A callback function to handle any errors or exceptions encountered during the search.
+   * @param lat Latitude of the location.
+   * @param lon Longitude of the location.
+   * @param onSuccess Callback function to handle the succesful retrieval of the address.
+   * @param onFailure Callback function to handle any errors or exceptions encountered during the search.
    */
   fun reverseSearch(
     lat: Double,

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModel.kt
@@ -26,12 +26,14 @@ interface LocationModel {
    * In other words, the function returns the closest address to the latitude and longitude of the
    * [Location] parameter.
    *
-   * @param gpsCoordinates The location object containing the latitude and longitude.
+   * @param lat The latitude of the location.
+   * @param lon The longitude of the location.
    * @param onSuccess A callback function to handle the succesful retrieval of the address.
    * @param onFailure A callback function to handle any errors or exceptions encountered during the search.
    */
   fun reverseSearch(
-    gpsCoordinates: Location,
+    lat: Double,
+    lon: Double,
     onSuccess: (String) -> Unit,
     onFailure: (Exception) -> Unit
   )

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
@@ -113,20 +113,19 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
   }
 
   override fun reverseSearch(
-    gpsCoordinates: Location,
+    lat: Double,
+    lon: Double,
     onSuccess: (String) -> Unit,
     onFailure: (Exception) -> Unit
   ){
-    val lat = gpsCoordinates.latitude.toString()
-    val lon = gpsCoordinates.longitude.toString()
 
     val url =
       HttpUrl.Builder()
         .scheme(SCHEME)
         .host(HOST)
         .addPathSegment("reverse")
-        .addQueryParameter("lat", lat)
-        .addQueryParameter("lon", lon)
+        .addQueryParameter("lat", lat.toString())
+        .addQueryParameter("lon", lon.toString())
         .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
         .build()
 

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
@@ -129,6 +129,7 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
         .addQueryParameter("lon", lon)
         .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
         .build()
+
     val request = Request.Builder().url(url).header(HEADER_NAME, HEADER_VALUE).build()
     Log.d(TAG, "Request url: $url")
 
@@ -153,8 +154,8 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
               val responseBody = response.body?.string()
               responseBody?.let {
                 val jsonObject = org.json.JSONObject(it)
-                jsonObject.getString("display_name")
-                onSuccess(it)
+                val displayName = jsonObject.getString("display_name")
+                onSuccess(displayName)
               } ?: onSuccess("Unknown address")
             }
           }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
@@ -1,6 +1,7 @@
 package com.android.periodpals.model.location
 
 import android.util.Log
+import java.io.IOException
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.HttpUrl
@@ -8,7 +9,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
-import java.io.IOException
 
 private const val TAG = "LocationModelNominatim"
 
@@ -62,19 +62,19 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
    *   its parameter.
    */
   override fun search(
-    query: String,
-    onSuccess: (List<Location>) -> Unit,
-    onFailure: (Exception) -> Unit,
+      query: String,
+      onSuccess: (List<Location>) -> Unit,
+      onFailure: (Exception) -> Unit,
   ) {
     // Using HttpUrl.Builder to properly construct the URL with query parameters.
     val url =
-      HttpUrl.Builder()
-        .scheme(SCHEME)
-        .host(HOST)
-        .addPathSegment("search")
-        .addQueryParameter("q", query)
-        .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
-        .build()
+        HttpUrl.Builder()
+            .scheme(SCHEME)
+            .host(HOST)
+            .addPathSegment("search")
+            .addQueryParameter("q", query)
+            .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
+            .build()
 
     // Log the URL to Logcat for inspection
     Log.d(TAG, "Request URL: $url")
@@ -82,83 +82,81 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
     // Create the request with a custom User-Agent and optional Referer
     val request = Request.Builder().url(url).header(HEADER_NAME, HEADER_VALUE).build()
     client
-      .newCall(request)
-      .enqueue(
-        object : Callback {
-          override fun onFailure(call: Call, e: IOException) {
-            Log.e(TAG, "Failed to execute request", e)
-            onFailure(e)
-          }
-
-          override fun onResponse(call: Call, response: Response) {
-            response.use {
-              if (!response.isSuccessful) {
-                onFailure(Exception("Unexpected code $response"))
-                Log.d(TAG, "Unexpected code $response")
-                return
+        .newCall(request)
+        .enqueue(
+            object : Callback {
+              override fun onFailure(call: Call, e: IOException) {
+                Log.e(TAG, "Failed to execute request", e)
+                onFailure(e)
               }
 
-              val body = response.body?.string()
-              if (body != null) {
-                onSuccess(parseBody(body))
-                Log.d(TAG, "Body: $body")
-              } else {
-                Log.d(TAG, "Empty body")
-                onSuccess(emptyList())
+              override fun onResponse(call: Call, response: Response) {
+                response.use {
+                  if (!response.isSuccessful) {
+                    onFailure(Exception("Unexpected code $response"))
+                    Log.d(TAG, "Unexpected code $response")
+                    return
+                  }
+
+                  val body = response.body?.string()
+                  if (body != null) {
+                    onSuccess(parseBody(body))
+                    Log.d(TAG, "Body: $body")
+                  } else {
+                    Log.d(TAG, "Empty body")
+                    onSuccess(emptyList())
+                  }
+                }
               }
-            }
-          }
-        }
-      )
+            })
   }
 
   override fun reverseSearch(
-    lat: Double,
-    lon: Double,
-    onSuccess: (String) -> Unit,
-    onFailure: (Exception) -> Unit
-  ){
+      lat: Double,
+      lon: Double,
+      onSuccess: (String) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
 
     val url =
-      HttpUrl.Builder()
-        .scheme(SCHEME)
-        .host(HOST)
-        .addPathSegment("reverse")
-        .addQueryParameter("lat", lat.toString())
-        .addQueryParameter("lon", lon.toString())
-        .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
-        .build()
+        HttpUrl.Builder()
+            .scheme(SCHEME)
+            .host(HOST)
+            .addPathSegment("reverse")
+            .addQueryParameter("lat", lat.toString())
+            .addQueryParameter("lon", lon.toString())
+            .addQueryParameter(FORMAT_NAME, FORMAT_VAL)
+            .build()
 
     val request = Request.Builder().url(url).header(HEADER_NAME, HEADER_VALUE).build()
     Log.d(TAG, "Request url: $url")
 
     client
-      .newCall(request)
-      .enqueue(
-        object : Callback {
+        .newCall(request)
+        .enqueue(
+            object : Callback {
 
-          override fun onFailure(call: Call, e: IOException) {
-            Log.e(TAG, "Failed to execute request", e)
-            onFailure(e)
-          }
-
-          override fun onResponse(call: Call, response: Response) {
-            response.use {
-              if(!response.isSuccessful){
-                Log.e(TAG, "Unexpected code: $response")
-                onFailure( Exception("Unexpected code: $response"))
-                return
+              override fun onFailure(call: Call, e: IOException) {
+                Log.e(TAG, "Failed to execute request", e)
+                onFailure(e)
               }
 
-              val responseBody = response.body?.string()
-              responseBody?.let {
-                val jsonObject = org.json.JSONObject(it)
-                val displayName = jsonObject.getString("display_name")
-                onSuccess(displayName)
-              } ?: onSuccess("Unknown address")
-            }
-          }
-        }
-      )
+              override fun onResponse(call: Call, response: Response) {
+                response.use {
+                  if (!response.isSuccessful) {
+                    Log.e(TAG, "Unexpected code: $response")
+                    onFailure(Exception("Unexpected code: $response"))
+                    return
+                  }
+
+                  val responseBody = response.body?.string()
+                  responseBody?.let {
+                    val jsonObject = org.json.JSONObject(it)
+                    val displayName = jsonObject.getString("display_name")
+                    onSuccess(displayName)
+                  } ?: onSuccess("Unknown address")
+                }
+              }
+            })
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationModelNominatim.kt
@@ -112,7 +112,7 @@ class LocationModelNominatim(val client: OkHttpClient) : LocationModel {
       )
   }
 
-  override fun addressFromCoordinates(
+  override fun reverseSearch(
     gpsCoordinates: Location,
     onSuccess: (String) -> Unit,
     onFailure: (Exception) -> Unit

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -24,10 +24,12 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
   val query: StateFlow<String> = _query
 
   private var _locationSuggestions = MutableStateFlow(emptyList<Location>())
-  val locationSuggestions: StateFlow<List<Location>> get() = _locationSuggestions
+  val locationSuggestions: StateFlow<List<Location>>
+    get() = _locationSuggestions
 
   private val _address = MutableStateFlow("")
-  val address: StateFlow<String> get() = _address
+  val address: StateFlow<String>
+    get() = _address
 
   // create factory
   companion object {
@@ -61,23 +63,22 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
   }
 
   /**
-   * Finds the address closest to the specified latitude and longitude and assigns it to the [address]
-   * state flow.
+   * Finds the address closest to the specified latitude and longitude and assigns it to the
+   * [address] state flow.
    *
    * @param lat Latitude of the location.
    * @param lon Longitude of the location.
    */
   fun getAddressFromCoordinates(lat: Double, lon: Double) {
     repository.reverseSearch(
-      lat = lat,
-      lon = lon,
-      onSuccess = { resultAddress ->
-        Log.d(TAG, "Successfully fetched address related to coordinates: ($lat, $lon")
-        _address.value = resultAddress
-      },
-      onFailure = {
-        Log.d(TAG, "Failed to fetch address related to the coordinates: ($lat, $lon)")
-      }
-    )
+        lat = lat,
+        lon = lon,
+        onSuccess = { resultAddress ->
+          Log.d(TAG, "Successfully fetched address related to coordinates: ($lat, $lon")
+          _address.value = resultAddress
+        },
+        onFailure = {
+          Log.d(TAG, "Failed to fetch address related to the coordinates: ($lat, $lon)")
+        })
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -68,17 +68,15 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
    * @param location Location to find the address closest to.
    */
   fun getAddressFromCoordinates(location: Location) {
-    viewModelScope.launch {
-      val result = repository.reverseSearch(
-        gpsCoordinates = location,
-        onSuccess = { resultAddress ->
-          Log.d(TAG, "Successfully fetched address related to coordinates: (${location.latitude}, ${location.longitude}")
-          _address.value = resultAddress
-        },
-        onFailure = {
-          Log.d(TAG, "Failed to fetch address related to the coordinates: (${location.latitude}, ${location.longitude})")
-        }
-      )
-    }
+    repository.reverseSearch(
+      gpsCoordinates = location,
+      onSuccess = { resultAddress ->
+        Log.d(TAG, "Successfully fetched address related to coordinates: (${location.latitude}, ${location.longitude}")
+        _address.value = resultAddress
+      },
+      onFailure = {
+        Log.d(TAG, "Failed to fetch address related to the coordinates: (${location.latitude}, ${location.longitude})")
+      }
+    )
   }
 }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -62,6 +62,11 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
     }
   }
 
+  /**
+   * Finds the address closest to the latitude and longitude of the [location].
+   *
+   * @param location Location to find the address closest to.
+   */
   fun getAddressFromCoordinates(location: Location) {
     viewModelScope.launch {
       val result = repository.reverseSearch(

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -56,9 +56,9 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
           query,
           {
             _locationSuggestions.value = it
-            Log.d("SearchSuccess", "Successfully fetched location suggestions for query: $query")
+            Log.d(TAG, "Successfully fetched location suggestions for query: $query")
           },
-          { Log.d("SearchError", "Failed to fetch location suggestions for query: $query") })
+          { Log.d(TAG, "Failed to fetch location suggestions for query: $query") })
     }
   }
 

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -61,10 +61,11 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
   }
 
   /**
-   * Finds the address closest to the latitude and longitude of the [location].
+   * Finds the address closest to the specified latitude and longitude and assigns it to the [address]
+   * state flow.
    *
-   * @param lat
-   * @param lon
+   * @param lat Latitude of the location.
+   * @param lon Longitude of the location.
    */
   fun getAddressFromCoordinates(lat: Double, lon: Double) {
     repository.reverseSearch(

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -18,7 +18,7 @@ private const val TAG = "LocationViewModel"
  * query input. It exposes StateFlows to observe query changes and location suggestions in a
  * reactive way.
  */
-class LocationViewModel(val repository: LocationModel) : ViewModel() {
+class LocationViewModel(private val repository: LocationModel) : ViewModel() {
 
   private val _query = MutableStateFlow("")
   val query: StateFlow<String> = _query

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -3,10 +3,8 @@ package com.android.periodpals.model.location
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 
 private const val TAG = "LocationViewModel"
@@ -65,17 +63,19 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
   /**
    * Finds the address closest to the latitude and longitude of the [location].
    *
-   * @param location Location to find the address closest to.
+   * @param lat
+   * @param lon
    */
-  fun getAddressFromCoordinates(location: Location) {
+  fun getAddressFromCoordinates(lat: Double, lon: Double) {
     repository.reverseSearch(
-      gpsCoordinates = location,
+      lat = lat,
+      lon = lon,
       onSuccess = { resultAddress ->
-        Log.d(TAG, "Successfully fetched address related to coordinates: (${location.latitude}, ${location.longitude}")
+        Log.d(TAG, "Successfully fetched address related to coordinates: ($lat, $lon")
         _address.value = resultAddress
       },
       onFailure = {
-        Log.d(TAG, "Failed to fetch address related to the coordinates: (${location.latitude}, ${location.longitude})")
+        Log.d(TAG, "Failed to fetch address related to the coordinates: ($lat, $lon)")
       }
     )
   }

--- a/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
+++ b/app/src/main/java/com/android/periodpals/model/location/LocationViewModel.kt
@@ -26,7 +26,7 @@ class LocationViewModel(val repository: LocationModel) : ViewModel() {
   val query: StateFlow<String> = _query
 
   private var _locationSuggestions = MutableStateFlow(emptyList<Location>())
-  val locationSuggestions: StateFlow<List<Location>> = _locationSuggestions
+  val locationSuggestions: StateFlow<List<Location>> get() = _locationSuggestions
 
   private val _address = MutableStateFlow("")
   val address: StateFlow<String> get() = _address

--- a/app/src/main/java/com/android/periodpals/services/GPSServiceImpl.kt
+++ b/app/src/main/java/com/android/periodpals/services/GPSServiceImpl.kt
@@ -9,9 +9,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.periodpals.model.location.Location
-import com.android.periodpals.model.location.LocationViewModel
 import com.android.periodpals.model.location.parseLocationGIS
 import com.android.periodpals.model.user.UserViewModel
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -246,7 +244,6 @@ class GPSServiceImpl(
             result.lastLocation?.let { location ->
               val lat = location.latitude
               val long = location.longitude
-
 
               _location.value =
                   Location(

--- a/app/src/main/java/com/android/periodpals/services/GPSServiceImpl.kt
+++ b/app/src/main/java/com/android/periodpals/services/GPSServiceImpl.kt
@@ -9,7 +9,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.periodpals.model.location.Location
+import com.android.periodpals.model.location.LocationViewModel
 import com.android.periodpals.model.location.parseLocationGIS
 import com.android.periodpals.model.user.UserViewModel
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -244,13 +246,14 @@ class GPSServiceImpl(
             result.lastLocation?.let { location ->
               val lat = location.latitude
               val long = location.longitude
+
+
               _location.value =
                   Location(
                       lat,
                       long,
                       Location.CURRENT_LOCATION_NAME,
-                  ) // TODO change CURRENT_LOCATION_NAME to actual
-              // location based on the coordinates
+                  )
 
               _accuracy.value = location.accuracy
 

--- a/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
@@ -142,7 +142,7 @@ fun LocationField(
   var name by remember { mutableStateOf(location?.name ?: "") }
   val gpsLocation by gpsService.location.collectAsState()
 
-  LaunchedEffect(gpsLocation) {
+  LaunchedEffect(Unit) {
     locationViewModel
       .getAddressFromCoordinates(
         lat = gpsLocation.latitude,

--- a/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
@@ -142,6 +142,14 @@ fun LocationField(
   var name by remember { mutableStateOf(location?.name ?: "") }
   val gpsLocation by gpsService.location.collectAsState()
 
+  LaunchedEffect(gpsLocation) {
+    locationViewModel
+      .getAddressFromCoordinates(
+        lat = gpsLocation.latitude,
+        lon = gpsLocation.longitude
+      )
+  }
+
   // State for dropdown visibility
   var showDropdown by remember { mutableStateOf(false) }
 
@@ -189,7 +197,13 @@ fun LocationField(
                 "Selected current location: ${gpsLocation.name} at (${gpsLocation.latitude}, ${gpsLocation.longitude})",
             )
             name = Location.CURRENT_LOCATION_NAME
-            onLocationSelected(gpsLocation)
+            onLocationSelected(
+              Location(
+              latitude = gpsLocation.latitude,
+              longitude = gpsLocation.longitude,
+              name = locationViewModel.address.value
+              )
+            )
             showDropdown = false
           },
           modifier =

--- a/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
+++ b/app/src/main/java/com/android/periodpals/ui/components/AlertComponents.kt
@@ -143,11 +143,8 @@ fun LocationField(
   val gpsLocation by gpsService.location.collectAsState()
 
   LaunchedEffect(Unit) {
-    locationViewModel
-      .getAddressFromCoordinates(
-        lat = gpsLocation.latitude,
-        lon = gpsLocation.longitude
-      )
+    locationViewModel.getAddressFromCoordinates(
+        lat = gpsLocation.latitude, lon = gpsLocation.longitude)
   }
 
   // State for dropdown visibility
@@ -198,12 +195,10 @@ fun LocationField(
             )
             name = Location.CURRENT_LOCATION_NAME
             onLocationSelected(
-              Location(
-              latitude = gpsLocation.latitude,
-              longitude = gpsLocation.longitude,
-              name = locationViewModel.address.value
-              )
-            )
+                Location(
+                    latitude = gpsLocation.latitude,
+                    longitude = gpsLocation.longitude,
+                    name = locationViewModel.address.value))
             showDropdown = false
           },
           modifier =

--- a/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
@@ -27,7 +27,7 @@ class LocationViewModelTest {
   private val mockLocations = listOf(Location(46.5197, 6.5662, "EPFL"))
 
   private val mockAddressName =
-    "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland"
+      "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland"
 
   private val mockLat = 46.509858
   private val mockLon = 6.485742
@@ -56,7 +56,8 @@ class LocationViewModelTest {
   fun getAddressFromCoordinatesCallsRepository() = runTest {
     locationViewModel.getAddressFromCoordinates(lat = mockLat, lon = mockLon)
     verify(locationRepository)
-      .reverseSearch(eq(mockLat), eq(mockLon), any<(String) -> Unit>(), any<(Exception) -> Unit>())
+        .reverseSearch(
+            eq(mockLat), eq(mockLon), any<(String) -> Unit>(), any<(Exception) -> Unit>())
   }
 
   @Test
@@ -108,11 +109,11 @@ class LocationViewModelTest {
   fun reverseSearchSuccessfulUpdatesAddress() = runTest {
     // Simulate successful repository call
     doAnswer {
-      val successCallback = it.getArgument<(String) -> Unit>(1)
-      successCallback(mockAddressName)
-    }
-      .whenever(locationRepository)
-      .reverseSearch(any(),any(), any(), any())
+          val successCallback = it.getArgument<(String) -> Unit>(1)
+          successCallback(mockAddressName)
+        }
+        .whenever(locationRepository)
+        .reverseSearch(any(), any(), any(), any())
 
     locationViewModel.getAddressFromCoordinates(mockLat, mockLon)
     testDispatcher.scheduler.advanceUntilIdle() // Ensure all coroutines complete
@@ -124,11 +125,11 @@ class LocationViewModelTest {
   fun reverseSearchFailureDoesNotCrash() = runTest {
     // Simulate failure in the repository call
     doAnswer {
-      val failureCallback = it.getArgument<(Exception) -> Unit>(2)
-      failureCallback(RuntimeException("Network error"))
-    }
-      .whenever(locationRepository)
-      .reverseSearch(any(), any(), any(), any())
+          val failureCallback = it.getArgument<(Exception) -> Unit>(2)
+          failureCallback(RuntimeException("Network error"))
+        }
+        .whenever(locationRepository)
+        .reverseSearch(any(), any(), any(), any())
 
     locationViewModel.getAddressFromCoordinates(mockLat, mockLon)
     testDispatcher.scheduler.advanceUntilIdle() // Ensure all coroutines complete

--- a/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
@@ -109,7 +109,7 @@ class LocationViewModelTest {
   fun reverseSearchSuccessfulUpdatesAddress() = runTest {
     // Simulate successful repository call
     doAnswer {
-          val successCallback = it.getArgument<(String) -> Unit>(1)
+          val successCallback = it.getArgument<(String) -> Unit>(2)
           successCallback(mockAddressName)
         }
         .whenever(locationRepository)
@@ -125,7 +125,7 @@ class LocationViewModelTest {
   fun reverseSearchFailureDoesNotCrash() = runTest {
     // Simulate failure in the repository call
     doAnswer {
-          val failureCallback = it.getArgument<(Exception) -> Unit>(2)
+          val failureCallback = it.getArgument<(Exception) -> Unit>(3)
           failureCallback(RuntimeException("Network error"))
         }
         .whenever(locationRepository)

--- a/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
@@ -23,7 +23,7 @@ class LocationViewModelTest {
   private lateinit var locationRepository: LocationModel
   private lateinit var locationViewModel: LocationViewModel
 
-  val testQuery = "EPFL"
+  private val testQuery = "EPFL"
   private val mockLocations = listOf(Location(46.5197, 6.5662, "EPFL"))
 
   private val mockAddressName =

--- a/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/LocationViewModelTest.kt
@@ -29,12 +29,8 @@ class LocationViewModelTest {
   private val mockAddressName =
     "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland"
 
-  private val mockLocation =
-    Location(
-      latitude = 46.509858,
-      longitude = 6.485742,
-      name = "some place"
-    )
+  private val mockLat = 46.509858
+  private val mockLon = 6.485742
 
   private val testDispatcher = StandardTestDispatcher()
 
@@ -58,9 +54,9 @@ class LocationViewModelTest {
 
   @Test
   fun getAddressFromCoordinatesCallsRepository() = runTest {
-    locationViewModel.getAddressFromCoordinates(mockLocation)
+    locationViewModel.getAddressFromCoordinates(lat = mockLat, lon = mockLon)
     verify(locationRepository)
-      .reverseSearch(eq(mockLocation), any<(String) -> Unit>(), any<(Exception) -> Unit>())
+      .reverseSearch(eq(mockLat), eq(mockLon), any<(String) -> Unit>(), any<(Exception) -> Unit>())
   }
 
   @Test
@@ -116,9 +112,9 @@ class LocationViewModelTest {
       successCallback(mockAddressName)
     }
       .whenever(locationRepository)
-      .reverseSearch(any(), any(), any())
+      .reverseSearch(any(),any(), any(), any())
 
-    locationViewModel.getAddressFromCoordinates(mockLocation)
+    locationViewModel.getAddressFromCoordinates(mockLat, mockLon)
     testDispatcher.scheduler.advanceUntilIdle() // Ensure all coroutines complete
 
     assertThat(locationViewModel.address.value, `is`(mockAddressName))
@@ -132,9 +128,9 @@ class LocationViewModelTest {
       failureCallback(RuntimeException("Network error"))
     }
       .whenever(locationRepository)
-      .reverseSearch(any(), any(), any())
+      .reverseSearch(any(), any(), any(), any())
 
-    locationViewModel.getAddressFromCoordinates(mockLocation)
+    locationViewModel.getAddressFromCoordinates(mockLat, mockLon)
     testDispatcher.scheduler.advanceUntilIdle() // Ensure all coroutines complete
 
     assertThat(locationViewModel.address.value, `is`(""))

--- a/app/src/test/java/com/android/periodpals/model/location/NominatimLocationRepositoryTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/NominatimLocationRepositoryTest.kt
@@ -137,11 +137,8 @@ class LocationModelNominatimTest {
       .enqueue(any())
 
     locationRepository.reverseSearch(
-      Location(
-        latitude = 46.509858,
-        longitude = 6.485742,
-        name = "some place"
-      ),
+      lat = 46.509858,
+      lon = 6.485742,
       onSuccess = {address ->
         assert(address.isNotEmpty())
         assert(address == "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland")
@@ -172,11 +169,8 @@ class LocationModelNominatimTest {
       .enqueue(any())
 
     locationRepository.reverseSearch(
-      Location(
-        latitude = 0.0,
-        longitude = 0.0,
-        name = "some place"
-      ),
+      lon = 0.0,
+      lat = 0.0,
       onSuccess = { assert(false) { "Expected failure, but got success" }  },
       onFailure = { exception -> assert(exception.message?.contains("Server Error") == true)  }
     )

--- a/app/src/test/java/com/android/periodpals/model/location/NominatimLocationRepositoryTest.kt
+++ b/app/src/test/java/com/android/periodpals/model/location/NominatimLocationRepositoryTest.kt
@@ -107,44 +107,46 @@ class LocationModelNominatimTest {
   @Test
   fun reverse_search_successful_response() {
     val jsonResponse =
-      """
+        """
         {
           "place_id": 83566034,
           "lat": "46.5098584",
           "lon": "6.4857429",
           "display_name": "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland"
         }
-      """.trimIndent()
+      """
+            .trimIndent()
 
     // Create a basic Request object
     val mockRequest = Request.Builder().url("https://mockurl.com").build()
 
     val response =
-      Response.Builder()
-        .request(mockRequest)
-        .protocol(okhttp3.Protocol.HTTP_1_1)
-        .code(200)
-        .message("OK")
-        .body(jsonResponse.toResponseBody("application/json".toMediaType()))
-        .build()
+        Response.Builder()
+            .request(mockRequest)
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(jsonResponse.toResponseBody("application/json".toMediaType()))
+            .build()
 
     whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
     doAnswer { invocation ->
-      val callback = invocation.getArgument<okhttp3.Callback>(0)
-      callback.onResponse(mockCall, response)
-    }
-      .whenever(mockCall)
-      .enqueue(any())
+          val callback = invocation.getArgument<okhttp3.Callback>(0)
+          callback.onResponse(mockCall, response)
+        }
+        .whenever(mockCall)
+        .enqueue(any())
 
     locationRepository.reverseSearch(
-      lat = 46.509858,
-      lon = 6.485742,
-      onSuccess = {address ->
-        assert(address.isNotEmpty())
-        assert(address == "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland")
-      },
-      onFailure = { assert(false) { "Expected success, but got failure" } }
-    )
+        lat = 46.509858,
+        lon = 6.485742,
+        onSuccess = { address ->
+          assert(address.isNotEmpty())
+          assert(
+              address ==
+                  "1, Avenue de Praz-Rodet, Morges, District de Morges, Vaud, 1110, Switzerland")
+        },
+        onFailure = { assert(false) { "Expected success, but got failure" } })
   }
 
   @Test
@@ -152,27 +154,26 @@ class LocationModelNominatimTest {
     val mockRequest = Request.Builder().url("https://mockurl.com").build()
 
     val response =
-      Response.Builder()
-        .request(mockRequest)
-        .protocol(okhttp3.Protocol.HTTP_1_1)
-        .code(500)
-        .message("Server Error")
-        .body("Internal Server Error".toResponseBody("text/plain".toMediaType()))
-        .build()
+        Response.Builder()
+            .request(mockRequest)
+            .protocol(okhttp3.Protocol.HTTP_1_1)
+            .code(500)
+            .message("Server Error")
+            .body("Internal Server Error".toResponseBody("text/plain".toMediaType()))
+            .build()
 
     whenever(mockHttpClient.newCall(any())).thenReturn(mockCall)
     doAnswer { invocation ->
-      val callback = invocation.getArgument<okhttp3.Callback>(0)
-      callback.onResponse(mockCall, response)
-    }
-      .whenever(mockCall)
-      .enqueue(any())
+          val callback = invocation.getArgument<okhttp3.Callback>(0)
+          callback.onResponse(mockCall, response)
+        }
+        .whenever(mockCall)
+        .enqueue(any())
 
     locationRepository.reverseSearch(
-      lon = 0.0,
-      lat = 0.0,
-      onSuccess = { assert(false) { "Expected failure, but got success" }  },
-      onFailure = { exception -> assert(exception.message?.contains("Server Error") == true)  }
-    )
+        lon = 0.0,
+        lat = 0.0,
+        onSuccess = { assert(false) { "Expected failure, but got success" } },
+        onFailure = { exception -> assert(exception.message?.contains("Server Error") == true) })
   }
 }

--- a/app/src/test/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/CreateAlertScreenTest.kt
@@ -58,6 +58,7 @@ class CreateAlertScreenTest {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var locationViewModel: LocationViewModel
+  private val mockAddress = MutableStateFlow("Some address")
   private lateinit var gpsService: GPSServiceImpl
   private val mockLocationFLow = MutableStateFlow(Location.DEFAULT_LOCATION)
   private lateinit var authenticationViewModel: AuthenticationViewModel
@@ -162,6 +163,7 @@ class CreateAlertScreenTest {
     `when`(userViewModel.user).thenReturn(userState)
     `when`(authenticationViewModel.authUserData).thenReturn(authUserData)
     `when`(navigationActions.currentRoute()).thenReturn(Route.ALERT)
+    `when`(locationViewModel.address).thenReturn(mockAddress)
   }
 
   @Test

--- a/app/src/test/java/com/android/periodpals/ui/alert/EditAlertScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/alert/EditAlertScreenTest.kt
@@ -57,6 +57,7 @@ import org.robolectric.RobolectricTestRunner
 class EditAlertScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var locationViewModel: LocationViewModel
+  private val mockAddress = MutableStateFlow("Some address")
   private lateinit var gpsService: GPSServiceImpl
   private val mockLocationFLow = MutableStateFlow(Location.DEFAULT_LOCATION)
   private lateinit var authenticationViewModel: AuthenticationViewModel
@@ -179,6 +180,8 @@ class EditAlertScreenTest {
             MutableStateFlow(
                 listOf(LOCATION_SUGGESTION1, LOCATION_SUGGESTION2, LOCATION_SUGGESTION3)))
     `when`(locationViewModel.query).thenReturn(MutableStateFlow(LOCATION_SUGGESTION1.name))
+
+    `when`(locationViewModel.address).thenReturn(mockAddress)
   }
 
   @Test


### PR DESCRIPTION
# Add search from coordinates to address

## Description
This PR introduces the possibility to find the address closest to a given latitude and longitude. For this end, it uses the Nominatim API's reverse search. 

It closes issue #326.

## Changes
- Add a function to the `LocationModelNominatim` class called `reverseSearch` which creates a request to Nominatim using the latitude and longitude passed as parameter. If the request is successful, it provides the address closest to the longitude.
- Add a function to the `LocationViewModel` class called `getAddressFromCoordinates` which calls `reverseSearch` and handles the success and failure cases.
- I did some slight modification in the `LocationModelNominatim` and `LocationViewModel` files.

## Implementation details
Originally, I wanted to use the `getAddressFromCoordinates` method directly in the `GPSServiceImpl` class: 

```kotlin
result.lastLocation?.let { location ->
            val lat = location.latitude
            val long = location.longitude

            _location.value = Location(lat, long, Location.CURRENT_LOCATION_NAME) // Use it here

            _accuracy.value = location.accuracy

            Log.d(TAG_CALLBACK, "Last (lat, long): ($lat, $long)")
          } ?: run { Log.d(TAG_CALLBACK, "Last received location is null") }
```

However, there are two problems with this approach:
1. It would mean that every two seconds (the time interval for the GPS location updates), the app would make a request to the Nominatim API. I think that this is far from efficient and could eventually lead to the app being slow or buggy.
2. The class isn't designed as a view model, thus making it impossible to call `getAddressFromCoordinates`, as it is a view model function and should be called within a composable or another view model.

Therefore, the solution I opted for is the following. In the `LocationField` composable in `AlertComponents`, I added:

```kotlin
LaunchedEffect(Unit) {
    locationViewModel.getAddressFromCoordinates(
        lat = gpsLocation.latitude, lon = gpsLocation.longitude)
}
```

This means that the request to the API is done at the first composition, thus leaving enough time for API to answer before the name of the location is assigned in the `onClick` callback:

```kotlin
DropdownMenuItem(
          text = { Text(Location.CURRENT_LOCATION_NAME) },
        onClick = {
          Log.d(
            LOCATION_FIELD_TAG,
            "Selected current location: ${gpsLocation.name} at (${gpsLocation.latitude}, ${gpsLocation.longitude})",
          )
          name = Location.CURRENT_LOCATION_NAME
          onLocationSelected(
            Location(
              latitude = gpsLocation.latitude,
              longitude = gpsLocation.longitude,
              name = locationViewModel.address.value // Name is assigned here
            )
          )
          showDropdown = false
        },
```

## Files 

### Added
None.

### Modified
See files section.

### Removed
None.

## Dependencies Added
None.

## Testing
I added tests for the repository and view model in the spirit of the tests that were already written by @taghizadlaura.