### PR TITLE
Fix/misc/profile settings extract strings

### DIFF
--- a/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/CreateProfile.kt
@@ -47,10 +47,6 @@ import com.android.periodpals.ui.theme.dimens
 import com.dsc.form_builder.TextFieldState
 import kotlin.math.roundToInt
 
-private const val SCREEN_TITLE = "Create Your Account"
-private const val RADIUS_EXPLANATION_TEXT =
-    "By specifying this radius, " +
-        "you can control the geographical range for receiving alerts from other users."
 private val DEFAULT_PROFILE_PICTURE =
     Uri.parse("android.resource://com.android.periodpals/${R.drawable.generic_avatar}")
 private const val DEFAULT_RADIUS = 500F
@@ -86,7 +82,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
 
   Scaffold(
       modifier = Modifier.fillMaxSize().testTag(CreateProfileScreen.SCREEN),
-      topBar = { TopAppBar(title = SCREEN_TITLE) },
+      topBar = { TopAppBar(title = context.getString(R.string.create_profile_screen_title)) },
       containerColor = MaterialTheme.colorScheme.surface,
       contentColor = MaterialTheme.colorScheme.onSurface,
   ) { paddingValues ->
@@ -133,7 +129,7 @@ fun CreateProfileScreen(userViewModel: UserViewModel, navigationActions: Navigat
       SliderMenu(sliderPosition) { sliderPosition = (it / 100).roundToInt() * 100f }
 
       Text(
-          text = RADIUS_EXPLANATION_TEXT,
+          text = context.getString(R.string.create_profile_radius_explanation_text),
           style = MaterialTheme.typography.labelMedium,
           modifier =
               Modifier.wrapContentHeight()

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -48,7 +48,6 @@ import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 import com.dsc.form_builder.TextFieldState
 
-private const val SCREEN_TITLE = "Edit Your Profile"
 private const val TAG = "EditProfile"
 private val DEFAULT_PROFILE_PICTURE =
     "android.resource://com.android.periodpals/${R.drawable.generic_avatar}"
@@ -98,7 +97,7 @@ fun EditProfileScreen(userViewModel: UserViewModel, navigationActions: Navigatio
       modifier = Modifier.fillMaxSize().testTag(EditProfileScreen.SCREEN),
       topBar = {
         TopAppBar(
-            title = SCREEN_TITLE,
+            title = context.getString(R.string.edit_profile_screen_title),
             true,
             onBackButtonClick = { navigationActions.navigateTo(Screen.PROFILE) },
         )

--- a/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/EditProfile.kt
@@ -48,7 +48,6 @@ import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 import com.dsc.form_builder.TextFieldState
 
-private const val TAG = "EditProfile"
 private val DEFAULT_PROFILE_PICTURE =
     "android.resource://com.android.periodpals/${R.drawable.generic_avatar}"
 

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -114,7 +114,7 @@ fun ProfileScreen(
       modifier = Modifier.fillMaxSize().testTag(ProfileScreen.SCREEN),
       topBar = {
         TopAppBar(
-            title = SCREEN_TITLE,
+            title = context.getString(R.string.profile_screen_title),
             settingsButton = true,
             onSettingsButtonClick = { navigationActions.navigateTo(Screen.SETTINGS) },
             editButton = true,
@@ -150,7 +150,7 @@ fun ProfileScreen(
       // Name
       Text(
           modifier = Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.NAME_FIELD),
-          text = userState?.name ?: DEFAULT_NAME,
+          text = userState?.name ?: context.getString(R.string.profile_default_name),
           textAlign = TextAlign.Center,
           style = MaterialTheme.typography.titleSmall,
       )
@@ -159,7 +159,7 @@ fun ProfileScreen(
       Text(
           modifier =
               Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.DESCRIPTION_FIELD),
-          text = userState?.description ?: DEFAULT_DESCRIPTION,
+          text = userState?.description ?: context.getString(R.string.profile_default_description),
           textAlign = TextAlign.Center,
           style = MaterialTheme.typography.bodyMedium,
       )
@@ -169,14 +169,16 @@ fun ProfileScreen(
           modifier =
               Modifier.fillMaxWidth().wrapContentHeight().testTag(ProfileScreen.CONTRIBUTION_FIELD),
           text =
-              if (numberInteractions == 0) NEW_USER_TEXT
-              else NUMBER_INTERACTION_TEXT + numberInteractions,
+              if (numberInteractions == 0) context.getString(R.string.profile_new_user)
+              else context.getString(R.string.profile_number_interaction_text) + numberInteractions,
           textAlign = TextAlign.Left,
           style = MaterialTheme.typography.bodyMedium,
       )
 
       // Review section text
-      ProfileSection(text = REVIEWS_TITLE, testTag = ProfileScreen.REVIEWS_SECTION)
+      ProfileSection(
+          text = context.getString(R.string.profile_reviews_title),
+          testTag = ProfileScreen.REVIEWS_SECTION)
 
       // Reviews or no reviews card
       if (numberInteractions == 0) {
@@ -197,6 +199,7 @@ fun ProfileScreen(
  */
 @Composable
 private fun NoReviewCard() {
+  val context = LocalContext.current
   Card(
       modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_CARD),
       shape = RoundedCornerShape(size = MaterialTheme.dimens.cardRoundedSize),
@@ -217,7 +220,7 @@ private fun NoReviewCard() {
       )
       Text(
           modifier = Modifier.wrapContentSize().testTag(ProfileScreen.NO_REVIEWS_TEXT),
-          text = NO_REVIEWS_TEXT,
+          text = context.getString(R.string.profile_no_reviews_text),
           style = MaterialTheme.typography.bodyMedium,
       )
     }

--- a/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/profile/ProfileScreen.kt
@@ -49,17 +49,10 @@ import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 
-private const val SCREEN_TITLE = "Your Profile"
 private const val TAG = "ProfileScreen"
-private const val DEFAULT_NAME = "Error loading name, try again later."
-private const val DEFAULT_DESCRIPTION = "Error loading description, try again later."
+
 private val DEFAULT_PROFILE_PICTURE =
     Uri.parse("android.resource://com.android.periodpals/${R.drawable.generic_avatar}")
-
-private const val NEW_USER_TEXT = "New user"
-private const val NUMBER_INTERACTION_TEXT = "Number of interactions: "
-private const val REVIEWS_TITLE = "Reviews"
-private const val NO_REVIEWS_TEXT = "No reviews yet..."
 
 /**
  * A composable function that displays the user's profile screen.

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -278,8 +278,7 @@ fun SettingsScreen(
                                   Toast.LENGTH_SHORT)
                               .show()
                         }
-                    Log.d(
-                        LOG_SETTINGS_TAG, context.getString(R.string.settings_log_success_sign_out))
+                    Log.d(LOG_SETTINGS_TAG, "Sign out successful")
                     navigationActions.navigateTo(Screen.SIGN_IN)
                   },
                   onFailure = {
@@ -291,8 +290,7 @@ fun SettingsScreen(
                                   Toast.LENGTH_SHORT)
                               .show()
                         }
-                    Log.d(
-                        LOG_SETTINGS_TAG, context.getString(R.string.settings_log_failure_sign_out))
+                    Log.d(LOG_SETTINGS_TAG, "Failed to sign out")
                   })
             },
             icon = Icons.AutoMirrored.Outlined.Logout,
@@ -485,8 +483,7 @@ private fun DeleteAccountDialog(
                     authenticationViewModel.loadAuthenticationUserData(
                         onSuccess = {
                           Log.d(
-                              LOG_SETTINGS_TAG,
-                              context.getString(R.string.settings_log_success_load_data))
+                              LOG_SETTINGS_TAG, "user data loaded successfully, deleting the user")
                           userViewModel.deleteUser(
                               authenticationViewModel.authUserData.value!!.uid,
                               onSuccess = {
@@ -499,9 +496,7 @@ private fun DeleteAccountDialog(
                                               Toast.LENGTH_SHORT)
                                           .show()
                                     }
-                                Log.d(
-                                    LOG_SETTINGS_TAG,
-                                    context.getString(R.string.settings_log_success_delete))
+                                Log.d(LOG_SETTINGS_TAG, "Account deleted successfully")
                                 navigationActions.navigateTo(Screen.SIGN_IN)
                               },
                               onFailure = {
@@ -514,9 +509,7 @@ private fun DeleteAccountDialog(
                                               Toast.LENGTH_SHORT)
                                           .show()
                                     }
-                                Log.d(
-                                    LOG_SETTINGS_TAG,
-                                    context.getString(R.string.settings_log_failure_delete))
+                                Log.d(LOG_SETTINGS_TAG, "Failed to delete account")
                               })
                         },
                         onFailure = {
@@ -529,9 +522,7 @@ private fun DeleteAccountDialog(
                                         Toast.LENGTH_SHORT)
                                     .show()
                               }
-                          Log.d(
-                              LOG_SETTINGS_TAG,
-                              context.getString(R.string.settings_log_failure_load_data))
+                          Log.d(LOG_SETTINGS_TAG, "failed to load user data, can't delete the user")
                         })
                   },
                   colors =

--- a/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/periodpals/ui/settings/SettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.UserViewModel
 import com.android.periodpals.resources.C.Tag.SettingsScreen
@@ -69,31 +70,10 @@ import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopAppBar
 import com.android.periodpals.ui.theme.dimens
 
-private const val SCREEN_TITLE = "My Settings"
-
-// Comments
-private const val COMMENT_NOTIFICATIONS = "Notify me when a pal needs ..."
-private const val COMMENT_ORGANIC = "Which are ..."
-
-// Notifications
-private const val NOTIF_PALS = "Pals’ Notifications"
-private const val NOTIF_PADS = "Pads"
-private const val NOTIF_TAMPONS = "Tampons"
-private const val NOTIF_ORGANIC = "Organic"
-
 // Themes
-private const val THEME_LABEL = "Theme"
 private const val THEME_SYSTEM = "System"
 private const val THEME_LIGHT = "Light Mode"
 private const val THEME_DARK = "Dark Mode"
-
-// account management
-private const val ACCOUNT_PASSWORD = "Change Password"
-private const val ACCOUNT_SIGN_OUT = "Sign Out"
-private const val ACCOUNT_DELETE = "Delete Account"
-
-// Dialog
-private const val DIALOG_TEXT = "Are you sure you want to delete your account?"
 
 // Dropdown choices
 private val THEME_DROPDOWN_CHOICES =
@@ -104,26 +84,6 @@ private val THEME_DROPDOWN_CHOICES =
 
 // Log messages
 private const val LOG_SETTINGS_TAG = "SettingsScreen"
-
-private const val LOG_SETTINGS_SUCCESS_SIGN_OUT = "Sign out successful"
-private const val LOG_SETTINGS_FAILURE_SIGN_OUT = "Failed to sign out"
-
-private const val LOG_SETTINGS_SUCCESS_DELETE = "Account deleted successfully"
-private const val LOG_SETTINGS_FAILURE_DELETE = "Failed to delete account"
-
-private const val LOG_SETTINGS_SUCCESS_LOAD_DATA =
-    "user data loaded successfully, deleting the user"
-private const val LOG_SETTINGS_FAILURE_LOAD_DATA = "failed to load user data, can't delete the user"
-
-// Toast messages
-
-private const val TOAST_SETTINGS_SUCCESS_SIGN_OUT = "Sign out successful"
-private const val TOAST_SETTINGS_FAILURE_SIGN_OUT = "Failed to sign out"
-
-private const val TOAST_SETTINGS_SUCCESS_DELETE = "Account deleted successfully"
-private const val TOAST_SETTINGS_FAILURE_DELETE = "Failed to delete account"
-
-private const val TOAST_LOAD_DATA_FAILURE = "Failed loading user authentication data"
 
 /**
  * A composable function that displays the Settings screen, where users can manage their
@@ -143,7 +103,7 @@ private const val TOAST_LOAD_DATA_FAILURE = "Failed loading user authentication 
 fun SettingsScreen(
     userViewModel: UserViewModel,
     authenticationViewModel: AuthenticationViewModel,
-    navigationActions: NavigationActions
+    navigationActions: NavigationActions,
 ) {
 
   // notifications states
@@ -176,7 +136,7 @@ fun SettingsScreen(
       modifier = Modifier.fillMaxSize().testTag(SettingsScreen.SCREEN),
       topBar = {
         TopAppBar(
-            title = SCREEN_TITLE,
+            title = context.getString(R.string.settings_screen_title),
             true,
             onBackButtonClick = { navigationActions.goBack() },
         )
@@ -201,7 +161,7 @@ fun SettingsScreen(
       // notification section
       SettingsContainer(testTag = SettingsScreen.NOTIFICATIONS_CONTAINER) {
         SettingsSwitchRow(
-            text = NOTIF_PALS,
+            text = context.getString(R.string.settings_notif_pals),
             isChecked = receiveNotifications,
             onCheckedChange = { receiveNotifications = it },
             textTestTag = SettingsScreen.PALS_TEXT,
@@ -211,22 +171,25 @@ fun SettingsScreen(
             color = MaterialTheme.colorScheme.outlineVariant,
             modifier = Modifier.testTag(SettingsScreen.HORIZONTAL_DIVIDER))
         SettingsDescription(
-            text = COMMENT_NOTIFICATIONS, testTag = SettingsScreen.NOTIFICATIONS_DESCRIPTION)
+            text = context.getString(R.string.settings_comment_notifications),
+            testTag = SettingsScreen.NOTIFICATIONS_DESCRIPTION)
         SettingsSwitchRow(
-            text = NOTIF_PADS,
+            text = context.getString(R.string.settings_notif_pads),
             isChecked = receiveNotifications && padsNotifications,
             onCheckedChange = { padsNotifications = it },
             textTestTag = SettingsScreen.PADS_TEXT,
             switchTestTag = SettingsScreen.PADS_SWITCH)
         SettingsSwitchRow(
-            text = NOTIF_TAMPONS,
+            text = context.getString(R.string.settings_notif_tampons),
             isChecked = receiveNotifications && tamponsNotifications,
             onCheckedChange = { tamponsNotifications = it },
             textTestTag = SettingsScreen.TAMPONS_TEXT,
             switchTestTag = SettingsScreen.TAMPONS_SWITCH)
-        SettingsDescription(COMMENT_ORGANIC, SettingsScreen.ORGANIC_DESCRIPTION)
+        SettingsDescription(
+            context.getString(R.string.settings_comment_organic),
+            SettingsScreen.ORGANIC_DESCRIPTION)
         SettingsSwitchRow(
-            text = NOTIF_ORGANIC,
+            text = context.getString(R.string.settings_notif_organic),
             isChecked = receiveNotifications && organicNotifications,
             onCheckedChange = { organicNotifications = it },
             textTestTag = SettingsScreen.ORGANIC_TEXT,
@@ -245,7 +208,11 @@ fun SettingsScreen(
               textStyle = MaterialTheme.typography.labelLarge,
               value = theme,
               onValueChange = {},
-              label = { Text(THEME_LABEL, style = MaterialTheme.typography.labelMedium) },
+              label = {
+                Text(
+                    context.getString(R.string.settings_theme_label),
+                    style = MaterialTheme.typography.labelMedium)
+              },
               singleLine = true,
               readOnly = true,
               leadingIcon = { Icon(icon, contentDescription = null) },
@@ -292,34 +259,40 @@ fun SettingsScreen(
       // account management section
       SettingsContainer(testTag = SettingsScreen.ACCOUNT_MANAGEMENT_CONTAINER) {
         SettingsIconRow(
-            text = ACCOUNT_PASSWORD,
+            text = context.getString(R.string.settings_account_password),
             onClick = {},
             icon = Icons.Outlined.Key,
             textTestTag = SettingsScreen.PASSWORD_TEXT,
             iconTestTag = SettingsScreen.PASSWORD_ICON,
         )
         SettingsIconRow(
-            text = ACCOUNT_SIGN_OUT,
+            text = context.getString(R.string.settings_account_sign_out),
             onClick = {
               authenticationViewModel.logOut(
                   onSuccess = {
                     Handler(Looper.getMainLooper())
                         .post { // used to show the Toast on the main thread
                           Toast.makeText(
-                                  context, TOAST_SETTINGS_SUCCESS_SIGN_OUT, Toast.LENGTH_SHORT)
+                                  context,
+                                  context.getString(R.string.settings_toast_success_sign_out),
+                                  Toast.LENGTH_SHORT)
                               .show()
                         }
-                    Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_SIGN_OUT)
+                    Log.d(
+                        LOG_SETTINGS_TAG, context.getString(R.string.settings_log_success_sign_out))
                     navigationActions.navigateTo(Screen.SIGN_IN)
                   },
                   onFailure = {
                     Handler(Looper.getMainLooper())
                         .post { // used to show the Toast on the main thread
                           Toast.makeText(
-                                  context, TOAST_SETTINGS_FAILURE_SIGN_OUT, Toast.LENGTH_SHORT)
+                                  context,
+                                  context.getString(R.string.settings_toast_failure_sign_out),
+                                  Toast.LENGTH_SHORT)
                               .show()
                         }
-                    Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_SIGN_OUT)
+                    Log.d(
+                        LOG_SETTINGS_TAG, context.getString(R.string.settings_log_failure_sign_out))
                   })
             },
             icon = Icons.AutoMirrored.Outlined.Logout,
@@ -327,7 +300,7 @@ fun SettingsScreen(
             iconTestTag = SettingsScreen.SIGN_OUT_ICON,
         )
         SettingsIconRow(
-            text = ACCOUNT_DELETE,
+            text = context.getString(R.string.settings_account_delete),
             onClick = { showDialog = true },
             icon = Icons.Outlined.Delete,
             textTestTag = SettingsScreen.DELETE_ACCOUNT_TEXT,
@@ -502,7 +475,7 @@ private fun DeleteAccountDialog(
             )
             Text(
                 modifier = Modifier.wrapContentSize().testTag(SettingsScreen.CARD_TEXT),
-                text = DIALOG_TEXT,
+                text = context.getString(R.string.settings_dialog_text),
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
             )
@@ -511,7 +484,9 @@ private fun DeleteAccountDialog(
                   onClick = {
                     authenticationViewModel.loadAuthenticationUserData(
                         onSuccess = {
-                          Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_LOAD_DATA)
+                          Log.d(
+                              LOG_SETTINGS_TAG,
+                              context.getString(R.string.settings_log_success_load_data))
                           userViewModel.deleteUser(
                               authenticationViewModel.authUserData.value!!.uid,
                               onSuccess = {
@@ -519,11 +494,14 @@ private fun DeleteAccountDialog(
                                     .post { // used to show the Toast on the main thread
                                       Toast.makeText(
                                               context,
-                                              TOAST_SETTINGS_SUCCESS_DELETE,
+                                              context.getString(
+                                                  R.string.settings_toast_success_delete),
                                               Toast.LENGTH_SHORT)
                                           .show()
                                     }
-                                Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_SUCCESS_DELETE)
+                                Log.d(
+                                    LOG_SETTINGS_TAG,
+                                    context.getString(R.string.settings_log_success_delete))
                                 navigationActions.navigateTo(Screen.SIGN_IN)
                               },
                               onFailure = {
@@ -531,20 +509,29 @@ private fun DeleteAccountDialog(
                                     .post { // used to show the Toast on the main thread
                                       Toast.makeText(
                                               context,
-                                              TOAST_SETTINGS_FAILURE_DELETE,
+                                              context.getString(
+                                                  R.string.settings_toast_failure_delete),
                                               Toast.LENGTH_SHORT)
                                           .show()
                                     }
-                                Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_DELETE)
+                                Log.d(
+                                    LOG_SETTINGS_TAG,
+                                    context.getString(R.string.settings_log_failure_delete))
                               })
                         },
                         onFailure = {
                           Handler(Looper.getMainLooper())
                               .post { // used to show the Toast on the main thread
-                                Toast.makeText(context, TOAST_LOAD_DATA_FAILURE, Toast.LENGTH_SHORT)
+                                Toast.makeText(
+                                        context,
+                                        context.getString(
+                                            R.string.settings_toast_load_data_failure),
+                                        Toast.LENGTH_SHORT)
                                     .show()
                               }
-                          Log.d(LOG_SETTINGS_TAG, LOG_SETTINGS_FAILURE_LOAD_DATA)
+                          Log.d(
+                              LOG_SETTINGS_TAG,
+                              context.getString(R.string.settings_log_failure_load_data))
                         })
                   },
                   colors =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,36 @@
     <string name="profile_reviews_title">Reviews</string>
     <string name="profile_no_reviews_text">No reviews yet...</string>
 
+    <!-- Settings Screen -->
+    <string name="settings_screen_title">My Settings</string>
+
+    <string name="settings_comment_notifications">Notify me when a pal needs ...</string>
+    <string name="settings_comment_organic">Which are ...</string>
+
+    <string name="settings_notif_pals">Pals’ Notifications</string>
+    <string name="settings_notif_pads">Pads</string>
+    <string name="settings_notif_tampons">Tampons</string>
+    <string name="settings_notif_organic">Organic</string>
+
+    <string name="settings_theme_label">Theme</string>
+
+    <string name="settings_account_password">Change Password</string>
+    <string name="settings_account_sign_out">Sign Out</string>
+    <string name="settings_account_delete">Delete Account</string>
+
+    <string name="settings_dialog_text">Are you sure you want to delete your account?</string>
+
+    <string name="settings_log_success_sign_out">Sign out successful</string>
+    <string name="settings_log_failure_sign_out">Failed to sign out</string>
+    <string name="settings_log_success_delete">Account deleted successfully</string>
+    <string name="settings_log_failure_delete">Failed to delete account</string>
+    <string name="settings_log_success_load_data">user data loaded successfully, deleting the user</string>
+    <string name="settings_log_failure_load_data">failed to load user data, can\'t delete the user</string>
+
+    <string name="settings_toast_success_sign_out">Sign out successful</string>
+    <string name="settings_toast_failure_sign_out">Failed to sign out</string>
+    <string name="settings_toast_success_delete">Account deleted successfully</string>
+    <string name="settings_toast_failure_delete">Failed to delete account</string>
+    <string name="settings_toast_load_data_failure">Failed loading user authentication data</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,11 @@
 <resources>
     <string name="app_name">PeriodPals</string>
     <string name="google_client_id">683519755288-5dhnhoqhelf1lfsdpb9l1a8lghe445c5.apps.googleusercontent.com</string>
+
+    <!-- Create Profile Screen -->
+    <string name="create_profile_screen_title">Create Your Account</string>
+    <string name="create_profile_radius_explanation_text">
+        By specifying this radius, you can control the geographical range for receiving alerts from other users.
+    </string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
         By specifying this radius, you can control the geographical range for receiving alerts from other users.
     </string>
 
+    !-- Edit Profile Screen -->
+    <string name="edit_profile_screen_title">Edit Your Profile</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,16 @@
         By specifying this radius, you can control the geographical range for receiving alerts from other users.
     </string>
 
-    !-- Edit Profile Screen -->
+    <!-- Edit Profile Screen -->
     <string name="edit_profile_screen_title">Edit Your Profile</string>
+
+    <!-- Profile Screen -->
+    <string name="profile_screen_title">Your Profile</string>
+    <string name="profile_default_name">Error loading name, try again later.</string>
+    <string name="profile_default_description">Error loading description, try again later.</string>
+    <string name="profile_new_user">New user</string>
+    <string name="profile_number_interaction_text">Number of interactions: </string>
+    <string name="profile_reviews_title">Reviews</string>
+    <string name="profile_no_reviews_text">No reviews yet...</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,13 +39,6 @@
 
     <string name="settings_dialog_text">Are you sure you want to delete your account?</string>
 
-    <string name="settings_log_success_sign_out">Sign out successful</string>
-    <string name="settings_log_failure_sign_out">Failed to sign out</string>
-    <string name="settings_log_success_delete">Account deleted successfully</string>
-    <string name="settings_log_failure_delete">Failed to delete account</string>
-    <string name="settings_log_success_load_data">user data loaded successfully, deleting the user</string>
-    <string name="settings_log_failure_load_data">failed to load user data, can\'t delete the user</string>
-
     <string name="settings_toast_success_sign_out">Sign out successful</string>
     <string name="settings_toast_failure_sign_out">Failed to sign out</string>
     <string name="settings_toast_success_delete">Account deleted successfully</string>

--- a/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/CreateProfileTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
+import com.android.periodpals.R
 import com.android.periodpals.model.user.MIN_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
@@ -30,6 +31,7 @@ import com.android.periodpals.ui.navigation.TopLevelDestination
 import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import junit.framework.TestCase.assertFalse
@@ -130,7 +132,7 @@ class CreateProfileTest {
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
-        .assertTextEquals("Create Your Account")
+        .assertTextEquals(getResourceString(R.string.create_profile_screen_title))
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.SETTINGS_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.CHAT_BUTTON).assertIsNotDisplayed()
@@ -169,6 +171,7 @@ class CreateProfileTest {
         .onNodeWithTag(CreateProfileScreen.FILTER_RADIUS_EXPLANATION_TEXT)
         .performScrollTo()
         .assertIsDisplayed()
+        .assertTextEquals(getResourceString(R.string.create_profile_radius_explanation_text))
     composeTestRule
         .onNodeWithTag(AlertListsScreen.FILTER_RADIUS_TEXT)
         .performScrollTo()

--- a/app/src/test/java/com/android/periodpals/ui/profile/EditProfileTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/EditProfileTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import com.android.periodpals.R
 import com.android.periodpals.model.user.MIN_AGE
 import com.android.periodpals.model.user.User
 import com.android.periodpals.model.user.UserViewModel
@@ -30,6 +31,7 @@ import com.android.periodpals.ui.navigation.Screen
 import com.dsc.form_builder.FormState
 import com.dsc.form_builder.TextFieldState
 import com.dsc.form_builder.Validators
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.junit.Before
@@ -128,7 +130,7 @@ class EditProfileTest {
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
-        .assertTextEquals("Edit Your Profile")
+        .assertTextEquals(getResourceString(R.string.edit_profile_screen_title))
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.SETTINGS_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.CHAT_BUTTON).assertIsNotDisplayed()

--- a/app/src/test/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -229,11 +229,11 @@ class ProfileScreenTest {
     composeTestRule
         .onNodeWithTag(ProfileScreen.NAME_FIELD)
         .performScrollTo()
-        .assertTextEquals("Error loading name, try again later.")
+        .assertTextEquals(getResourceString(R.string.profile_default_name))
     composeTestRule
         .onNodeWithTag(ProfileScreen.DESCRIPTION_FIELD)
         .performScrollTo()
-        .assertTextEquals("Error loading description, try again later.")
+        .assertTextEquals(getResourceString(R.string.profile_default_description))
   }
 
   @Test

--- a/app/src/test/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/profile/ProfileScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.chat.ChatViewModel
 import com.android.periodpals.model.user.User
@@ -20,6 +21,7 @@ import com.android.periodpals.services.PushNotificationsService
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Route
 import com.android.periodpals.ui.navigation.Screen
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -86,7 +88,7 @@ class ProfileScreenTest {
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
-        .assertTextEquals("Your Profile")
+        .assertTextEquals(getResourceString(R.string.profile_screen_title))
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.SETTINGS_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.CHAT_BUTTON).assertIsNotDisplayed()
@@ -110,7 +112,7 @@ class ProfileScreenTest {
         .onNodeWithTag(ProfileScreen.REVIEWS_SECTION)
         .performScrollTo()
         .assertIsDisplayed()
-        .assertTextEquals("Reviews")
+        .assertTextEquals(getResourceString(R.string.profile_reviews_title))
     composeTestRule
         .onNodeWithTag(ProfileScreen.NO_REVIEWS_ICON)
         .performScrollTo()
@@ -119,6 +121,7 @@ class ProfileScreenTest {
         .onNodeWithTag(ProfileScreen.NO_REVIEWS_TEXT)
         .performScrollTo()
         .assertIsDisplayed()
+        .assertTextEquals(getResourceString(R.string.profile_no_reviews_text))
     composeTestRule
         .onNodeWithTag(ProfileScreen.NO_REVIEWS_CARD)
         .performScrollTo()

--- a/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/com/android/periodpals/ui/settings/SettingsScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.android.periodpals.R
 import com.android.periodpals.model.authentication.AuthenticationViewModel
 import com.android.periodpals.model.user.AuthenticationUserData
 import com.android.periodpals.model.user.UserViewModel
@@ -17,6 +18,7 @@ import com.android.periodpals.resources.C.Tag.TopAppBar
 import com.android.periodpals.ui.navigation.NavigationActions
 import com.android.periodpals.ui.navigation.Screen
 import com.android.periodpals.ui.navigation.TopLevelDestination
+import io.github.kakaocup.kakao.common.utilities.getResourceString
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -61,7 +63,7 @@ class SettingsScreenTest {
     composeTestRule
         .onNodeWithTag(TopAppBar.TITLE_TEXT)
         .assertIsDisplayed()
-        .assertTextEquals("My Settings")
+        .assertTextEquals(getResourceString(R.string.settings_screen_title))
     composeTestRule.onNodeWithTag(TopAppBar.GO_BACK_BUTTON).assertIsDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.SETTINGS_BUTTON).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(TopAppBar.CHAT_BUTTON).assertIsNotDisplayed()


### PR DESCRIPTION
# Create Profile, Edit Profile, Profile, and Settings texts in `strings.xml`

## Description  
This PR introduces string resources for the Create Profile, Edit Profile, Profile, and Settings screens to improve readability and maintainability across the app. It ensures the content of these screens is easily managed through the `strings.xml` file. This update closes issue #336 (and part of #328).

## Changes  
- Added string resources for Create Profile, Edit Profile, Profile, and Settings screens, including titles, instructions, labels, and toast messages.
- Updated the respective screens (`CreateProfileScreen`, `EditProfileScreen`, `ProfileScreen`, `SettingsScreen`) to use the newly added string resources, ensuring consistency and ease of maintenance.

## Files  

#### Added  
- No files added.

#### Modified  
- `CreateProfileScreen.kt` (updated to use string resources from `strings.xml`)
- `EditProfileScreen.kt` (updated to use string resources from `strings.xml`)
- `ProfileScreen.kt` (updated to use string resources from `strings.xml`)
- `SettingsScreen.kt` (updated to use string resources from `strings.xml`)
- `res/values/strings.xml` (new strings added for Create Profile, Edit Profile, Profile, and Settings)

#### Removed  
- No files removed.

## Dependencies Added  
- No new dependencies added.

## Testing  
The Create Profile, Edit Profile, Profile, and Settings screens have been updated to ensure the correct string resources are being used. Relevant tests have been adjusted to verify proper usage of the new resources.
